### PR TITLE
feat(components/sidebar): added outer-content

### DIFF
--- a/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.html
@@ -1,5 +1,14 @@
 <button type="button" (click)="show()" prizmButton>Show SideBar</button>
 
+<ng-template #contentExample>
+  <div style="height: 100%; display: flex; align-items: center">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+    ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+    fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+    mollit anim id est laborum.
+  </div>
+</ng-template>
 <div style="margin-top: 16px">
   <prizm-doc-documentation>
     <ng-template

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
 import { PrizmSidebarService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
 
 @Component({
@@ -14,6 +14,7 @@ import { PrizmSidebarService, PrizmOverlayInsidePlacement } from '@prizm-ui/comp
   ],
 })
 export class PrizmSidebarServiceExampleComponent {
+  @ViewChild('contentExample') contentExample: TemplateRef<any>;
   public positionVariants: PrizmOverlayInsidePlacement[] = [
     PrizmOverlayInsidePlacement.LEFT,
     PrizmOverlayInsidePlacement.RIGHT,
@@ -26,27 +27,16 @@ export class PrizmSidebarServiceExampleComponent {
 
   public show(): void {
     this.sidebarService
-      .open(
-        `
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        `,
-        {
-          closeable: true,
-          header: 'Header',
-          width: '400px',
-          closeWord: 'Продолжить',
-          position: this.position,
-          backdrop: this.backdrop,
-          dismissible: this.dismissible,
-          size: 'm',
-        }
-      )
+      .open(this.contentExample, {
+        closeable: true,
+        header: 'Header',
+        width: '400px',
+        closeWord: 'Продолжить',
+        position: this.position,
+        backdrop: this.backdrop,
+        dismissible: this.dismissible,
+        size: 'm',
+      })
       .subscribe();
   }
 }

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/custom-close-guard/custom-close-guard.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/custom-close-guard/custom-close-guard.component.ts
@@ -22,7 +22,7 @@ export class PrizmSidebarCustomCloseGuardExampleComponent {
   public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
   public backdrop = false;
   public dismissible = false;
-  public canClose = false;
+  public canClose = true;
 
   constructor(@Inject(PrizmSidebarService) private readonly sidebarService: PrizmSidebarService) {}
 

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/custom-header-template/custom-header-template.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/custom-header-template/custom-header-template.component.html
@@ -1,0 +1,34 @@
+<ng-template #headerTemplate let-completeWith="completeWith">
+  Full template header
+
+  <button
+    [size]="16"
+    prizmInputIconButton="cancel-close-circle-fill"
+    (click)="completeWith(false)"
+    [interactive]="true"
+  ></button>
+</ng-template>
+
+<ng-template #outerTemplate>
+  <prizm-scrollbar class="scrollbar full-height">
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+    industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+    scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
+    electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release
+    of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
+    like Aldus PageMaker including versions of Lorem Ipsum. Lorem Ipsum is simply dummy text of the printing
+    and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+    when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has
+    survived not only five centuries, but also the leap into electronic typesetting, remaining essentially
+    unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum
+    passages, and more recently with desktop publishing software like Aldus PageMaker including versions of
+    Lorem Ipsum. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+    been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
+    type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the
+    leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+    the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing
+    software like Aldus PageMaker including versions of Lorem Ipsum.
+  </prizm-scrollbar>
+</ng-template>
+
+<button type="button" (click)="show()" prizmButton>Show SideBar</button>

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/custom-header-template/custom-header-template.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/custom-header-template/custom-header-template.component.ts
@@ -1,0 +1,54 @@
+import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
+import { PrizmSidebarService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
+import { of } from 'rxjs';
+
+@Component({
+  selector: 'prizm-sidebar-custom-header-template-example',
+  templateUrl: './custom-header-template.component.html',
+  styles: [
+    `
+      .box {
+        display: flex;
+        gap: 1rem;
+      }
+    `,
+  ],
+})
+export class PrizmSidebarCustomHeaderTemplateExampleComponent {
+  public positionVariants: PrizmOverlayInsidePlacement[] = [
+    PrizmOverlayInsidePlacement.LEFT,
+    PrizmOverlayInsidePlacement.RIGHT,
+  ];
+  public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
+  public backdrop = false;
+  public dismissible = false;
+  public canClose = true;
+
+  @ViewChild('headerTemplate') headerTemplate: TemplateRef<any>;
+  @ViewChild('outerTemplate') outerTemplate: TemplateRef<any>;
+
+  constructor(@Inject(PrizmSidebarService) private readonly sidebarService: PrizmSidebarService) {}
+
+  public show(): void {
+    this.sidebarService
+      .open(
+        `
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        `,
+        {
+          zIndex: 20,
+          outerContent: this.outerTemplate,
+          closeable: true,
+          width: '400px',
+          canClose: () => of(this.canClose),
+          closeWord: 'Продолжить',
+          position: this.position,
+          dismissible: this.dismissible,
+          backdrop: this.backdrop,
+          headerTemplate: this.headerTemplate,
+          size: 'm',
+        }
+      )
+      .subscribe();
+  }
+}

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
@@ -139,8 +139,16 @@
         documentationPropertyType="PolymorphContent<PrizmBaseDialogContext>"
         [documentationPropertyValues]="generatePolymorphVariants(headerTemp)"
         [(documentationPropertyValue)]="header"
+        [documentationPropertyDeprecated]="true"
       >
-        Header
+        Header (does not include close button)
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="headerTemplate"
+        documentationPropertyType="PolymorphContent<PrizmBaseDialogContext>"
+      >
+        Header (for change full header with close button)
       </ng-template>
 
       <ng-template
@@ -149,7 +157,14 @@
         [documentationPropertyValues]="generatePolymorphVariants(contentTemp)"
         [(documentationPropertyValue)]="content"
       >
-        Content
+        Content (will be in sidebar)
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="outerContent"
+        documentationPropertyType="PolymorphContent<PrizmBaseDialogContext>"
+      >
+        Outer Content (wont be in sidebar)
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
@@ -18,6 +18,10 @@
     <prizm-doc-example id="custom-close-guard" heading="Custom Close Guard" [content]="exampleCustomClose">
       <prizm-sidebar-custom-close-guard-example></prizm-sidebar-custom-close-guard-example>
     </prizm-doc-example>
+
+    <prizm-doc-example id="custom-header" heading="Custom Header" [content]="exampleCustomHeader">
+      <prizm-sidebar-custom-header-template-example></prizm-sidebar-custom-header-template-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>
@@ -75,6 +79,14 @@
         [(documentationPropertyValue)]="backdrop"
       >
         Backdrop
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="zIndex"
+        documentationPropertyType="number"
+        [(documentationPropertyValue)]="zIndex"
+      >
+        Z-Index for overlay container
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.ts
@@ -63,6 +63,7 @@ export class SidebarComponent {
   public positionVariants: any = ['t', 'b', 'l', 'r'];
   public position: PrizmOverlayInsidePlacement = PrizmOverlayInsidePlacement.LEFT;
   public backdrop = false;
+  public zIndex = 20;
   public dismissible = false;
   public height = 'auto';
   public width = '500px';
@@ -99,6 +100,11 @@ export class SidebarComponent {
     HTML: import('./examples/top-bottom/top-bottom.component.html?raw'),
   };
 
+  public readonly exampleCustomHeader: TuiDocExample = {
+    TypeScript: import('./examples/custom-header-template/custom-header-template.component.ts?raw'),
+    HTML: import('./examples/custom-header-template/custom-header-template.component.html?raw'),
+  };
+
   constructor(@Inject(PrizmSidebarService) private readonly sidebarService: PrizmSidebarService) {}
 
   @prizmPure
@@ -110,6 +116,7 @@ export class SidebarComponent {
     this.sidebarService
       .open(this.content, {
         closeable: this.closeable,
+        zIndex: this.zIndex,
         backdrop: this.backdrop,
         footer: this.footer,
         dismissible: this.dismissible,

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.module.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.module.ts
@@ -5,7 +5,9 @@ import { RouterModule } from '@angular/router';
 import {
   PolymorphModule,
   PrizmButtonModule,
+  PrizmInputIconButtonModule,
   PrizmRadioButtonModule,
+  PrizmScrollbarModule,
   PrizmSidebarModule,
 } from '@prizm-ui/components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -14,6 +16,7 @@ import { PrizmSidebarServiceExampleComponent } from './examples/base/base.compon
 import { PrizmSidebarTopBottomExampleComponent } from './examples/top-bottom/top-bottom.component';
 import { PrizmSidebarHiddenFooterExampleComponent } from './examples/hidden-footer/hidden-footer.component';
 import { PrizmSidebarCustomCloseGuardExampleComponent } from './examples/custom-close-guard/custom-close-guard.component';
+import { PrizmSidebarCustomHeaderTemplateExampleComponent } from './examples/custom-header-template/custom-header-template.component';
 
 @NgModule({
   imports: [
@@ -24,10 +27,13 @@ import { PrizmSidebarCustomCloseGuardExampleComponent } from './examples/custom-
     PolymorphModule,
     PrizmButtonModule,
     PrizmSidebarModule,
+    PrizmInputIconButtonModule,
+    PrizmScrollbarModule,
     PrizmRadioButtonModule,
     RouterModule.forChild(prizmDocGenerateRoutes(SidebarComponent)),
   ],
   declarations: [
+    PrizmSidebarCustomHeaderTemplateExampleComponent,
     PrizmSidebarCustomCloseGuardExampleComponent,
     PrizmSidebarServiceExampleComponent,
     PrizmSidebarTopBottomExampleComponent,

--- a/libs/components/src/lib/abstract/dialog.service.ts
+++ b/libs/components/src/lib/abstract/dialog.service.ts
@@ -68,6 +68,8 @@ export abstract class AbstractPrizmDialogService<
         })
         .create();
 
+      if (typeof options.zIndex === 'number') control.zIndex = options.zIndex;
+
       control.open();
 
       this.setOverscrollMode(options.overscroll ?? 'scroll', control, destroy$);

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
@@ -25,6 +25,7 @@ export type PrizmDialogSize = PrizmSizeM | PrizmSizeL;
 
 export interface PrizmDialogBaseOptions {
   readonly width?: string | number;
+  readonly zIndex?: number;
   readonly height?: string | number;
   readonly id?: string;
   readonly backdrop?: boolean;

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
@@ -1,25 +1,43 @@
 <div class="box" prizmFocusTrap prizmTheme>
-  <div *ngIf="context.header" class="header prizm-font-title-h4">
-    <prizm-scrollbar visibility="hidden" *polymorphOutlet="context.header as data; context: context">
-      <div class="title">
-        {{ data }}
-      </div>
-    </prizm-scrollbar>
-    <button
-      *ngIf="context.closeable"
-      [size]="16"
-      prizmInputIconButton="cancel-close"
-      (click)="closeSidebar()"
-      [interactive]="true"
-    ></button>
+  <div
+    [ngSwitch]="!!context.headerTemplate"
+    *ngIf="context.headerTemplate ?? context.header"
+    class="header prizm-font-title-h4"
+  >
+    <ng-container *ngSwitchCase="true">
+      <ng-container *polymorphOutlet="context.headerTemplate as headerTemplate; context: context">
+        headerTemplate
+      </ng-container>
+    </ng-container>
+    <ng-container *ngSwitchDefault>
+      <prizm-scrollbar visibility="hidden" *polymorphOutlet="context.header as data; context: context">
+        <div class="title">
+          {{ data }}
+        </div>
+      </prizm-scrollbar>
+      <button
+        *ngIf="context.closeable"
+        [size]="16"
+        prizmInputIconButton="cancel-close"
+        (click)="closeSidebar()"
+        [interactive]="true"
+      ></button>
+    </ng-container>
   </div>
 
   <div class="content prizm-font-main-body-14">
-    <prizm-scrollbar class="scrollbar full-height">
-      <div class="full-height" *polymorphOutlet="context.content as text; context: context">
-        {{ text }}
-      </div>
-    </prizm-scrollbar>
+    <ng-container *polymorphOutlet="context.outerContent as outerContent">
+      <ng-container *ngIf="outerContent; else innerTemplate">
+        {{ outerContent }}
+      </ng-container>
+      <ng-template #innerTemplate>
+        <prizm-scrollbar class="scrollbar full-height">
+          <div class="full-height" *polymorphOutlet="context.content as text; context: context">
+            {{ text }}
+          </div>
+        </prizm-scrollbar>
+      </ng-template>
+    </ng-container>
   </div>
 
   <div class="footer prizm-font-btn-links-14" *ngIf="!context.hideFooter">

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
@@ -6,7 +6,7 @@
   >
     <ng-container *ngSwitchCase="true">
       <ng-container *polymorphOutlet="context.headerTemplate as headerTemplate; context: context">
-        headerTemplate
+        {{ headerTemplate }}
       </ng-container>
     </ng-container>
     <ng-container *ngSwitchDefault>

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
@@ -2,6 +2,7 @@
 
 .content {
   .ellipsis();
+  flex: 1 1 0;
   padding: var(--prizm-sidebar-padding, 32px 16px);
   color: var(--prizm-text-main);
   overflow: hidden;
@@ -9,6 +10,7 @@
 }
 
 .header {
+  flex: 0 0 auto;
   border-bottom: 1px solid var(--prizm-border-widget);
   padding: var(--prizm-sidebar-padding, 14px 16px);
   display: flex;
@@ -106,8 +108,10 @@
 
 .box {
   height: 100%;
-  grid-template-rows: min-content 1fr min-content;
-  display: grid;
+  //grid-template-rows: min-content 1fr min-content;
+  //display: grid;
+  display: flex;
+  flex-direction: column;
 }
 
 .close-btn {

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.models.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.models.ts
@@ -28,8 +28,11 @@ export interface PrizmSidebarOptions<DATA = unknown> extends PrizmDialogBaseOpti
 
   closeWord: string;
   readonly content?: any;
+  readonly outerContent?: any;
   readonly closeable: boolean;
+  /** @deprecated use headerTemplate */
   readonly header: any;
+  readonly headerTemplate: any;
   readonly canClose?: () => Observable<boolean>;
   readonly hideFooter?: boolean;
   readonly footer: PolymorphContent<

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.models.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.models.ts
@@ -30,8 +30,14 @@ export interface PrizmSidebarOptions<DATA = unknown> extends PrizmDialogBaseOpti
   readonly content?: any;
   readonly outerContent?: any;
   readonly closeable: boolean;
-  /** @deprecated use headerTemplate */
+  /**
+   * header (not include close button)
+   * @deprecated use headerTemplate
+   * */
   readonly header: any;
+  /**
+   * for change full header with close button
+   * */
   readonly headerTemplate: any;
   readonly canClose?: () => Observable<boolean>;
   readonly hideFooter?: boolean;

--- a/libs/components/src/lib/components/scrollbar/scrollbar.component.less
+++ b/libs/components/src/lib/components/scrollbar/scrollbar.component.less
@@ -29,5 +29,5 @@
   flex: 1;
   flex-basis: auto;
   width: 100%;
-  height: max-content;
+  height: 100%;
 }

--- a/libs/components/src/lib/modules/overlay/overlay-control.ts
+++ b/libs/components/src/lib/modules/overlay/overlay-control.ts
@@ -34,6 +34,7 @@ export class PrizmOverlayControl {
   readonly config: PrizmOverlayConfig;
   content: PrizmOverlayContent;
   zid: PrizmOverlayId;
+  zIndex = 9999;
   comp: PrizmOverlayComponent;
   updateTextContent: Subject<string> = new Subject();
   hostView: ViewRef;
@@ -156,9 +157,9 @@ export class PrizmOverlayControl {
     this.comp = this.compRef.instance;
 
     /* assign props */
-    const { position, content, config, zid } = this;
+    const { position, content, config, zid, zIndex } = this;
     content.props.close = this.close.bind(this);
-    Object.assign(this.comp, { position, content, config, zid: zid });
+    Object.assign(this.comp, { position, content, config, zid: zid, zIndex: zIndex });
 
     /* attach view */
     this.hostView = this.compRef.hostView;

--- a/libs/components/src/lib/modules/overlay/overlay.component.less
+++ b/libs/components/src/lib/modules/overlay/overlay.component.less
@@ -5,7 +5,6 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  z-index: 9999;
 
   &.no-width {
     width: auto;

--- a/libs/components/src/lib/modules/overlay/overlay.component.ts
+++ b/libs/components/src/lib/modules/overlay/overlay.component.ts
@@ -5,6 +5,7 @@ import {
   Component,
   ComponentFactoryResolver,
   ElementRef,
+  HostBinding,
   Injector,
   OnDestroy,
   OnInit,
@@ -14,7 +15,7 @@ import {
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmThemeService } from '@prizm-ui/theme';
 import { Observable } from 'rxjs';
-import { filter, map, startWith, takeUntil, tap } from 'rxjs/operators';
+import { startWith, takeUntil, tap } from 'rxjs/operators';
 import { PrizmOverlayConfig, PrizmOverlayContent, PrizmOverlayContentType, PrizmOverlayId } from './models';
 import { PrizmOverlayAbstractPosition } from './position/position';
 import { cssClass, EventBus, objToCss } from './utils';
@@ -36,6 +37,8 @@ export class PrizmOverlayComponent implements OnInit, AfterViewInit, OnDestroy {
   config: PrizmOverlayConfig;
   position: PrizmOverlayAbstractPosition;
   zid: PrizmOverlayId;
+  @HostBinding('style.zIndex')
+  zIndex: number;
   el: HTMLElement | any;
   wrapperEl: HTMLElement | any;
   extra: string;


### PR DESCRIPTION
- feat(components/sidebar): added outerContent input to pass full content for example with your scrollbar [[199](https://github.com/zyfra/Prizm/issues/199)](https://github.com/zyfra/Prizm/issues/199)
- feat(components/sidebar): added headerTemplate input to pass your header with close button[[131](https://github.com/zyfra/Prizm/issues/131)](https://github.com/zyfra/Prizm/issues/131)
- feat(component/sidebar): content container is not stretching to full height  [[130](https://github.com/zyfra/Prizm/issues/130)](https://github.com/zyfra/Prizm/issues/130)
- feat(component/sidebar): add input to control overlay zIndex [[223](https://github.com/zyfra/Prizm/issues/223)](https://github.com/zyfra/Prizm/issues/223)