### PR TITLE
Feat/release 2.1.0 next.3

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0-next.3](https://github.com/zyfra/Prizm) (13-07-2023)
+
+### Bracking Changes
+
+- BC(components/hint): remove input prizmHintShow
+- BC(components/tooltip): remove input prizmHintShow
+- BC(components/hint): rename output prizmHoverChange > prizmHintShowed
+- BC(components/tooltip): raname output prizmHoverChange > prizmTooltipShowed
+
+### BUG FIXES
+
+- fix(doc/tooltip): corrected api page
+- fix(doc/hint): corrected api page
+- fix(components/hint): long string without hyphenation is truncated #414
+
+### Features
+
+- feat(doc): now input/output getter can distinguish altered properties
+
 ## [2.1.0-next.2](https://github.com/zyfra/Prizm) (13-07-2023)
 
 ### BUG FIXES

--- a/apps/doc/src/app/components/hint/hint.component.html
+++ b/apps/doc/src/app/components/hint/hint.component.html
@@ -19,25 +19,18 @@
   <ng-template prizmDocPageTab prizmDocHost>
     <prizm-doc-demo>
       <button
+        #element="prizmHint"
+        [prizmDocHostElement]="element"
         [prizmHint]="content"
         [prizmAutoReposition]="prizmAutoReposition"
         [prizmHintCanShow]="prizmHintCanShow"
         [prizmHintDirection]="prizmHintDirection"
         [prizmHintId]="prizmHintId"
-        [prizmHintShow]="prizmHintShow"
         [prizmHintShowDelay]="prizmHintShowDelay"
         [prizmHintHideDelay]="prizmHintHideDelay"
         [prizmHintContext]="prizmHintContext"
         [prizmHintHost]="prizmHintHost"
         [size]="size"
-        [icon]="icon"
-        [iconRight]="iconRight"
-        [appearanceType]="appearanceType"
-        [appearance]="appearance"
-        [disabled]="disabled"
-        [showLoader]="showLoader"
-        [focusable]="focusable"
-        [pseudoState]="pseudoState"
         prizmButton
       >
         Button

--- a/apps/doc/src/app/components/hint/hint.component.html
+++ b/apps/doc/src/app/components/hint/hint.component.html
@@ -40,7 +40,7 @@
       <ng-template
         [(documentationPropertyValue)]="content"
         documentationPropertyName="prizmHint"
-        documentationPropertyType="string"
+        documentationPropertyType="PolymorphContent"
         documentationPropertyMode="input"
       >
         Content
@@ -74,12 +74,11 @@
       </ng-template>
 
       <ng-template
-        [(documentationPropertyValue)]="prizmHintShow"
-        documentationPropertyName="prizmHintShow"
+        documentationPropertyName="prizmHintShowed"
         documentationPropertyType="boolean"
-        documentationPropertyMode="input"
+        documentationPropertyMode="output"
       >
-        Show
+        Trigger on hint showed/hidden
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/tooltip/tooltip.component.html
+++ b/apps/doc/src/app/components/tooltip/tooltip.component.html
@@ -7,11 +7,11 @@
       <prizm-tooltip-base-example></prizm-tooltip-base-example>
     </prizm-doc-example>
 
-    <prizm-doc-example id="base" [content]="exampleWithTemplate" heading="With Template">
+    <prizm-doc-example id="with-template" [content]="exampleWithTemplate" heading="With Template">
       <prizm-tooltip-with-template-example></prizm-tooltip-with-template-example>
     </prizm-doc-example>
 
-    <prizm-doc-example id="base" [content]="exampleWithComponent" heading="With Component">
+    <prizm-doc-example id="with-component" [content]="exampleWithComponent" heading="With Component">
       <prizm-tooltip-with-component-example></prizm-tooltip-with-component-example>
     </prizm-doc-example>
   </ng-template>
@@ -19,13 +19,14 @@
   <ng-template prizmDocPageTab prizmDocHost>
     <prizm-doc-demo>
       <button
-        #element
+        #element="prizmTooltip"
         [prizmDocHostElement]="element"
         [prizmTooltip]="content"
         [prizmAutoReposition]="prizmAutoReposition"
         [prizmTooltipDirection]="prizmTooltipDirection"
         [prizmTooltipId]="prizmTooltipId"
         [prizmTooltipShowDelay]="prizmTooltipShowDelay"
+        [prizmTooltipCanShow]="prizmTooltipCanShow"
         [prizmTooltipHideDelay]="prizmTooltipHideDelay"
         [prizmTooltipHost]="prizmTooltipHost"
         [size]="size"
@@ -43,208 +44,91 @@
       </button>
     </prizm-doc-demo>
     <prizm-doc-documentation>
-      <!-- <ng-template
+      <ng-template
         documentationPropertyName="prizmTooltip"
-        documentationPropertyType="string"
+        documentationPropertyType="PolymorphContent"
         documentationPropertyMode="input"
-        [(documentationPropertyValue)]="content"
       >
         Content
-      </ng-template> -->
+      </ng-template>
 
-      <!-- <ng-template
-        documentationPropertyName="prizmAutoReposition"
+      <ng-template
+        documentationPropertyName="prizmTooltipHost"
+        documentationPropertyType="HTMLElement | null"
+        documentationPropertyMode="input"
+      >
+        Element relative to which the tooltip will appear (default: current)
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmTooltipCanShow"
+        documentationPropertyName="prizmTooltipCanShow"
         documentationPropertyType="boolean"
         documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmAutoReposition"
       >
-        Auto Reposition
-      </ng-template> -->
+        Tooltip might appear
+      </ng-template>
 
-      <!-- <ng-template
-        documentationPropertyName="prizmTooltipDirection"
-        documentationPropertyType="PrizmOverlayOutsidePlacement"
-        documentationPropertyMode="input"
-        [documentationPropertyValues]="prizmTooltipDirectionVariants"
-        [(documentationPropertyValue)]="prizmTooltipDirection"
+      <ng-template
+        documentationPropertyName="prizmTooltipShowed"
+        documentationPropertyType="boolean"
+        documentationPropertyMode="output"
       >
-        Tooltip Direction
-      </ng-template> -->
+        Trigger on tooltip showed/hidden
+      </ng-template>
 
-      <!-- <ng-template
-        documentationPropertyName="prizmTooltipId"
-        documentationPropertyType="string"
-        documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmTooltipId"
-      >
-        Tooltip Id
-      </ng-template> -->
-
-      <!-- <ng-template
-        documentationPropertyName="prizmTooltipShowDelay"
-        documentationPropertyType="number"
-        documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmTooltipShowDelay"
-      >
-        Show Delay
-      </ng-template> -->
-
-      <!-- <ng-template
+      <ng-template
+        [(documentationPropertyValue)]="prizmTooltipHideDelay"
         documentationPropertyName="prizmTooltipHideDelay"
         documentationPropertyType="number"
         documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmTooltipHideDelay"
       >
-        Hide Delay
-      </ng-template> -->
-
-      <!-- <ng-template
-        documentationPropertyName="prizmTooltipHost"
-        documentationPropertyType="HtmlElement"
-        documentationPropertyMode="input"
-      >
-        Host
-      </ng-template> -->
-
-      <ng-template
-        [(documentationPropertyValue)]="appearance"
-        [documentationPropertyValues]="appearanceVariants"
-        documentationPropertyName="appearance"
-        documentationPropertyType="PrizmAppearance"
-        documentationPropertyMode="input"
-      >
-        Appearance
+        Delay to hide tooltip
       </ng-template>
 
       <ng-template
-        [(documentationPropertyValue)]="appearanceType"
-        [documentationPropertyValues]="appearanceTypeVariants"
-        documentationPropertyName="appearanceType"
-        documentationPropertyType="PrizmAppearanceType"
+        [(documentationPropertyValue)]="prizmTooltipShowDelay"
+        documentationPropertyName="prizmTooltipShowDelay"
+        documentationPropertyType="number"
         documentationPropertyMode="input"
       >
-        AppearanceType
+        Delay to show tooltip
       </ng-template>
 
       <ng-template
-        [(documentationPropertyValue)]="size"
-        [documentationPropertyValues]="sizeVariants"
-        documentationPropertyName="size"
-        documentationPropertyType="PrizmDialogSize"
+        documentationPropertyName="prizmTooltipContext"
+        documentationPropertyType="Record<stiring, unknown>"
         documentationPropertyMode="input"
       >
-        Size
+        Context passed to tooltip
       </ng-template>
 
       <ng-template
-        [(documentationPropertyValue)]="icon"
-        [documentationPropertyValues]="iconVariants"
-        documentationPropertyName="icon"
-        documentationPropertyType="PrizmContent"
-        documentationPropertyMode="input"
-      >
-        Icon
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="iconRight"
-        [documentationPropertyValues]="iconVariants"
-        documentationPropertyName="iconRight"
-        documentationPropertyType="PrizmContent"
-        documentationPropertyMode="input"
-      >
-        Right Icon
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="disabled"
-        documentationPropertyName="disabled"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-      >
-        Disabled
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="showLoader"
-        documentationPropertyName="showLoader"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-      >
-        Show Loader
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="pseudoHovered"
-        documentationPropertyName="pseudoHovered"
-        documentationPropertyType="boolean | null"
-        documentationPropertyMode="input"
-      >
-        Pseudo Hovered
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pseudoPressed"
-        documentationPropertyName="pseudoPressed"
-        documentationPropertyType="boolean | null"
-        documentationPropertyMode="input"
-      >
-        Pseudo Pressed
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pseudoFocused"
-        documentationPropertyName="pseudoFocused"
-        documentationPropertyType="boolean | null"
-        documentationPropertyMode="input"
-      >
-        Pseudo Focused
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="focusable"
-        documentationPropertyName="focusable"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-      >
-        Focusable
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pseudoState"
-        documentationPropertyName="pseudoState"
+        [(documentationPropertyValue)]="prizmTooltipId"
+        documentationPropertyName="prizmTooltipId"
         documentationPropertyType="string"
         documentationPropertyMode="input"
       >
-        Pseudo State
+        Tooltip ID
       </ng-template>
+
       <ng-template
-        [(documentationPropertyValue)]="focusedChange"
-        documentationPropertyName="focusedChange"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="output"
+        [(documentationPropertyValue)]="prizmTooltipDirection"
+        [documentationPropertyValues]="prizmTooltipDirectionVariants"
+        documentationPropertyName="prizmTooltipDirection"
+        documentationPropertyType="PrizmTooltipOptions['direction']"
+        documentationPropertyMode="input"
       >
-        Focused Change
+        Tooltip direction
       </ng-template>
+
       <ng-template
-        [(documentationPropertyValue)]="pressedChange"
-        documentationPropertyName="pressedChange"
+        [(documentationPropertyValue)]="prizmAutoReposition"
+        documentationPropertyName="prizmAutoReposition"
         documentationPropertyType="boolean"
-        documentationPropertyMode="output"
+        documentationPropertyMode="input"
       >
-        Pressed Change
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="hoveredChange"
-        documentationPropertyName="hoveredChange"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="output"
-      >
-        Hovered Change
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="focusVisibleChange"
-        documentationPropertyName="focusVisibleChange"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="output"
-      >
-        Focus Visible Change
+        Auto recalculate positioning
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/components/tooltip/tooltip.component.ts
+++ b/apps/doc/src/app/components/tooltip/tooltip.component.ts
@@ -55,6 +55,8 @@ export class TooltipComponent {
 
   public content = 'Тестовое содержимое';
   public prizmAutoReposition = false;
+  public prizmTooltipShow = true;
+  public prizmTooltipCanShow = true;
 
   public readonly prizmTooltipDirectionVariants: ReadonlyArray<PrizmTooltipOptions['direction']> =
     Object.values(PrizmOverlayOutsidePlacement);

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
@@ -32,9 +32,9 @@ import { PrizmHintDirective } from '../hint/hint.directive';
 export class PrizmConfirmPopupDirective<
   T extends Record<string, unknown>
 > extends PrizmHintDirective<PrizmConfirmPopupOptions> {
-  @Input('prizmConfirmPopupMode')
-  @prizmDefaultProp()
-  override prizmHintMode: PrizmHintOptions['mode'] = this.options.mode;
+  // @Input('prizmConfirmPopupMode')
+  // @prizmDefaultProp()
+  // override prizmHintMode: PrizmHintOptions['mode'] = this.options.mode;
 
   @Input('prizmAutoReposition')
   @prizmDefaultProp()
@@ -97,7 +97,7 @@ export class PrizmConfirmPopupDirective<
   protected override getContext(): PrizmConfirmPopupContext {
     const context = {
       size: this.size,
-      mode: this.prizmHintMode,
+      // mode: this.prizmHintMode,
       reposition: this.prizmAutoReposition,
       direction: this.prizmHintDirection,
       completeWith: (value: PrizmConfirmPopupButton) => {

--- a/libs/components/src/lib/directives/hint/hint-container.component.less
+++ b/libs/components/src/lib/directives/hint/hint-container.component.less
@@ -42,3 +42,9 @@
     margin-left: var(--prizm-hint-container-margin, 8px);
   }
 }
+
+.content {
+  word-break: break-word;
+  width: 100%;
+  height: 100%;
+}

--- a/libs/components/src/lib/directives/hint/hint-container.component.ts
+++ b/libs/components/src/lib/directives/hint/hint-container.component.ts
@@ -24,7 +24,7 @@ import { PrizmHintOptions } from './hint-options';
     <div class="prizm-font-main-body-12">
       <prizm-scrollbar visibility="hidden">
         <ng-container *polymorphOutlet="content() as data; context: context">
-          {{ data }}
+          <div class="content">{{ data }}</div>
         </ng-container>
       </prizm-scrollbar>
     </div>

--- a/libs/components/src/lib/directives/hint/hint-container.component.ts
+++ b/libs/components/src/lib/directives/hint/hint-container.component.ts
@@ -42,16 +42,16 @@ export class PrizmHintContainerComponent<CONTEXT extends Record<string, unknown>
   @Input()
   content: () => PolymorphContent;
 
-  @Input()
-  mode: () => PrizmHintOptions['mode'];
+  // @Input()
+  // mode: () => PrizmHintOptions['mode'];
 
   @Input()
   @prizmDefaultProp()
   context: CONTEXT = {} as CONTEXT;
 
-  @HostListener('attr.mode') get getMode(): PrizmHintOptions['mode'] {
-    return this.mode();
-  }
+  // @HostListener('attr.mode') get getMode(): PrizmHintOptions['mode'] {
+  //   return this.mode();
+  // }
 
   constructor(
     protected readonly destroy$: PrizmDestroyService,

--- a/libs/components/src/lib/directives/hint/hint-options.ts
+++ b/libs/components/src/lib/directives/hint/hint-options.ts
@@ -5,13 +5,13 @@ export type PrizmHintMode = 'error' | 'dark' | 'light' | null;
 export interface PrizmHintOptions {
   readonly showDelay: number;
   readonly hideDelay: number;
-  readonly mode: PrizmHintMode;
+  // readonly mode: PrizmHintMode;
   readonly autoReposition: boolean;
   readonly direction: PrizmOverlayOutsidePlacement;
 }
 
 export interface PrizmHintContext {
-  mode: PrizmHintOptions['mode'];
+  // mode: PrizmHintOptions['mode'];
   reposition: boolean;
   direction: PrizmHintOptions['direction'];
   id: string;
@@ -26,7 +26,7 @@ export const PRIZM_HINT_DEFAULT_OPTIONS: PrizmHintOptions = {
   showDelay: 500,
   hideDelay: 200,
   autoReposition: true,
-  mode: null,
+  // mode: null,
   direction: PrizmOverlayOutsidePlacement.RIGHT,
 };
 

--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -22,7 +22,7 @@ import {
 } from '../../modules/overlay';
 import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { PrizmHoveredService } from '../../services';
-import { delay, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { delay, distinctUntilChanged, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PrizmHintContainerComponent } from './hint-container.component';
 import { PrizmHintService } from './hint.service';
 
@@ -38,9 +38,9 @@ export class PrizmHintDirective<
   CONTEXT extends PrizmHintContext = PrizmHintContext
 > implements OnChanges, OnInit, OnDestroy
 {
-  @Input()
-  @prizmDefaultProp()
-  prizmHintMode: PrizmHintOptions['mode'] = this.options.mode;
+  // @Input()
+  // @prizmDefaultProp()
+  // prizmHintMode: PrizmHintOptions['mode'] = this.options.mode;
 
   @Input()
   @prizmDefaultProp()
@@ -74,16 +74,15 @@ export class PrizmHintDirective<
   @prizmDefaultProp()
   prizmHintCanShow = true;
 
-  @Input()
-  set prizmHintShow(show: boolean) {
+  set show(show: boolean) {
     if (show) this.open();
     else this.close();
   }
-  get prizmHintShow(): boolean {
+  get show(): boolean {
     return this.show_;
   }
 
-  private show_ = false;
+  protected show_ = false;
 
   @Input()
   @prizmRequiredSetter()
@@ -96,8 +95,9 @@ export class PrizmHintDirective<
     this.content = value;
   }
 
+  readonly prizmHoveredChange$$ = new Subject<boolean>();
   @Output()
-  readonly prizmHoveredChange = new EventEmitter<boolean>();
+  readonly prizmHintShowed = new EventEmitter<boolean>();
 
   protected readonly onHoverActive: boolean = true;
 
@@ -131,6 +131,16 @@ export class PrizmHintDirective<
 
   public ngOnInit(): void {
     this.initVisibleController();
+
+    this.prizmHoveredChange$$
+      .pipe(
+        distinctUntilChanged(),
+        tap(state => {
+          this.prizmHintShowed.emit(state);
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe();
   }
 
   public ngOnDestroy(): void {
@@ -150,14 +160,14 @@ export class PrizmHintDirective<
     this.show_ = true;
     this.renderer.addClass(this.elementRef.nativeElement, HINT_HOVERED_CLASS);
     this.overlay.open();
-    this.prizmHoveredChange.emit(this.show_);
+    this.prizmHoveredChange$$.next(this.show_);
   }
 
   protected close(): void {
     this.show_ = false;
     this.renderer.removeClass(this.elementRef.nativeElement, HINT_HOVERED_CLASS);
     this.overlay?.close();
-    this.prizmHoveredChange.emit(this.show_);
+    this.prizmHoveredChange$$.next(this.show_);
   }
 
   private initVisibleController(): void {
@@ -190,7 +200,7 @@ export class PrizmHintDirective<
       })
       .content(this.containerComponent, {
         content: () => this.content,
-        mode: () => this.prizmHintMode,
+        // mode: () => this.prizmHintMode,
         id: this.prizmHintId,
         context: this.getContext(),
       })
@@ -211,7 +221,7 @@ export class PrizmHintDirective<
 
   protected getContext(): CONTEXT {
     return {
-      mode: this.prizmHintMode,
+      // mode: this.prizmHintMode,
       reposition: this.prizmAutoReposition,
       direction: this.prizmHintDirection,
       id: this.prizmHintId,

--- a/libs/components/src/lib/directives/tooltip/tooltip-container.component.less
+++ b/libs/components/src/lib/directives/tooltip/tooltip-container.component.less
@@ -114,3 +114,9 @@
 prizm-scrollbar {
   height: 100%;
 }
+
+.content {
+  word-break: break-word;
+  width: 100%;
+  height: 100%;
+}

--- a/libs/components/src/lib/directives/tooltip/tooltip-container.component.ts
+++ b/libs/components/src/lib/directives/tooltip/tooltip-container.component.ts
@@ -9,7 +9,7 @@ import { PrizmHintContainerComponent } from '../hint/hint-container.component';
     <div class="box prizm-font-main-body-14" prizmFocusTrap>
       <prizm-scrollbar visibility="hidden">
         <ng-container *polymorphOutlet="content() as data; context: context">
-          {{ data }}
+          <div class="content">{{ data }}</div>
         </ng-container>
       </prizm-scrollbar>
 

--- a/libs/components/src/lib/directives/tooltip/tooltip.directive.ts
+++ b/libs/components/src/lib/directives/tooltip/tooltip.directive.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @angular-eslint/no-input-rename */
-import { Directive, forwardRef, HostListener, Input } from '@angular/core';
+import { Directive, forwardRef, HostListener, Input, Output } from '@angular/core';
 import { PrizmDestroyService, prizmGenerateId } from '@prizm-ui/helpers';
 import { PrizmTooltipContainerComponent } from './tooltip-container.component';
 import { PRIZM_TOOLTIP_OPTIONS } from './tooltip-options';
@@ -20,9 +20,9 @@ import { PrizmHintDirective } from '../hint/hint.directive';
   exportAs: 'prizmTooltip',
 })
 export class PrizmTooltipDirective extends PrizmHintDirective {
-  @Input('prizmTooltipMode')
-  @prizmDefaultProp()
-  override prizmHintMode: PrizmHintOptions['mode'] = this.options.mode;
+  // @Input('prizmTooltipMode')
+  // @prizmDefaultProp()
+  // override prizmHintMode: PrizmHintOptions['mode'] = this.options.mode;
 
   @Input('prizmAutoReposition')
   @prizmDefaultProp()
@@ -48,6 +48,14 @@ export class PrizmTooltipDirective extends PrizmHintDirective {
   @prizmDefaultProp()
   override prizmHintHost: HTMLElement | null = null;
 
+  @Input('prizmTooltipContext')
+  @prizmDefaultProp()
+  override prizmHintContext = super.prizmHintContext;
+
+  @Input('prizmTooltipCanShow')
+  @prizmDefaultProp()
+  override prizmHintCanShow = super.prizmHintCanShow;
+
   @Input('prizmTooltip')
   @prizmRequiredSetter()
   override set prizmHint(value: PolymorphContent | null) {
@@ -58,6 +66,10 @@ export class PrizmTooltipDirective extends PrizmHintDirective {
 
     this.content = value;
   }
+
+  @Output('prizmTooltipShowed')
+  override prizmHintShowed = super.prizmHintShowed;
+
   protected override readonly containerComponent = PrizmTooltipContainerComponent;
   protected override readonly onHoverActive = false;
 

--- a/libs/components/src/lib/directives/tooltip/tooltip.directive.ts
+++ b/libs/components/src/lib/directives/tooltip/tooltip.directive.ts
@@ -67,6 +67,7 @@ export class PrizmTooltipDirective extends PrizmHintDirective {
     this.content = value;
   }
 
+  // eslint-disable-next-line @angular-eslint/no-output-rename
   @Output('prizmTooltipShowed')
   override prizmHintShowed = super.prizmHintShowed;
 


### PR DESCRIPTION
## [2.1.0-next.3](https://github.com/zyfra/Prizm) (13-07-2023)

### Bracking Changes

- BC(components/hint): remove input prizmHintShow
- BC(components/tooltip): remove input prizmHintShow
- BC(components/hint): rename output prizmHoverChange > prizmHintShowed
- BC(components/tooltip): raname output prizmHoverChange > prizmTooltipShowed

### BUG FIXES

- fix(doc/tooltip): corrected api page
- fix(doc/hint): corrected api page
- fix(components/hint): long string without hyphenation is truncated #414

### Features

- feat(doc): now input/output getter can distinguish altered properties
