### PR TITLE
fix(components/navigation-menu): removed duplicate template outlet for headerExtraTemplate

### DIFF
--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.html
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.html
@@ -3,7 +3,6 @@
     <div class="header__top" (prizmHoveredChange)="headerIsHovered = $event">
       <div class="header__title">{{ title }}</div>
       <div class="header__instruments">
-        <ng-container *ngTemplateOutlet="headerExtraTemplate"></ng-container>
         <ng-container
           [ngTemplateOutlet]="headerExtraTemplate"
           [ngTemplateOutletContext]="{ headerIsHovered: headerIsHovered }"


### PR DESCRIPTION
Дублировался контент который пробрасывали в шаблон шапки меню. 


Не поймали на стэнде, тк в примере прокидывалась иконка которая отображается только когда мы навели мышку на шапку меню. Это состояние прокидывалось только в один темплэйт, поэтому вторая иконка не отображалась

![image](https://user-images.githubusercontent.com/126816006/235104217-bb4d5692-b934-47f3-90e8-095fae5ddc9c.png)
![image](https://user-images.githubusercontent.com/126816006/235104392-4ac8a265-e593-4868-88d6-90ef1d8727d6.png)
