### PR TITLE
feat(components/button): now you can pass polymorph content as icon t…

### DIFF
--- a/apps/doc/src/app/components/buttons/button/button.component.html
+++ b/apps/doc/src/app/components/buttons/button/button.component.html
@@ -80,7 +80,7 @@
 
       <ng-template
         documentationPropertyName="icon"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyType="PolymorphContent<{size: PrizmSize}>"
         documentationPropertyMode="input"
         [documentationPropertyValues]="iconVariants"
         [(documentationPropertyValue)]="icon"
@@ -90,7 +90,7 @@
 
       <ng-template
         documentationPropertyName="iconRight"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyType="PolymorphContent<{size: PrizmSize}>"
         documentationPropertyMode="input"
         [documentationPropertyValues]="iconVariants"
         [(documentationPropertyValue)]="iconRight"

--- a/apps/doc/src/app/components/buttons/button/button.component.ts
+++ b/apps/doc/src/app/components/buttons/button/button.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
 import {
   IconDefs,
+  PolymorphContent,
   PrizmAppearance,
   PrizmAppearanceType,
   PrizmContent,
@@ -27,9 +28,12 @@ export class ButtonComponent {
   public pressedChange = false;
   public hoveredChange = false;
   public focusVisibleChange = false;
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/buttons/icon-button/examples/icons/icons-buttons-example.component.ts
+++ b/apps/doc/src/app/components/buttons/icon-button/examples/icons/icons-buttons-example.component.ts
@@ -20,4 +20,4 @@ import { Component } from '@angular/core';
   ],
   templateUrl: './icons-buttons-example.component.html',
 })
-export class prizmIconsButtonsExampleComponent {}
+export class PrizmIconsButtonsExampleComponent {}

--- a/apps/doc/src/app/components/buttons/icon-button/examples/your-icon-set/icons-your-icon-set-example.component.html
+++ b/apps/doc/src/app/components/buttons/icon-button/examples/your-icon-set/icons-your-icon-set-example.component.html
@@ -1,0 +1,170 @@
+<h1>Icon</h1>
+
+<div class="box">
+  <div class="title">Fill button[prizmIconButton]</div>
+  <div class="content">
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      appearance="primary"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      appearance="secondary"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      appearance="success"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      appearance="warning"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      appearance="danger"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      [disabled]="true"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="fill"
+      [icon]="ourIconTemplate"
+      [showLoader]="true"
+      size="m"
+    ></button>
+  </div>
+</div>
+
+<div class="box">
+  <div class="title">Ghost button[prizmIconButton]</div>
+  <div class="content">
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      appearance="primary"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      appearance="secondary"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      appearance="success"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      appearance="warning"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      appearance="danger"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      [disabled]="true"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="ghost"
+      [icon]="ourIconTemplate"
+      [showLoader]="true"
+      size="m"
+    ></button>
+  </div>
+</div>
+
+<div class="box">
+  <div class="title">Outline button[prizmIconButton]</div>
+  <div class="content">
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      appearance="primary"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      appearance="secondary"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      appearance="success"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      appearance="warning"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      appearance="danger"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      [disabled]="true"
+      size="m"
+    ></button>
+    <button
+      prizmIconButton
+      appearanceType="outline"
+      [icon]="ourIconTemplate"
+      [showLoader]="true"
+      size="m"
+    ></button>
+  </div>
+</div>
+
+<ng-template #ourIconTemplate>
+  <prizm-icons-svg [size]="24" [name]="PrizmIconSvgEnum.PRODUCTION_INDUSTRY_SNAKE_CUP"></prizm-icons-svg>
+</ng-template>

--- a/apps/doc/src/app/components/buttons/icon-button/examples/your-icon-set/icons-your-icon-set-example.component.ts
+++ b/apps/doc/src/app/components/buttons/icon-button/examples/your-icon-set/icons-your-icon-set-example.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import {
+  PrizmIconsSvgRegistry,
+  prizmIconSvgDateTimeCalendarPlus,
+  PrizmIconSvgEnum,
+  prizmIconSvgProductionIndustrySnakeCup,
+  prizmIconSvgSettingsToolsBan,
+} from '@prizm-ui/icons';
+
+@Component({
+  selector: 'prizm-icons-your-icon-set-example',
+  styles: [
+    `
+      .box {
+        margin-bottom: 2rem;
+
+        .title {
+          margin-bottom: 0.5rem;
+        }
+
+        .content {
+          display: flex;
+          gap: 1rem;
+        }
+      }
+    `,
+  ],
+  templateUrl: './icons-your-icon-set-example.component.html',
+})
+export class PrizmIconsYourIconSetExampleComponent {
+  readonly PrizmIconSvgEnum = PrizmIconSvgEnum;
+  constructor(private readonly iconRegistry: PrizmIconsSvgRegistry) {
+    /** Также можете добавить свою иконку */
+    this.iconRegistry.registerIcons([
+      prizmIconSvgSettingsToolsBan,
+      prizmIconSvgProductionIndustrySnakeCup,
+      prizmIconSvgDateTimeCalendarPlus,
+    ]);
+
+    /** для добавление всего сета наших иконок
+     * используйте PRIZM_ICONS_SVG_SET
+     * */
+    // this.iconRegistry.registerIcons([
+    //   ...PRIZM_ICONS_SVG_SET
+    // ]);
+  }
+}

--- a/apps/doc/src/app/components/buttons/icon-button/icon-button.component.html
+++ b/apps/doc/src/app/components/buttons/icon-button/icon-button.component.html
@@ -7,6 +7,9 @@
     <prizm-doc-example id="base" heading="Icons" [content]="exampleIcons">
       <prizm-icons-buttons-example></prizm-icons-buttons-example>
     </prizm-doc-example>
+    <prizm-doc-example id="custom-icon-set" heading="Custom Icon Set" [content]="exampleOurIconSet">
+      <prizm-icons-your-icon-set-example></prizm-icons-your-icon-set-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>
@@ -62,7 +65,7 @@
 
       <ng-template
         documentationPropertyName="icon"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyType="PolymorphContent<{size: PrizmSize}>"
         documentationPropertyMode="input"
         [documentationPropertyValues]="iconVariants"
         [(documentationPropertyValue)]="icon"
@@ -90,7 +93,7 @@
 
       <ng-template
         documentationPropertyName="iconRight"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyType="PolymorphContent<{size: PrizmSize}>"
         documentationPropertyMode="input"
         [(documentationPropertyValue)]="iconRight"
       >

--- a/apps/doc/src/app/components/buttons/icon-button/icon-button.component.ts
+++ b/apps/doc/src/app/components/buttons/icon-button/icon-button.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
 import {
   IconDefs,
+  PolymorphContent,
   PrizmAppearance,
   PrizmAppearanceType,
   PrizmContent,
@@ -43,12 +44,12 @@ export class IconButtonComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = [
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
     'account-card-details',
     ...IconDefs.reduce((a, c) => a.concat(c.data), []),
   ];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',
@@ -69,5 +70,9 @@ export class IconButtonComponent {
   readonly exampleIcons: TuiDocExample = {
     TypeScript: import('./examples/icons/icons-buttons-example.component.ts?raw'),
     HTML: import('./examples/icons/icons-buttons-example.component.html?raw'),
+  };
+  readonly exampleOurIconSet: TuiDocExample = {
+    TypeScript: import('./examples/your-icon-set/icons-your-icon-set-example.component.ts?raw'),
+    HTML: import('./examples/your-icon-set/icons-your-icon-set-example.component.html?raw'),
   };
 }

--- a/apps/doc/src/app/components/buttons/icon-button/icon-button.module.ts
+++ b/apps/doc/src/app/components/buttons/icon-button/icon-button.module.ts
@@ -1,19 +1,26 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { IconButtonComponent } from './icon-button.component';
 import { PrizmButtonModule } from '@prizm-ui/components';
-import { prizmIconsButtonsExampleComponent } from './examples/icons/icons-buttons-example.component';
+import { PrizmIconsYourIconSetExampleComponent } from './examples/your-icon-set/icons-your-icon-set-example.component';
+import { PrizmIconsButtonsExampleComponent } from './examples/icons/icons-buttons-example.component';
+import { PrizmIconsSvgModule } from '@prizm-ui/icons';
 
 @NgModule({
   imports: [
     CommonModule,
     PrizmAddonDocModule,
+    PrizmIconsSvgModule,
     PrizmButtonModule,
     RouterModule.forChild(prizmDocGenerateRoutes(IconButtonComponent)),
   ],
-  declarations: [prizmIconsButtonsExampleComponent, IconButtonComponent],
+  declarations: [
+    PrizmIconsYourIconSetExampleComponent,
+    PrizmIconsButtonsExampleComponent,
+    IconButtonComponent,
+  ],
   exports: [IconButtonComponent],
 })
 export class IconButtonModule {}

--- a/apps/doc/src/app/components/buttons/split-button/split-button.component.html
+++ b/apps/doc/src/app/components/buttons/split-button/split-button.component.html
@@ -72,7 +72,7 @@
 
       <ng-template
         documentationPropertyName="icon"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyType="PolymorphContent<{size: PrizmSize}>"
         documentationPropertyMode="input"
         [documentationPropertyValues]="iconVariants"
         [(documentationPropertyValue)]="icon"

--- a/apps/doc/src/app/components/buttons/split-button/split-button.component.ts
+++ b/apps/doc/src/app/components/buttons/split-button/split-button.component.ts
@@ -1,6 +1,12 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
-import { PrizmAppearance, PrizmAppearanceType, PrizmContent, PrizmSize } from '@prizm-ui/components';
+import {
+  PolymorphContent,
+  PrizmAppearance,
+  PrizmAppearanceType,
+  PrizmContent,
+  PrizmSize,
+} from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-split-button-example',
@@ -30,9 +36,9 @@ export class SplitButtonComponent {
   public clickIcon: void;
   public clickButton: void;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['chevrons-dropdown', ''];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = ['chevrons-dropdown', ''];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/buttons/tree-button/tree-button.component.html
+++ b/apps/doc/src/app/components/buttons/tree-button/tree-button.component.html
@@ -69,7 +69,7 @@
 
       <ng-template
         documentationPropertyName="icon"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyType="PolymorphContent<{size: PrizmSize}>"
         documentationPropertyMode="input"
         [documentationPropertyValues]="iconVariants"
         [(documentationPropertyValue)]="icon"

--- a/apps/doc/src/app/components/confirm-popup/confirm-popup.component.ts
+++ b/apps/doc/src/app/components/confirm-popup/confirm-popup.component.ts
@@ -11,6 +11,7 @@ import {
   PrizmContent,
   IconDefs,
   PrizmDialogSize,
+  PrizmSize,
 } from '@prizm-ui/components';
 
 @Component({
@@ -33,9 +34,12 @@ export class ConfirmPopupComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/dialogs/confirm-dialog/confirm.component.ts
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/confirm.component.ts
@@ -14,6 +14,7 @@ import {
   PrizmOverlayInsidePlacement,
   PrizmOverscrollMode,
   PrizmSidebarOptions,
+  PrizmSize,
 } from '@prizm-ui/components';
 import { prizmPure } from '@prizm-ui/core';
 import { generatePolymorphVariants } from '../../../util';
@@ -36,9 +37,12 @@ export class ConfirmComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/dialogs/dialog/dialog.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog.component.ts
@@ -12,6 +12,7 @@ import {
   PrizmAppearanceType,
   PrizmContent,
   IconDefs,
+  PrizmSize,
 } from '@prizm-ui/components';
 import { generatePolymorphVariants } from '../../../util';
 import { prizmPure } from '@prizm-ui/core';
@@ -34,9 +35,12 @@ export class DialogComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.ts
@@ -13,6 +13,7 @@ import {
   PrizmSidebarOptions,
   PrizmSidebarResultDefaultType,
   PrizmSidebarService,
+  PrizmSize,
 } from '@prizm-ui/components';
 import { generatePolymorphVariants } from '../../../util';
 import { prizmPure } from '@prizm-ui/core';
@@ -35,9 +36,12 @@ export class SidebarComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/hint/hint.component.ts
+++ b/apps/doc/src/app/components/hint/hint.component.ts
@@ -10,6 +10,7 @@ import {
   PrizmAppearance,
   PrizmAppearanceType,
   PrizmDialogSize,
+  PrizmSize,
 } from '@prizm-ui/components';
 
 @Component({
@@ -30,9 +31,12 @@ export class HintComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/apps/doc/src/app/components/tooltip/tooltip.component.ts
+++ b/apps/doc/src/app/components/tooltip/tooltip.component.ts
@@ -11,6 +11,7 @@ import {
   PrizmContent,
   IconDefs,
   PrizmDialogSize,
+  PrizmSize,
 } from '@prizm-ui/components';
 
 @Component({
@@ -32,9 +33,12 @@ export class TooltipComponent {
   public hoveredChange = false;
   public focusVisibleChange = false;
 
-  iconVariants: ReadonlyArray<PrizmContent> = ['', ...IconDefs.reduce((a, c) => a.concat(c.data), [])];
-  icon: PrizmContent = this.iconVariants[0];
-  iconRight: PrizmContent = this.iconVariants[0];
+  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
+    '',
+    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
+  ];
+  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
+  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
   appearanceVariants: ReadonlyArray<PrizmAppearance> = [
     'primary',
     'secondary',

--- a/libs/components/src/lib/components/button/button.component.html
+++ b/libs/components/src/lib/components/button/button.component.html
@@ -25,8 +25,7 @@
 </prizm-wrapper>
 
 <ng-template #showIconTemp let-icon="icon">
-  <ng-container [ngSwitch]="icon | prizmCallFunc : isTemplateRef">
-    <ng-container *ngSwitchCase="true" [ngTemplateOutlet]="$any(icon)"></ng-container>
-    <prizm-icon *ngSwitchDefault [iconClass]="$any(icon)" [size]="16"></prizm-icon>
+  <ng-container *polymorphOutlet="icon as content; context: { size: size }">
+    <prizm-icon [iconClass]="content" [size]="16"></prizm-icon>
   </ng-container>
 </ng-template>

--- a/libs/components/src/lib/components/button/button.component.ts
+++ b/libs/components/src/lib/components/button/button.component.ts
@@ -24,6 +24,7 @@ import { PRIZM_FOCUSABLE_ITEM_ACCESSOR } from '../../tokens';
 import { PrizmFocusableElementAccessor } from '../../types';
 import { PrizmFocusVisibleService } from '../../directives/focus-visible/focus-visible.service';
 import { PrizmHoveredService } from '../../services';
+import { PolymorphContent } from '../../directives';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -48,11 +49,11 @@ export class PrizmButtonComponent extends AbstractPrizmInteractive implements Pr
 
   /** can pass template or icon class */
   @Input()
-  icon: PrizmContent;
+  icon: PolymorphContent<{ size: PrizmSize }>;
 
   /** can pass template or icon class */
   @Input()
-  iconRight: PrizmContent;
+  iconRight: PolymorphContent<{ size: PrizmSize }>;
 
   @Input()
   @HostBinding('attr.data-appearance')

--- a/libs/components/src/lib/components/button/button.component.ts
+++ b/libs/components/src/lib/components/button/button.component.ts
@@ -24,7 +24,7 @@ import { PRIZM_FOCUSABLE_ITEM_ACCESSOR } from '../../tokens';
 import { PrizmFocusableElementAccessor } from '../../types';
 import { PrizmFocusVisibleService } from '../../directives/focus-visible/focus-visible.service';
 import { PrizmHoveredService } from '../../services';
-import { PolymorphContent } from '../../directives';
+import { PolymorphContent } from '../../directives/polymorph/types/content';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector

--- a/libs/components/src/lib/components/button/button.module.ts
+++ b/libs/components/src/lib/components/button/button.module.ts
@@ -6,10 +6,18 @@ import { PrizmIconModule } from '../icon';
 import { PrizmCallFuncModule } from '@prizm-ui/helpers';
 import { PrizmSplitButtonComponent } from './split-button/split-button.component';
 import { PrizmLoaderModule } from '../loader/loader.module';
+import { PolymorphModule } from '../../directives';
 
 @NgModule({
   declarations: [PrizmButtonComponent, PrizmSplitButtonComponent],
-  imports: [CommonModule, PrizmWrapperModule, PrizmIconModule, PrizmLoaderModule, PrizmCallFuncModule],
+  imports: [
+    CommonModule,
+    PrizmWrapperModule,
+    PolymorphModule,
+    PrizmIconModule,
+    PrizmLoaderModule,
+    PrizmCallFuncModule,
+  ],
   exports: [PrizmButtonComponent, PrizmSplitButtonComponent],
 })
 export class PrizmButtonModule {}

--- a/libs/components/src/lib/components/button/split-button/split-button.component.ts
+++ b/libs/components/src/lib/components/button/split-button/split-button.component.ts
@@ -12,6 +12,7 @@ import { PrizmContent } from '../button-options';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmSize } from '../../../util';
 import { PrizmAppearance, PrizmAppearanceType } from '../../../types';
+import { PolymorphContent } from '../../../directives';
 
 @Component({
   selector: 'prizm-split-button',
@@ -27,7 +28,7 @@ export class PrizmSplitButtonComponent {
 
   /** can pass template or icon class */
   @Input()
-  icon: PrizmContent = 'chevrons-dropdown';
+  icon: PolymorphContent<{ size: PrizmSize }> = 'chevrons-dropdown';
 
   @Input()
   @HostBinding('attr.data-appearance')


### PR DESCRIPTION
- feat(components/button): now you can pass polymorph content as icon to use any icon set [151](https://github.com/zyfra/Prizm/issues/151)
- feat(doc/icon-button): add example with you custom icon [151](https://github.com/zyfra/Prizm/issues/151)