### PR TITLE
Fix/breadcrumbs icon only

### DIFF
--- a/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component.ts
+++ b/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component.ts
@@ -10,6 +10,10 @@ import { IBreadcrumb } from '@prizm-ui/components';
 export class BreadcrumbsExampleWithIconComponent {
   public breadcrumbs: IBreadcrumb[] = [
     {
+      name: '',
+      icon: 'social-home-breadcrumbs',
+    },
+    {
       name: 'Lady',
       icon: 'account',
     },

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.html
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.html
@@ -17,9 +17,9 @@
           class="breadcrumb__icon"
           [size]="16"
           [iconClass]="breadcrumb.icon"
-          *ngIf="!!breadcrumb.icon"
+          *ngIf="breadcrumb.icon"
         ></prizm-icon>
-        <span class="breadcrumb__name">{{ breadcrumb?.name }}</span>
+        <span *ngIf="breadcrumb.name" class="breadcrumb__name">{{ breadcrumb.name }}</span>
       </button>
 
       <prizm-dropdown-host

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
@@ -26,26 +26,28 @@ import { debounceTime, observeOn, takeUntil, tap } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [PrizmDestroyService],
 })
-export class BreadcrumbsComponent implements OnInit, OnDestroy, AfterViewInit {
-  @Input() set breadcrumbs(data: IBreadcrumb[]) {
+export class BreadcrumbsComponent<Breadcrumb extends IBreadcrumb>
+  implements OnInit, OnDestroy, AfterViewInit
+{
+  @Input() set breadcrumbs(data: Breadcrumb[]) {
     this.breadcrumbs$.next(data);
   }
 
-  public get breadcrumbs(): IBreadcrumb[] {
+  public get breadcrumbs(): Breadcrumb[] {
     return this.breadcrumbs$.getValue();
   }
 
   @HostBinding('attr.testId')
   readonly testId = 'prizm_breadcrumbs';
 
-  @Output() public breadcrumbChange: EventEmitter<IBreadcrumb> = new EventEmitter();
+  @Output() public breadcrumbChange: EventEmitter<Breadcrumb> = new EventEmitter();
   @ViewChild('container', { static: true }) public containerRef: ElementRef;
   @ViewChild('breadcrumbsFake', { static: true }) public fakeBreadcrumbContainer: ElementRef;
   @ViewChildren('breadcrumb', { read: ElementRef }) public breadcrumbsList: QueryList<ElementRef>;
 
-  public breadcrumbs$: BehaviorSubject<IBreadcrumb[]> = new BehaviorSubject<IBreadcrumb[]>([]);
-  public breadcrumbsToShow$: BehaviorSubject<IBreadcrumb[]> = new BehaviorSubject<IBreadcrumb[]>([]);
-  public breadcrumbsInMenu$: BehaviorSubject<IBreadcrumb[]> = new BehaviorSubject<IBreadcrumb[]>([]);
+  public breadcrumbs$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);
+  public breadcrumbsToShow$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);
+  public breadcrumbsInMenu$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);
 
   public isDropdownOpened = false;
   public isContainerOverflowed = false;
@@ -116,7 +118,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy, AfterViewInit {
     this.breadcrumbsElementsWidth = this.fakeBreadcrumbContainer.nativeElement.clientWidth;
   }
 
-  private setViewBreadcrumbs(breadcrumbs: IBreadcrumb[]): void {
+  private setViewBreadcrumbs(breadcrumbs: Breadcrumb[]): void {
     if (this.isContainerOverflowed) {
       this.breadcrumbsInMenu$.next(breadcrumbs.filter((item, i) => i > 0 && i < breadcrumbs.length - 1));
       this.breadcrumbsToShow$.next(breadcrumbs.filter((item, i) => i === 0 || i === breadcrumbs.length - 1));


### PR DESCRIPTION
1) Добавлена возможность отображать только иконку в "хлебной крошке". Ранее отображался гэп 8px + отступы от пустого текста.
![image](https://user-images.githubusercontent.com/126816006/234961254-44147608-f00d-4b97-bae4-752b581fa1d4.png)

2) [DevOnly] Сделал BreadcrumbsCompoentn дженериком. Ранее крошки, приходящие в событие `(breadcrumbChange)` приходилось кастить `as OurBreadcrumbs`  хотя в него мы получали именно те данные, которые мы передавали в компонент
