### PR TITLE
feat(components/input-select): cleat search value on open input-selec…

### DIFF
--- a/apps/doc/src/app/components/dropdowns/select/select.component.html
+++ b/apps/doc/src/app/components/dropdowns/select/select.component.html
@@ -117,7 +117,7 @@
         [(documentationPropertyValue)]="items"
         [documentationPropertyValues]="itemsVariants"
         documentationPropertyName="items"
-        documentationPropertyType="unknown[]"
+        documentationPropertyType="T[]"
         documentationPropertyMode="input"
       >
         Items

--- a/apps/doc/src/app/components/input/input-layout-date-time/input-layout-date-time.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-time/input-layout-date-time.component.html
@@ -39,11 +39,10 @@
           [timeStrict]="timeStrict"
           [placeholder]="placeholder"
           [timeMode]="timeMode"
-          [size]="size"
         ></prizm-input-layout-date-time>
       </prizm-input-layout>
     </prizm-doc-demo>
-    <prizm-doc-documentation [control]="valueControl" [hostComponentKey]="controlKey">
+    <prizm-doc-documentation [control]="valueControl" [hostComponentKey]="controlKey" [heading]="controlKey">
       <ng-template
         [(documentationPropertyValue)]="placeholder"
         documentationPropertyName="placeholder"
@@ -51,16 +50,6 @@
         documentationPropertyMode="input"
       >
         Placeholder
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="size"
-        [documentationPropertyValues]="sizeVariants"
-        documentationPropertyName="size"
-        documentationPropertyType="PrizmInputSize"
-        documentationPropertyMode="input"
-      >
-        Size
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-select/examples/base/select-base-example.component.html
+++ b/apps/doc/src/app/components/input/input-select/examples/base/select-base-example.component.html
@@ -1,5 +1,5 @@
 <prizm-input-layout label="Validators">
-  <prizm-input-select [formControl]="control" [items]="items"></prizm-input-select>
+  <prizm-input-select [formControl]="control" [stringify]="stringify" [items]="items"></prizm-input-select>
 </prizm-input-layout>
 <br />
 <br />

--- a/apps/doc/src/app/components/input/input-select/examples/base/select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/base/select-base-example.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
+import { PrizmSelectStringify } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-select-base-example',
@@ -15,12 +16,29 @@ import { UntypedFormControl, Validators } from '@angular/forms';
 })
 export class PrizmSelectBaseExampleComponent {
   readonly items = [
+    '',
+    false,
+    true,
+    0,
     'One',
     'Two',
     'Three',
     'Very long text with a lot of characters and spaces and other stuff and things',
   ];
   readonly control = new UntypedFormControl(this.items[1], [Validators.required]);
+
+  readonly stringify: PrizmSelectStringify<string | number | boolean> = (item: string | number | boolean) => {
+    switch (typeof item) {
+      case 'string':
+        return item || 'Пустая строка';
+      case 'number':
+        return item.toString();
+      case 'boolean':
+        return item ? 'TRUE' : 'FALSY';
+    }
+
+    return item;
+  };
 
   public setDefaultValue(): void {
     this.control.setValue(this.items[0], { emitEvent: false });

--- a/apps/doc/src/app/components/input/input-select/examples/base/select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/base/select-base-example.component.ts
@@ -16,29 +16,12 @@ import { PrizmSelectStringify } from '@prizm-ui/components';
 })
 export class PrizmSelectBaseExampleComponent {
   readonly items = [
-    '',
-    false,
-    true,
-    0,
     'One',
     'Two',
     'Three',
     'Very long text with a lot of characters and spaces and other stuff and things',
   ];
   readonly control = new UntypedFormControl(this.items[1], [Validators.required]);
-
-  readonly stringify: PrizmSelectStringify<string | number | boolean> = (item: string | number | boolean) => {
-    switch (typeof item) {
-      case 'string':
-        return item || 'Пустая строка';
-      case 'number':
-        return item.toString();
-      case 'boolean':
-        return item ? 'TRUE' : 'FALSY';
-    }
-
-    return item;
-  };
 
   public setDefaultValue(): void {
     this.control.setValue(this.items[0], { emitEvent: false });

--- a/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.html
+++ b/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.html
@@ -11,4 +11,4 @@
 
 <br />
 <br />
-<div>Current value: {{ control.value }}</div>
+<div>Current value: [{{ getType(control.value) }}] {{ control.value }}</div>

--- a/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.html
+++ b/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.html
@@ -1,5 +1,5 @@
 <prizm-input-layout label="Validators">
-  <prizm-input-select [formControl]="control" [items]="items"></prizm-input-select>
+  <prizm-input-select [formControl]="control" [stringify]="stringify" [items]="items"></prizm-input-select>
 </prizm-input-layout>
 <br />
 <br />

--- a/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { UntypedFormControl, Validators } from '@angular/forms';
+import { PrizmSelectStringify } from '@prizm-ui/components';
+
+@Component({
+  selector: 'prizm-select-stringify-example',
+  templateUrl: './select-stringify-example.component.html',
+  styles: [
+    `
+      .box {
+        display: flex;
+        gap: 1rem;
+      }
+    `,
+  ],
+})
+export class PrizmSelectStringifyExampleComponent {
+  readonly items = [
+    '',
+    false,
+    true,
+    0,
+    'One',
+    'Two',
+    'Three',
+    'Very long text with a lot of characters and spaces and other stuff and things',
+  ];
+  readonly control = new UntypedFormControl(this.items[1], [Validators.required]);
+
+  readonly stringify: PrizmSelectStringify<string | number | boolean> = (item: string | number | boolean) => {
+    switch (typeof item) {
+      case 'string':
+        return item || 'Пустая строка';
+      case 'number':
+        return item.toString();
+      case 'boolean':
+        return item ? 'TRUE' : 'FALSY';
+    }
+
+    return item;
+  };
+
+  public setDefaultValue(): void {
+    this.control.setValue(this.items[0], { emitEvent: false });
+  }
+}

--- a/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.ts
@@ -41,6 +41,10 @@ export class PrizmSelectStringifyExampleComponent {
   };
 
   public setDefaultValue(): void {
-    this.control.setValue(this.items[0], { emitEvent: false });
+    this.control.setValue(this.items[4], { emitEvent: false });
+  }
+
+  public getType(val: any): string {
+    return typeof val;
   }
 }

--- a/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/stringify/select-stringify-example.component.ts
@@ -34,7 +34,7 @@ export class PrizmSelectStringifyExampleComponent {
       case 'number':
         return item.toString();
       case 'boolean':
-        return item ? 'TRUE' : 'FALSY';
+        return item ? 'TRUE' : 'FALSE';
     }
 
     return item;

--- a/apps/doc/src/app/components/input/input-select/input-select.component.html
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.html
@@ -189,7 +189,7 @@
         [(documentationPropertyValue)]="items"
         [documentationPropertyValues]="itemsVariants"
         documentationPropertyName="items"
-        documentationPropertyType="unknown[]"
+        documentationPropertyType="T[]"
         documentationPropertyMode="input"
       >
         Items

--- a/apps/doc/src/app/components/input/input-select/input-select.component.html
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.html
@@ -6,6 +6,9 @@
     <prizm-doc-example id="base" [content]="exampleBase" heading="Base">
       <prizm-select-base-example></prizm-select-base-example>
     </prizm-doc-example>
+    <prizm-doc-example id="stringify" [content]="exampleStringify" heading="Stringify">
+      <prizm-select-stringify-example></prizm-select-stringify-example>
+    </prizm-doc-example>
 
     <prizm-doc-example id="with-search" [content]="exampleWithSearch" heading="With Search">
       <prizm-select-with-search-example></prizm-select-with-search-example>

--- a/apps/doc/src/app/components/input/input-select/input-select.component.ts
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.ts
@@ -85,6 +85,10 @@ export class InputSelectComponent {
     TypeScript: import('./examples/base/select-base-example.component.ts?raw'),
     HTML: import('./examples/base/select-base-example.component.html?raw'),
   };
+  readonly exampleStringify: TuiDocExample = {
+    TypeScript: import('./examples/stringify/select-stringify-example.component.ts?raw'),
+    HTML: import('./examples/stringify/select-stringify-example.component.html?raw'),
+  };
   readonly exampleFullWidth: TuiDocExample = {
     TypeScript: import('./examples/full-width/select-full-width-example.component.ts?raw'),
     HTML: import('./examples/full-width/select-full-width-example.component.html?raw'),

--- a/apps/doc/src/app/components/input/input-select/input-select.module.ts
+++ b/apps/doc/src/app/components/input/input-select/input-select.module.ts
@@ -18,6 +18,7 @@ import { PrizmSelectWithObjectExampleComponent } from './examples/with-object/se
 import { PrizmSelectWithBackendSearchExampleComponent } from './examples/with-backend-search/select-with-backend-search-example.component';
 import { PrizmSelectFullWidthExampleComponent } from './examples/full-width/select-full-width-example.component';
 import { PrizmSelectValidatorsExampleComponent } from './examples/validators/select-validators-example.component';
+import { PrizmSelectStringifyExampleComponent } from './examples/stringify/select-stringify-example.component';
 
 @NgModule({
   imports: [
@@ -38,6 +39,7 @@ import { PrizmSelectValidatorsExampleComponent } from './examples/validators/sel
     PrizmSelectBaseExampleComponent,
     PrizmSelectWithSearchExampleComponent,
     PrizmSelectWithBackendSearchExampleComponent,
+    PrizmSelectStringifyExampleComponent,
     PrizmSelectWithObjectExampleComponent,
     PrizmSelectWithTemplateExampleComponent,
     InputSelectComponent,

--- a/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.component.html
@@ -1,3 +1,3 @@
 <prizm-input-layout label="Заголовок">
-  <textarea prizmInput autoSize></textarea>
+  <textarea prizmInput autoSize placeholder="Введите заголовок"></textarea>
 </prizm-input-layout>

--- a/libs/components/src/lib/components/cron/cron.component.html
+++ b/libs/components/src/lib/components/cron/cron.component.html
@@ -57,10 +57,12 @@
       <prizm-input-date-time
         [label]="cronI18n$ | async | prizmPluck : ['startDateLabel']"
         [formControl]="startDateControl"
+        [max]="endDateControl.value"
       >
       </prizm-input-date-time>
 
       <prizm-input-date-time
+        [min]="startDateControl.value"
         [label]="cronI18n$ | async | prizmPluck : ['endDateLabel']"
         [disabled]="indefinitely"
         [formControl]="endDateControl"

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
@@ -7,7 +7,7 @@
   [prizmDropdownMinHeight]="minDropdownHeight"
   [prizmDropdownMaxHeight]="maxDropdownHeight"
   [ngSwitch]="layoutComponent.outer"
-  (isOpenChange)="opened$$.next($event)"
+  (isOpenChange)="$event && searchInputControl.setValue(''); opened$$.next($event)"
 >
   <input
     #focusableElementRef

--- a/libs/components/src/lib/components/dropdowns/multi-select/multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/multi-select.component.ts
@@ -339,6 +339,7 @@ export class PrizmMultiSelectComponent<T>
 
   public safeOpenModal(): void {
     const inputElement = this.focusableElement.nativeElement;
+    this.searchInputControl.setValue('');
     this.open =
       !this.open &&
       this.interactive &&

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -50,7 +50,7 @@
           "
           (click)="select(item)"
         >
-          <ng-container *ngIf="item; else nullContentTemplate">
+          <ng-container *ngIf="item != null; else nullContentTemplate">
             <span
               class="text"
               #elem

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -50,7 +50,7 @@
           "
           (click)="select(item)"
         >
-          <ng-container *ngIf="item != null; else nullContentTemplate">
+          <ng-container *ngIf="!isNullish(item); else nullContentTemplate">
             <span
               class="text"
               #elem

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -220,7 +220,7 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   public safeOpenModal(): void {
     // set touched on open modal
     this.ngControl.control.markAsTouched();
-    const inputElement = this.focusableElement.nativeElement;
+    this.printing$.next('');
 
     const open = !this.opened$$.value && !this.disabled; // && inputElement && prizmIsNativeFocused(inputElement);
     this.opened$$.next(open);

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -12,7 +12,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { Compare, PrizmDestroyService } from '@prizm-ui/helpers';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { PolymorphContent } from '../../../directives';
 import { PRIZM_SELECT_OPTIONS, PrizmSelectOptions, PrizmSelectValueContext } from './select.options';
@@ -136,6 +136,7 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   public readonly defaultIcon = 'chevrons-dropdown';
   public readonly nativeElementType = 'select';
   public readonly hasClearButton = true;
+  readonly isNullish = Compare.isNullish;
 
   filteredItems$!: any;
 

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -252,7 +252,7 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   }
 
   public override isEmpty(value: T): boolean {
-    return !value;
+    return value == null;
   }
 
   public getCurrentItem(value: T): string {

--- a/libs/components/src/lib/components/dropdowns/select/select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/select.component.html
@@ -57,7 +57,7 @@
           "
           (click)="select(item)"
         >
-          <ng-container *ngIf="item != null; else nullContentTemplate">
+          <ng-container *ngIf="!isNullish(item); else nullContentTemplate">
             <span
               class="text"
               #elem

--- a/libs/components/src/lib/components/dropdowns/select/select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/select.component.html
@@ -57,7 +57,7 @@
           "
           (click)="select(item)"
         >
-          <ng-container *ngIf="item; else nullContentTemplate">
+          <ng-container *ngIf="item != null; else nullContentTemplate">
             <span
               class="text"
               #elem

--- a/libs/components/src/lib/components/dropdowns/select/select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/select.component.ts
@@ -13,7 +13,7 @@ import {
   Self,
   ViewChild,
 } from '@angular/core';
-import { PrizmDestroyService, PrizmFormControlHelpers } from '@prizm-ui/helpers';
+import { Compare, PrizmDestroyService, PrizmFormControlHelpers } from '@prizm-ui/helpers';
 import { NgControl, UntypedFormControl } from '@angular/forms';
 import { PolymorphContent } from '../../../directives';
 import { PRIZM_SELECT_OPTIONS, PrizmSelectOptions, PrizmSelectValueContext } from './select.options';
@@ -190,6 +190,7 @@ export class PrizmSelectComponent<T>
 
   public filteredItems: T[] = [];
   private searchValue: string;
+  readonly isNullish = Compare.isNullish;
 
   constructor(
     @Inject(PRIZM_SELECT_OPTIONS) private readonly options: PrizmSelectOptions<T>,

--- a/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
+++ b/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
@@ -117,7 +117,7 @@ export abstract class PrizmInputNgControl<T>
 
   public clear(ev: MouseEvent) {
     this.updateValue(null);
-    this.markAsTouched();
+    this.markAsDirty();
   }
 
   public registerOnChange(onChange: any): void {
@@ -190,5 +190,9 @@ export abstract class PrizmInputNgControl<T>
 
   public markAsTouched(): void {
     this.ngControl.control.markAsTouched();
+  }
+
+  public markAsDirty(): void {
+    this.ngControl.control.markAsDirty();
   }
 }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -13,7 +13,8 @@
     display: none;
   }
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     .prizm-input-button-default {
       display: block;
     }

--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
@@ -83,10 +83,6 @@ export class PrizmInputLayoutDateTimeComponent extends PrizmInputNgControl<
 
   @Input()
   @prizmDefaultProp()
-  size: PrizmInputSize = 'm';
-
-  @Input()
-  @prizmDefaultProp()
   extraButtonInjector: Injector;
 
   @Input()

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -18,6 +18,7 @@ import { UntypedFormControl, NgControl, Validators } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
+import { interval } from 'rxjs';
 
 @Component({
   selector:
@@ -240,7 +241,9 @@ export class PrizmInputTextComponent extends PrizmInputControl<string> implement
     if (this.disabled) return;
 
     this.ngControl?.control.setValue('');
-    this._touched = true;
+
+    // this._touched = true;
+    this.ngControl?.control.markAsDirty();
 
     this._inputValue.value = '';
 

--- a/libs/doc/base/src/lib/components/documentation/documentation.component.html
+++ b/libs/doc/base/src/lib/components/documentation/documentation.component.html
@@ -173,6 +173,36 @@
 
 <ng-container *ngIf="control">
   <ng-template
+    [documentationPropertyValue]="control | prizmCallFunc : isTouchedFromControl$ | async"
+    (documentationPropertyValueChange)="setTouched(control, $any($event))"
+    documentationPropertyName="touched"
+    documentationPropertyType="boolean"
+    documentationPropertyMode="form-control"
+  >
+    Touched
+  </ng-template>
+
+  <ng-template
+    [documentationPropertyValue]="control | prizmCallFunc : isDirtyFromControl$ | async"
+    (documentationPropertyValueChange)="setDirty(control, $any($event))"
+    documentationPropertyName="dirty"
+    documentationPropertyType="boolean"
+    documentationPropertyMode="form-control"
+  >
+    Dirty
+  </ng-template>
+
+  <ng-template
+    [documentationPropertyValue]="control | prizmCallFunc : isPristineFromControl$ | async"
+    (documentationPropertyValueChange)="setPristine(control, $any($event))"
+    documentationPropertyName="pristine"
+    documentationPropertyType="boolean"
+    documentationPropertyMode="form-control"
+  >
+    Pristine
+  </ng-template>
+
+  <ng-template
     [documentationPropertyValue]="control | prizmCallFunc : getDisabledFromControl$ | async"
     (documentationPropertyValueChange)="updateStateOfControl(control, $any($event))"
     documentationPropertyName="disabled"

--- a/libs/helpers/src/lib/util/form/index.ts
+++ b/libs/helpers/src/lib/util/form/index.ts
@@ -22,6 +22,12 @@ export class PrizmFormControlHelpers {
   public static getDisabled(origin: UntypedFormControl): boolean {
     return origin.disabled;
   }
+  public static isTouched(origin: UntypedFormControl): boolean {
+    return origin.touched;
+  }
+  public static isDirty(origin: UntypedFormControl): boolean {
+    return origin.dirty;
+  }
 
   public static getValidators(origin: UntypedFormControl): ValidatorFn | ValidatorFn[] | null {
     return (origin as any)?.['_rawValidators'] ?? null;

--- a/libs/i18n/src/lib/languages/russian/cron.ts
+++ b/libs/i18n/src/lib/languages/russian/cron.ts
@@ -6,7 +6,7 @@ export const PRIZM_RUSSIAN_CRON: PrizmLanguageCron = {
     submitText: 'Применить',
     resetText: 'Отменить',
     startDateLabel: 'Начало работы',
-    endDateLabel: 'Начало работы',
+    endDateLabel: 'Конец работы',
     indefinitelyLabel: 'Бессрочно',
     day: {
       every: 'Каждый день',


### PR DESCRIPTION
- fix(components/cron): fix end date label [362](https://github.com/zyfra/Prizm/pull/362)
- feat(components/cron): add min/max validators for start and end date [364](https://github.com/zyfra/Prizm/issues/364)
- feat(components/select): clear search value after close modal
- fix(components/input-text): set only dirty afte clear value [354](https://github.com/zyfra/Prizm/issues/354)
- feat(doc): add pristine, dirty, touched controls to api page for form control components
- fix(components/input-select): falsy values does not display in dropdown [331](https://github.com/zyfra/Prizm/issues/331)
- feat(components/input-layout): clear button does not showed on focus with keyboard [356](https://github.com/zyfra/Prizm/issues/356)