### PR TITLE
feat(components/input-date*):  add forceClear control input

### DIFF
--- a/apps/doc/src/app/components/input/input-date-range/input-date-range.component.html
+++ b/apps/doc/src/app/components/input/input-date-range/input-date-range.component.html
@@ -27,11 +27,22 @@
         [size]="size"
         [(val)]="val"
         [readOnly]="readOnly"
+        [forceClear]="forceClear"
         [focusable]="focusable"
         [pseudoState]="pseudoState"
       ></prizm-input-date-range>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="dateControl">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-date-range/input-date-range.component.ts
+++ b/apps/doc/src/app/components/input/input-date-range/input-date-range.component.ts
@@ -30,6 +30,9 @@ export class InputDateRangeComponent {
   public size: PrizmInputSize = 'm';
   public outer = false;
 
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   readonly exampleBase: TuiDocExample = {

--- a/apps/doc/src/app/components/input/input-date-relative/input-date-relative.component.html
+++ b/apps/doc/src/app/components/input/input-date-relative/input-date-relative.component.html
@@ -14,6 +14,7 @@
         [prizmDocHostElement]="element"
         [formControl]="valueControl"
         [label]="label"
+        [forceClear]="forceClear"
         [placeholder]="placeholder"
         [outer]="outer"
         [disabled]="disabled"
@@ -23,6 +24,16 @@
       ></prizm-input-date-relative>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="valueControl">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-date-relative/input-date-relative.component.ts
+++ b/apps/doc/src/app/components/input/input-date-relative/input-date-relative.component.ts
@@ -20,6 +20,9 @@ export class InputDateRelativeRelativeComponent {
   public disabled = false;
   public showClear = false;
 
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   readonly exampleBase: TuiDocExample = {

--- a/apps/doc/src/app/components/input/input-date-time-range/input-date-time-range.component.html
+++ b/apps/doc/src/app/components/input/input-date-time-range/input-date-time-range.component.html
@@ -5,22 +5,6 @@
     <prizm-doc-example id="base" heading="Base" [content]="exampleBase">
       <prizm-input-date-time-range-base-example></prizm-input-date-time-range-base-example>
     </prizm-doc-example>
-
-    <!--    <prizm-doc-example-->
-    <!--      id="base"-->
-    <!--      heading="Disabled"-->
-    <!--      [content]="exampleDisabled"-->
-    <!--    >-->
-    <!--      <prizm-input-date-time-range-disabled-example></prizm-input-date-time-range-disabled-example>-->
-    <!--    </prizm-doc-example>-->
-
-    <!--    <prizm-doc-example-->
-    <!--      id="native-date"-->
-    <!--      heading="Native Date"-->
-    <!--      [content]="exampleNativeDate"-->
-    <!--    >-->
-    <!--      <prizm-input-date-time-range-native-example></prizm-input-date-time-range-native-example>-->
-    <!--    </prizm-doc-example>-->
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>
@@ -30,11 +14,22 @@
         [prizmDocHostElement]="element"
         [formControl]="value"
         [min]="min"
+        [forceClear]="forceClear"
         [max]="max"
       ></prizm-input-date-time-range>
     </prizm-doc-demo>
 
     <prizm-doc-documentation [control]="value">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-date-time-range/input-date-time-range.component.ts
+++ b/apps/doc/src/app/components/input/input-date-time-range/input-date-time-range.component.ts
@@ -29,6 +29,9 @@ export class InputDateTimeRangeComponent {
   public size: PrizmInputSize = 'm';
   public outer = false;
 
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public focusable = true;
   public pseudoState = '';
   public focusedChange = false;

--- a/apps/doc/src/app/components/input/input-date-time/input-date-time.component.html
+++ b/apps/doc/src/app/components/input/input-date-time/input-date-time.component.html
@@ -22,6 +22,7 @@
         [prizmDocHostElement]="element"
         [formControl]="valueControl"
         [timeStrict]="timeStrict"
+        [forceClear]="forceClear"
         [label]="label"
         [placeholder]="placeholder"
         [outer]="outer"
@@ -34,6 +35,15 @@
       ></prizm-input-date-time>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="valueControl">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-date-time/input-date-time.component.ts
+++ b/apps/doc/src/app/components/input/input-date-time/input-date-time.component.ts
@@ -31,6 +31,9 @@ export class InputDateTimeTimeComponent {
   public size: PrizmInputSize = 'm';
   public outer = false;
 
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public timeModeVariants: ReadonlyArray<PrizmTimeMode> = ['HH:MM', 'HH:MM:SS', 'HH:MM:SS.MSS'];
   public timeMode: PrizmTimeMode = `HH:MM`;
 

--- a/apps/doc/src/app/components/input/input-date/input-date.component.html
+++ b/apps/doc/src/app/components/input/input-date/input-date.component.html
@@ -19,6 +19,7 @@
         [formControl]="control"
         [label]="label"
         [placeholder]="placeholder"
+        [forceClear]="forceClear"
         [outer]="outer"
         [size]="size"
         [readOnly]="readOnly"
@@ -27,6 +28,16 @@
       ></prizm-input-date>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="control">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-date/input-date.component.ts
+++ b/apps/doc/src/app/components/input/input-date/input-date.component.ts
@@ -31,6 +31,9 @@ export class InputDateComponent {
   public size: PrizmInputSize = 'm';
   public outer = false;
 
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   readonly exampleBase: TuiDocExample = {

--- a/apps/doc/src/app/components/input/input-month-range/input-month-range.component.html
+++ b/apps/doc/src/app/components/input/input-month-range/input-month-range.component.html
@@ -14,6 +14,7 @@
         [label]="label"
         [placeholder]="placeholder"
         [readOnly]="readonly"
+        [forceClear]="forceClear"
         [outer]="outer"
         [size]="size"
         [focusable]="focusable"
@@ -21,6 +22,16 @@
       ></prizm-input-month-range>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="control">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-month-range/input-month-range.component.ts
+++ b/apps/doc/src/app/components/input/input-month-range/input-month-range.component.ts
@@ -10,6 +10,9 @@ import { FormControl } from '@angular/forms';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InputMonthRangeRangeComponent {
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public readOnly = false;
   val: PrizmDay;
   public pseudoInvalid = false;

--- a/apps/doc/src/app/components/input/input-month/input-month.component.html
+++ b/apps/doc/src/app/components/input/input-month/input-month.component.html
@@ -15,12 +15,23 @@
         [readOnly]="readonly"
         [placeholder]="placeholder"
         [outer]="outer"
+        [forceClear]="forceClear"
         [size]="size"
         [focusable]="focusable"
         [pseudoState]="pseudoState"
       ></prizm-input-month>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="control">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-month/input-month.component.ts
+++ b/apps/doc/src/app/components/input/input-month/input-month.component.ts
@@ -11,6 +11,10 @@ import { FormControl } from '@angular/forms';
 })
 export class InputMonthComponent {
   public readOnly = false;
+
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   val: PrizmDay;
   public pseudoInvalid = false;
   public pseudoHovered = false;

--- a/apps/doc/src/app/components/input/input-text/input.component.html
+++ b/apps/doc/src/app/components/input/input-text/input.component.html
@@ -158,6 +158,9 @@
   <ng-template prizmDocPageTab prizmDocHost>
     <prizm-doc-demo>
       <prizm-input-layout
+        #prizmInputLayout
+        key="PrizmInputLayout"
+        [prizmDocHostElement]="prizmInputLayout"
         [label]="label"
         [outer]="outer"
         [status]="status"
@@ -168,9 +171,10 @@
       >
         <input
           prizmInput
-          #element
+          #prizmInputElement
+          key="PrizmInput"
+          [prizmDocHostElement]="prizmInputElement"
           [formControl]="control"
-          [prizmDocHostElement]="element"
           [disabled]="disabled"
           [required]="required"
           [value]="value"
@@ -178,7 +182,81 @@
       </prizm-input-layout>
     </prizm-doc-demo>
 
-    <prizm-doc-documentation [control]="control">
+    <prizm-doc-documentation hostComponentKey="PrizmInputLayout" heading="PrizmInputLayout">
+      <ng-template
+        documentationPropertyName="outer"
+        documentationPropertyType="boolean"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="outer"
+      >
+        Outer
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="clear"
+        documentationPropertyType="MouseEvent"
+        documentationPropertyMode="output"
+      >
+        Clear
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="border"
+        documentationPropertyType="boolean"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="border"
+      >
+        Border
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="position"
+        documentationPropertyType="PrizmInputPosition"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="inputPosition"
+      >
+        Position
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="size"
+        documentationPropertyType="PrizmInputSize"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="size"
+      >
+        Size
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="status"
+        documentationPropertyType="PrizmInputStatus"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="status"
+      >
+        Status
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="label"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="label"
+      >
+        Label
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [(documentationPropertyValue)]="forceClear"
+        [documentationPropertyValues]="forceClearVariants"
+      >
+        Force Clear
+      </ng-template>
+    </prizm-doc-documentation>
+
+    <prizm-doc-documentation [control]="control" hostComponentKey="PrizmInput" heading="PrizmInput">
       <ng-template
         documentationPropertyName="disabled"
         documentationPropertyType="boolean"

--- a/apps/doc/src/app/components/input/input-time/input-time.component.html
+++ b/apps/doc/src/app/components/input/input-time/input-time.component.html
@@ -26,6 +26,7 @@
         [prizmDocHostElement]="element"
         [formControl]="valueControl"
         [label]="label"
+        [forceClear]="forceClear"
         [placeholder]="placeholder"
         [outer]="outer"
         [mode]="timeMode"
@@ -38,6 +39,16 @@
       ></prizm-input-time>
     </prizm-doc-demo>
     <prizm-doc-documentation [control]="valueControl">
+      <ng-template
+        documentationPropertyName="forceClear"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+        [documentationPropertyValues]="forceClearVariants"
+        [(documentationPropertyValue)]="forceClear"
+      >
+        Show clear button
+      </ng-template>
+
       <ng-template
         documentationPropertyName="label"
         documentationPropertyType="string"

--- a/apps/doc/src/app/components/input/input-time/input-time.component.ts
+++ b/apps/doc/src/app/components/input/input-time/input-time.component.ts
@@ -21,6 +21,10 @@ import { FormControl } from '@angular/forms';
 export class InputTimeTimeComponent {
   public readOnly = false;
   val: PrizmTime;
+
+  forceClear: boolean | null = null;
+  forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public pseudoInvalid = false;
   public pseudoHovered = false;
   public pseudoPressed = false;

--- a/libs/components/src/lib/components/input/input-date-range/input-date-range.component.html
+++ b/libs/components/src/lib/components/input/input-date-range/input-date-range.component.html
@@ -7,7 +7,7 @@
   (isOpenChange)="onOpenChange($event)"
   prizmDropdownHostWidth="auto"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" [size]="size">
+  <prizm-input-layout [forceClear]="forceClear" [label]="label" [outer]="outer" [size]="size">
     <input
       class="input-search"
       prizmInput

--- a/libs/components/src/lib/components/input/input-date-range/input-date-range.component.ts
+++ b/libs/components/src/lib/components/input/input-date-range/input-date-range.component.ts
@@ -85,6 +85,8 @@ export class PrizmInputDateRangeComponent
   @prizmDefaultProp()
   items: readonly PrizmDayRangePeriod[] = [];
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   placeholder = '';

--- a/libs/components/src/lib/components/input/input-date-relative/input-date-relative.component.html
+++ b/libs/components/src/lib/components/input/input-date-relative/input-date-relative.component.html
@@ -7,7 +7,13 @@
   (isOpenChange)="onOpenChange($event)"
   prizmDropdownHostWidth="auto"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" (click)="safeOpenModal()" [size]="size">
+  <prizm-input-layout
+    [label]="label"
+    [outer]="outer"
+    [forceClear]="forceClear"
+    (click)="safeOpenModal()"
+    [size]="size"
+  >
     <input
       class="input-search"
       prizmInput

--- a/libs/components/src/lib/components/input/input-date-relative/input-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-date-relative.component.ts
@@ -63,6 +63,8 @@ export class PrizmInputDateRelativeComponent
   @prizmDefaultProp()
   public placeholder = 'Выберите относительное время';
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   /**

--- a/libs/components/src/lib/components/input/input-date-time-range/input-date-range-time.component.html
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-date-range-time.component.html
@@ -6,6 +6,7 @@
   [defaultViewedMonth]="defaultViewedMonth"
   [items]="items"
   [size]="size"
+  [forceClear]="forceClear"
   [outer]="outer"
   [formControl]="dateControl"
   [placeholder]="placeholder"

--- a/libs/components/src/lib/components/input/input-date-time-range/input-date-range-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-date-range-time.component.ts
@@ -63,6 +63,8 @@ export class PrizmInputDateTimeRangeComponent
   @prizmDefaultProp()
   markerHandler: PrizmMarkerHandler = PRIZM_DEFAULT_MARKER_HANDLER;
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   label = 'Выберите дату и время';

--- a/libs/components/src/lib/components/input/input-date-time/input-date-time.component.html
+++ b/libs/components/src/lib/components/input/input-date-time/input-date-time.component.html
@@ -9,7 +9,7 @@
   [closeByEsc]="true"
   (isOpenChange)="onOpenChange($event); $event && prizmDropdownHostComponent.reCalculatePositions()"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" [size]="size">
+  <prizm-input-layout [label]="label" [outer]="outer" [forceClear]="forceClear" [size]="size">
     <ng-template prizmInputStatusText>Ошибка! Неправильный формат</ng-template>
     <input
       class="input-search"

--- a/libs/components/src/lib/components/input/input-date-time/input-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-date-time.component.ts
@@ -73,6 +73,8 @@ export class PrizmInputDateTimeComponent
   @prizmDefaultProp()
   label = 'Абсолютное';
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   placeholder = 'Выберите дату и время';

--- a/libs/components/src/lib/components/input/input-date/input-date.component.html
+++ b/libs/components/src/lib/components/input/input-date/input-date.component.html
@@ -7,7 +7,7 @@
   [closeByEsc]="true"
   (isOpenChange)="onOpenChange($event)"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" [size]="size">
+  <prizm-input-layout [label]="label" [outer]="outer" [forceClear]="forceClear" [size]="size">
     <input
       class="input-search"
       prizmInput

--- a/libs/components/src/lib/components/input/input-date/input-date.component.ts
+++ b/libs/components/src/lib/components/input/input-date/input-date.component.ts
@@ -79,6 +79,8 @@ export class PrizmInputDateComponent
   @prizmDefaultProp()
   placeholder = '';
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   max = PRIZM_LAST_DAY;

--- a/libs/components/src/lib/components/input/input-month-range/input-month-range.component.html
+++ b/libs/components/src/lib/components/input/input-month-range/input-month-range.component.html
@@ -7,7 +7,7 @@
   (isOpenChange)="onOpenChange($event)"
   prizmDropdownHostWidth="auto"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" [size]="size">
+  <prizm-input-layout [label]="label" [outer]="outer" [forceClear]="forceClear" [size]="size">
     <input
       class="input-search"
       prizmInput

--- a/libs/components/src/lib/components/input/input-month-range/input-month-range.component.ts
+++ b/libs/components/src/lib/components/input/input-month-range/input-month-range.component.ts
@@ -60,6 +60,8 @@ export class PrizmInputMonthRangeComponent
   @prizmDefaultProp()
   public label = 'Выберите период';
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   public size: PrizmInputSize = 'm';

--- a/libs/components/src/lib/components/input/input-month/input-month.component.html
+++ b/libs/components/src/lib/components/input/input-month/input-month.component.html
@@ -6,7 +6,7 @@
   [isOpen]="open && interactive"
   (isOpenChange)="onOpenChange($event)"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" [size]="size">
+  <prizm-input-layout [label]="label" [outer]="outer" [forceClear]="forceClear" [size]="size">
     <input
       class="input-search"
       prizmInput

--- a/libs/components/src/lib/components/input/input-month/input-month.component.ts
+++ b/libs/components/src/lib/components/input/input-month/input-month.component.ts
@@ -67,6 +67,8 @@ export class PrizmInputMonthComponent
   @prizmDefaultProp()
   public label = 'Выберите месяц';
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   public size: PrizmInputSize = 'm';

--- a/libs/components/src/lib/components/input/input-time/input-time.component.html
+++ b/libs/components/src/lib/components/input/input-time/input-time.component.html
@@ -7,7 +7,13 @@
   (isOpenChange)="onOpen($event)"
   [closeByEsc]="true"
 >
-  <prizm-input-layout [label]="label" [outer]="outer" (click)="safeOpenModal()" [size]="size">
+  <prizm-input-layout
+    [label]="label"
+    [outer]="outer"
+    [forceClear]="forceClear"
+    (click)="safeOpenModal()"
+    [size]="size"
+  >
     <input
       class="input-search"
       prizmInput

--- a/libs/components/src/lib/components/input/input-time/input-time.component.ts
+++ b/libs/components/src/lib/components/input/input-time/input-time.component.ts
@@ -60,6 +60,8 @@ export class PrizmInputTimeComponent
   @prizmDefaultProp()
   placeholder = '';
 
+  @Input() forceClear: boolean | null = null;
+
   @Input()
   @prizmDefaultProp()
   label = 'Выберите время';


### PR DESCRIPTION
- feat(doc/input): add input-layout to api page (components/input)
- feat(components/input-date-time): add forceClear control input
- feat(components/input-date-time-range): add forceClear control input [76](https://github.com/zyfra/Prizm/issues/76)
- feat(components/input-time): add forceClear control input
- feat(components/input-date): add forceClear control input
- feat(components/input-month): add forceClear control input
- feat(components/input-month-range): add forceClear control input
- feat(components/input-date-range): add forceClear control input
- feat(components/input-date-relative): add forceClear control input