### PR TITLE
Fixed versions in packages

### DIFF
--- a/libs/charts/base/package.json
+++ b/libs/charts/base/package.json
@@ -8,8 +8,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
     "@prizm-ui/theme": "^2.0.0",
     "@prizm-ui/helpers": "^2.0.0",
     "@antv/g2plot": "^2.4.22"

--- a/libs/charts/base/package.json
+++ b/libs/charts/base/package.json
@@ -10,8 +10,8 @@
   "peerDependencies": {
     "@angular/common": "^15.2.9",
     "@angular/core": "^15.2.9",
-    "@prizm-ui/theme": "^1.2.1",
-    "@prizm-ui/helpers": "^1.2.1",
+    "@prizm-ui/theme": "^2.0.0",
+    "@prizm-ui/helpers": "^2.0.0",
     "@antv/g2plot": "^2.4.22"
   },
   "dependencies": {

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -9,9 +9,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
-    "@angular/cdk": "^15.2.9",
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
+    "@angular/cdk": "^15.2.0",
     "ngx-mask": "15.1.5",
     "@ng-web-apis/common": "^2.0.0",
     "@ng-web-apis/resize-observer": "^1.0.3",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -9,8 +9,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9"
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/deprecated/package.json
+++ b/libs/deprecated/package.json
@@ -9,9 +9,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
-    "@angular/cdk": "^15.2.9",
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
+    "@angular/cdk": "^15.2.0",
     "ngx-mask": "15.1.5",
     "@ng-web-apis/common": "^2.0.0",
     "@ng-web-apis/resize-observer": "^1.0.3",

--- a/libs/deprecated/package.json
+++ b/libs/deprecated/package.json
@@ -19,9 +19,9 @@
     "@ng-web-apis/mutation-observer": "2.0.0",
     "primeicons": "^6.0.1",
     "primeng": "^15.4.5-lts",
-    "@prizm-ui/helpers": "^1.2.1",
-    "@prizm-ui/core": "^1.2.1",
-    "@prizm-ui/theme": "^1.2.1"
+    "@prizm-ui/helpers": "^2.0.0",
+    "@prizm-ui/core": "^2.0.0",
+    "@prizm-ui/theme": "^2.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/helpers/package.json
+++ b/libs/helpers/package.json
@@ -9,9 +9,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/forms": "^15.2.9",
-    "@angular/core": "^15.2.9"
+    "@angular/common": "^15.2.0",
+    "@angular/forms": "^15.2.0",
+    "@angular/core": "^15.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/i18n/package.json
+++ b/libs/i18n/package.json
@@ -2,8 +2,8 @@
   "name": "@prizm-ui/i18n",
   "version": "2.0.0",
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9"
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/base/package.json
+++ b/libs/icons/base/package.json
@@ -8,8 +8,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
     "@prizm-ui/core": "^2.0.0"
   },
   "dependencies": {

--- a/libs/icons/base/package.json
+++ b/libs/icons/base/package.json
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.9",
     "@angular/core": "^15.2.9",
-    "@prizm-ui/core": "^1.2.1"
+    "@prizm-ui/core": "^2.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json
+++ b/libs/icons/flags/package.json
@@ -8,8 +8,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
     "@prizm-ui/core": "^2.0.0"
   },
   "dependencies": {

--- a/libs/icons/flags/package.json
+++ b/libs/icons/flags/package.json
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.9",
     "@angular/core": "^15.2.9",
-    "@prizm-ui/core": "^1.2.1"
+    "@prizm-ui/core": "^2.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/schematics/package.json
+++ b/libs/schematics/package.json
@@ -9,7 +9,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@angular-devkit/schematics": "^14.2.12",
+    "@angular-devkit/schematics": "^15.2.9",
     "ng-morph": "^2.0.0"
   }
 }

--- a/libs/schematics/package.json
+++ b/libs/schematics/package.json
@@ -9,7 +9,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@angular-devkit/schematics": "^15.2.9",
+    "@angular-devkit/schematics": "^15.2.0",
     "ng-morph": "^2.0.0"
   }
 }

--- a/libs/theme/package.json
+++ b/libs/theme/package.json
@@ -2,8 +2,8 @@
   "name": "@prizm-ui/theme",
   "version": "2.0.0",
   "peerDependencies": {
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
     "@prizm-ui/core": "^2.0.0",
     "@prizm-ui/helpers": "^2.0.0"
   },


### PR DESCRIPTION
Some packages have old internal dependencies that cause an error during installation.
Also set more correct Angular version, without fixing patch number - `^15.2.0`.