### PR TITLE
2.1.2.next 3

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+- fix(components/input-layout): set empty value to input with default label #527
 - fix(components/input-select): select most relevant when you passed object
 
 ## [2.1.2.next-2](https://github.com/zyfra/Prizm) (20-07-2023)

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -8,12 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - feat(components/input-select): added new input transformer to transform value #514
 - feat(components/switcher): added support form controllers #508
-- feat(components/tooltip): added ability to close on exc pressed #307
+- feat(components/tooltip): added ability to close on esc pressed #307
 
 ### Bug fixes
 
 - fix(components/input-layout): set empty value to input with default label #527
 - fix(components/input-select): select most relevant when you passed object
+- fix(components/input-select): select most relevant when you passed object
+- fix(components/tooltip): color of arrows on dark theme #479
 
 ## [2.1.2.next-2](https://github.com/zyfra/Prizm) (20-07-2023)
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- feat(components/input-select): added ability to transform value #514
+- feat(components/input-select): added new input transformer to transform value #514
+
+### Bug fixes
+
+- fix(components/input-select): select most relevant when you passed object
 
 ## [2.1.2.next-2](https://github.com/zyfra/Prizm) (20-07-2023)
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - fix(components/input-select): select most relevant when you passed object
 - fix(components/input-select): select most relevant when you passed object
 - fix(components/tooltip): color of arrows on dark theme #479
+- fix(components/breadcrumbs): color of dots on dark theme #480
 
 ## [2.1.2.next-2](https://github.com/zyfra/Prizm) (20-07-2023)
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 
 - fix(components/input-layout): set empty value to input with default label #527
 - fix(components/input-select): select most relevant when you passed object
-- fix(components/input-select): select most relevant when you passed object
 - fix(components/tooltip): color of arrows on dark theme #479
 - fix(components/breadcrumbs): color of dots on dark theme #480
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - feat(components/input-select): added new input transformer to transform value #514
+- feat(components/switcher): added support form controllers #508
 
 ### Bug fixes
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2.next-3](https://github.com/zyfra/Prizm) (21-07-2023)
+
+### Features
+
+- feat(components/input-select): added ability to transform value #514
+
 ## [2.1.2.next-2](https://github.com/zyfra/Prizm) (20-07-2023)
 
 ### Features

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.2.next-3](https://github.com/zyfra/Prizm) (21-07-2023)
+## [2.1.2.next-3](https://github.com/zyfra/Prizm) (24-07-2023)
 
 ### Features
 
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - fix(components/tooltip): color of arrows on dark theme #479
 - fix(components/breadcrumbs): color of dots on dark theme #480
 
-## [2.1.2.next-2](https://github.com/zyfra/Prizm) (20-07-2023)
+## [2.1.2.next-2](https://github.com/zyfra/Prizm) (21-07-2023)
 
 ### Features
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - feat(components/input-select): added new input transformer to transform value #514
 - feat(components/switcher): added support form controllers #508
+- feat(components/tooltip): added ability to close on exc pressed #307
 
 ### Bug fixes
 

--- a/apps/doc/src/app/components/input/input-select/examples/with-transformer/select-with-transformer-example.component.html
+++ b/apps/doc/src/app/components/input/input-select/examples/with-transformer/select-with-transformer-example.component.html
@@ -1,0 +1,31 @@
+<prizm-input-layout label="Validators">
+  <prizm-input-select
+    [items]="items"
+    [valueTemplate]="valueTemplate"
+    [formControl]="valueControl"
+    [searchMatcher]="searchMatcher"
+    [transformer]="transformer"
+    [identityMatcher]="identityMatcher"
+    [stringify]="stringify"
+    [searchable]="true"
+  >
+  </prizm-input-select>
+</prizm-input-layout>
+<br />
+<br />
+<div>
+  <button (click)="setDefaultValue()">
+    Set default value: <b>{{ items[0].name | json }}</b>
+  </button>
+</div>
+
+<br />
+<br />
+<div>Current value: {{ valueControl.value | json }}</div>
+
+<ng-template #valueTemplate let-value let-stringify="stringify">
+  <div class="item">
+    <prizm-icon iconClass="account-done"></prizm-icon>
+    <span>{{ stringify }}</span>
+  </div>
+</ng-template>

--- a/apps/doc/src/app/components/input/input-select/examples/with-transformer/select-with-transformer-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/with-transformer/select-with-transformer-example.component.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core';
+import { UntypedFormControl } from '@angular/forms';
+import {
+  PrizmSelectIdentityMatcher,
+  PrizmSelectSearchMatcher,
+  PrizmSelectStringify,
+  PrizmSelectValueTransformver,
+} from '@prizm-ui/components';
+
+type PrizmItem = {
+  id: number;
+  name: string;
+};
+@Component({
+  selector: 'prizm-select-with-transformer-example',
+  templateUrl: './select-with-transformer-example.component.html',
+  styles: [
+    `
+      .item {
+        display: flex;
+        gap: 0.5rem;
+      }
+    `,
+  ],
+})
+export class PrizmSelectWithTransformerExampleComponent {
+  readonly items: PrizmItem[] = [
+    { id: 1, name: 'Россия' },
+    { id: 2, name: 'США' },
+    { id: 3, name: 'ОАЭ' },
+  ];
+  readonly valueControl = new UntypedFormControl(3);
+
+  readonly searchMatcher: PrizmSelectSearchMatcher<PrizmItem> = (search: string, item: PrizmItem) => {
+    return item.name.toLowerCase().includes(search.toLowerCase());
+  };
+
+  readonly transformer: PrizmSelectValueTransformver<PrizmItem> = a => a.id;
+  readonly identityMatcher: PrizmSelectIdentityMatcher<PrizmItem> = (a: PrizmItem, b: PrizmItem) => {
+    return a === b;
+  };
+
+  readonly stringify: PrizmSelectStringify<PrizmItem> = (item: PrizmItem): any => {
+    return item.name;
+  };
+
+  public setDefaultValue(): void {
+    this.valueControl.setValue(this.items[0]);
+  }
+}

--- a/apps/doc/src/app/components/input/input-select/input-select.component.html
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.html
@@ -1,6 +1,6 @@
 <prizm-doc-page header="InputSelect">
   <div class="page-description" description>
-    Our select component is a wrapper around the native select element.
+    Our select component is a wrapper around the input select element.
   </div>
   <ng-template prizmDocPageTab>
     <prizm-doc-example id="base" [content]="exampleBase" heading="Base">
@@ -36,6 +36,9 @@
 
     <prizm-doc-example id="validators" [content]="exampleValidators" heading="Validators">
       <prizm-select-validators-example></prizm-select-validators-example>
+    </prizm-doc-example>
+    <prizm-doc-example id="with-transformer" [content]="exampleWithTransformer" heading="With Transformer">
+      <prizm-select-with-transformer-example></prizm-select-with-transformer-example>
     </prizm-doc-example>
   </ng-template>
 
@@ -113,6 +116,14 @@
         documentationPropertyMode="input"
       >
         Identity Matcher
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="transformer"
+        documentationPropertyType="PrizmSelectSelectorMatcher"
+        documentationPropertyMode="input"
+      >
+        Value Transformer (get value from object)
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-select/input-select.component.ts
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.ts
@@ -104,6 +104,11 @@ export class InputSelectComponent {
     HTML: import('./examples/with-object/select-with-object-example.component.html?raw'),
   };
 
+  readonly exampleWithTransformer: TuiDocExample = {
+    TypeScript: import('./examples/with-transformer/select-with-transformer-example.component.ts?raw'),
+    HTML: import('./examples/with-transformer/select-with-transformer-example.component.html?raw'),
+  };
+
   readonly exampleWithSearch: TuiDocExample = {
     TypeScript: import('./examples/with-search/select-with-search-example.component.ts?raw'),
     HTML: import('./examples/with-search/select-with-search-example.component.html?raw'),
@@ -113,7 +118,6 @@ export class InputSelectComponent {
     TypeScript: import('./examples/validators/select-validators-example.component.ts?raw'),
     HTML: import('./examples/validators/select-validators-example.component.html?raw'),
   };
-
   readonly exampleWithBackendSearch: TuiDocExample = {
     TypeScript: import('./examples/with-backend-search/select-with-backend-search-example.component.ts?raw'),
     HTML: import('./examples/with-backend-search/select-with-backend-search-example.component.html?raw'),

--- a/apps/doc/src/app/components/input/input-select/input-select.module.ts
+++ b/apps/doc/src/app/components/input/input-select/input-select.module.ts
@@ -19,6 +19,7 @@ import { PrizmSelectWithBackendSearchExampleComponent } from './examples/with-ba
 import { PrizmSelectFullWidthExampleComponent } from './examples/full-width/select-full-width-example.component';
 import { PrizmSelectValidatorsExampleComponent } from './examples/validators/select-validators-example.component';
 import { PrizmSelectStringifyExampleComponent } from './examples/stringify/select-stringify-example.component';
+import { PrizmSelectWithTransformerExampleComponent } from './examples/with-transformer/select-with-transformer-example.component';
 
 @NgModule({
   imports: [
@@ -34,6 +35,7 @@ import { PrizmSelectStringifyExampleComponent } from './examples/stringify/selec
     RouterModule.forChild(prizmDocGenerateRoutes(InputSelectComponent)),
   ],
   declarations: [
+    PrizmSelectWithTransformerExampleComponent,
     PrizmSelectFullWidthExampleComponent,
     PrizmSelectValidatorsExampleComponent,
     PrizmSelectBaseExampleComponent,

--- a/apps/doc/src/app/components/switcher/examples/switcher-basic-example/switcher-basic-example.component.html
+++ b/apps/doc/src/app/components/switcher/examples/switcher-basic-example/switcher-basic-example.component.html
@@ -1,1 +1,5 @@
-<prizm-switcher [switchers]="switchers" [selectedSwitcherIdx]="1"></prizm-switcher>
+<prizm-switcher [formControl]="control" [switchers]="switchers"></prizm-switcher>
+
+<div>
+  Value: <b>{{ control.value }}</b>
+</div>

--- a/apps/doc/src/app/components/switcher/examples/switcher-basic-example/switcher-basic-example.component.ts
+++ b/apps/doc/src/app/components/switcher/examples/switcher-basic-example/switcher-basic-example.component.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { PrizmSwitcherItem } from '@prizm-ui/components';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'prizm-switcher-basic-example',
@@ -20,4 +21,5 @@ export class SwitcherBasicExampleComponent {
       title: 'Дашборды',
     },
   ];
+  public readonly control = new FormControl(1);
 }

--- a/apps/doc/src/app/components/switcher/switcher-example.component.html
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.html
@@ -41,6 +41,7 @@
       <prizm-switcher
         #element
         [(selectedSwitcherIdx)]="selectedSwitcherIdx"
+        [formControl]="control"
         [prizmDocHostElement]="element"
         [switchers]="switchers"
         [type]="type"
@@ -48,7 +49,7 @@
         [size]="size"
       ></prizm-switcher>
     </prizm-doc-demo>
-    <prizm-doc-documentation>
+    <prizm-doc-documentation [control]="control" [hasTestId]="true">
       <ng-template
         documentationPropertyName="switchers"
         documentationPropertyType="PrizmSwitcherItem[]"

--- a/apps/doc/src/app/components/switcher/switcher-example.component.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
 import { PrizmSwitcherItem, PrizmSwitcherSize, PrizmSwitcherType } from '@prizm-ui/components';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'prizm-switcher-example',
@@ -23,6 +24,7 @@ export class SwitcherExampleComponent {
       icon: 'view-dashboard',
     },
   ];
+  public control = new FormControl();
   public size: PrizmSwitcherSize = 'l';
   public sizeVariants: PrizmSwitcherSize[] = ['l', 'm', 's'];
   public type: PrizmSwitcherType = 'inner';

--- a/apps/doc/src/app/components/switcher/switcher-example.module.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.module.ts
@@ -12,6 +12,7 @@ import { SwitcherOuterLExampleComponent } from './examples/switcher-outer-l-exam
 import { SwitcherOuterSExampleComponent } from './examples/switcher-outer-s-example/switcher-outer-s-example.component';
 import { SwitcherWithIconExampleComponent } from './examples/switcher-with-icon-example/switcher-with-icon-example.component';
 import { SwitcherOnlyIconExampleComponent } from './examples/switcher-only-icon-example/switcher-only-icon-example.component';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -30,6 +31,7 @@ import { SwitcherOnlyIconExampleComponent } from './examples/switcher-only-icon-
     PrizmAddonDocModule,
     RouterModule.forChild(prizmDocGenerateRoutes(SwitcherExampleComponent)),
     PrizmSwitcherModule,
+    ReactiveFormsModule,
   ],
 })
 export class SwitcherExampleModule {}

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.html
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.html
@@ -31,7 +31,7 @@
       >
         <div class="dropdown-inner">
           <prizm-icon class="breadcrumbs__chevron" [size]="16" iconClass="chevrons-right"></prizm-icon>
-          <button (click)="isDropdownOpened = !isDropdownOpened">...</button>
+          <button class="dots-buttons" (click)="isDropdownOpened = !isDropdownOpened">...</button>
         </div>
       </prizm-dropdown-host>
     </div>

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.less
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.less
@@ -160,3 +160,7 @@ span {
     }
   }
 }
+
+.dots-buttons {
+  color: var(--prizm-border-icon);
+}

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -49,7 +49,7 @@
           *ngFor="let item of items; let idx = index"
           [class.most-relevant]="isMostRelevant(idx, items)"
           [class.selected]="
-            item === value || (item && value && (item | prizmCallFunc : identityMatcher : value))
+            item === value || (item && value && (transformer(item) | prizmCallFunc : identityMatcher : value))
           "
           (click)="select(item)"
         >

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -266,6 +266,7 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   }
 
   public getCurrentItem(value: T): string {
+    if (Compare.isNullish(value)) return '';
     const newItem = this.getValueFromItems(this.value);
     return this.stringify(newItem ?? value);
   }

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -243,7 +243,9 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
 
   public isMostRelevant(idx: number, items: T[]): boolean {
     const wroteInputValue = this.printing$.value;
-    const itIsNotCurrentValue = wroteInputValue && !this.identityMatcher(wroteInputValue as T, this.value);
+    const valueFromItems = this.value && this.getValueFromItems(this.value);
+    const itIsNotCurrentValue =
+      valueFromItems && wroteInputValue && !this.searchMatcher(wroteInputValue, valueFromItems);
     const isCanSearch = this.searchable;
     const hasNullValue = items[0] === null;
     const result =
@@ -258,8 +260,13 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
     this.searchChange.emit(value);
   }
 
+  public getValueFromItems(value: T) {
+    const newItem = this.items.find(i => this.identityMatcher(this.transformer(i), value));
+    return newItem;
+  }
+
   public getCurrentItem(value: T): string {
-    const newItem = this.items.find(i => this.identityMatcher(this.transformer(i), this.value));
+    const newItem = this.getValueFromItems(this.value);
     return this.stringify(newItem ?? value);
   }
 }

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -21,7 +21,11 @@ import { PrizmInputControl } from '../../input';
 import { prizmIsNativeFocused, prizmIsTextOverflow$ } from '../../../util';
 import { debounceTime, distinctUntilChanged, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { BehaviorSubject, concat, Observable, Subject, timer } from 'rxjs';
-import { PrizmSelectIdentityMatcher, PrizmSelectSearchMatcher } from './select.model';
+import {
+  PrizmSelectIdentityMatcher,
+  PrizmSelectSearchMatcher,
+  PrizmSelectValueTransformver,
+} from './select.model';
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { PrizmDropdownHostComponent } from '../dropdown-host';
 import { PrizmOverlayOutsidePlacement } from '../../../modules/overlay';
@@ -89,6 +93,10 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   @Input()
   @prizmDefaultProp()
   search: string | null = this.options.search;
+
+  @Input()
+  @prizmDefaultProp()
+  transformer: PrizmSelectValueTransformver<T> = this.options.transformer;
 
   @Input()
   @prizmDefaultProp()
@@ -212,8 +220,9 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
 
   public select(item: T): void {
     this.markAsTouched();
-    if (!this.identityMatcher(item, this.value)) {
-      this.updateValue(item);
+    const selectedValue = item && this.transformer(item);
+    if (!this.identityMatcher(selectedValue, this.value)) {
+      this.updateValue(selectedValue);
     }
     this.opened$$.next(false);
   }
@@ -250,7 +259,7 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   }
 
   public getCurrentItem(value: T): string {
-    const newItem = this.items.find(i => this.identityMatcher(i, this.value));
+    const newItem = this.items.find(i => this.identityMatcher(this.transformer(i), this.value));
     return this.stringify(newItem ?? value);
   }
 }

--- a/libs/components/src/lib/components/dropdowns/select/select.model.ts
+++ b/libs/components/src/lib/components/dropdowns/select/select.model.ts
@@ -1,2 +1,3 @@
 export type PrizmSelectSearchMatcher<T> = (searchValue: string, item: T) => boolean;
 export type PrizmSelectIdentityMatcher<T> = (item1: T, item2: T) => boolean;
+export type PrizmSelectValueTransformver<T> = (item1: T) => any;

--- a/libs/components/src/lib/components/dropdowns/select/select.options.ts
+++ b/libs/components/src/lib/components/dropdowns/select/select.options.ts
@@ -2,7 +2,11 @@ import { InjectionToken, ValueProvider } from '@angular/core';
 import { PolymorphContent } from '../../../directives';
 import { PrizmInputSize } from '../../input';
 import { PrizmContextWithImplicit } from '../../../types';
-import { PrizmSelectIdentityMatcher, PrizmSelectSearchMatcher } from './select.model';
+import {
+  PrizmSelectIdentityMatcher,
+  PrizmSelectSearchMatcher,
+  PrizmSelectValueTransformver,
+} from './select.model';
 
 export type PrizmSelectIconContext = { opened: boolean; disabled: boolean };
 export interface PrizmSelectOptions<T> {
@@ -31,6 +35,7 @@ export interface PrizmSelectOptions<T> {
   readonly nullContent: PolymorphContent;
   readonly searchMatcher: PrizmSelectSearchMatcher<T>;
   readonly identityMatcher: PrizmSelectIdentityMatcher<T>;
+  readonly transformer: PrizmSelectValueTransformver<T>;
   readonly minDropdownHeight: number;
   /**
    * @deprecated
@@ -59,6 +64,7 @@ export const PRIZM_SELECT_DEFAULT_OPTIONS: PrizmSelectOptions<unknown> = {
   maxDropdownHeight: 342,
   emptyContent: 'Ничего не найдено',
   nullContent: 'Не выбрано',
+  transformer: item => item,
   searchMatcher: (searchValue: string, item: unknown): boolean => {
     return item?.toString()?.toLowerCase().includes(searchValue?.toLowerCase());
   },

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
@@ -15,13 +15,13 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { BehaviorSubject, EMPTY, merge, ReplaySubject, Subject, timer } from 'rxjs';
+import { BehaviorSubject, EMPTY, merge, Subject, timer } from 'rxjs';
 import { PrizmInputControl } from '../base/input-control.class';
 import { PrizmInputStatusTextDirective } from '../input-status-text/input-status-text.directive';
 import { PrizmInputPosition, PrizmInputSize, PrizmInputStatus } from '../models/prizm-input.models';
 import { debounceTime, map, startWith, takeUntil, tap } from 'rxjs/operators';
 import { PolymorphContent } from '../../../../directives/polymorph';
-import { filterTruthy, PrizmDestroyService, PrizmLetDirective } from '@prizm-ui/helpers';
+import { Compare, filterTruthy, PrizmDestroyService, PrizmLetDirective } from '@prizm-ui/helpers';
 import { PrizmAbstractTestId } from '../../../../abstract/interactive';
 
 @Component({
@@ -39,7 +39,7 @@ export class PrizmInputLayoutComponent
   extends PrizmAbstractTestId
   implements OnInit, OnChanges, AfterViewInit
 {
-  @Input() set label(val: string) {
+  @Input() set label(val: string | null) {
     this.label$.next(val);
   }
   get label(): string {
@@ -135,7 +135,7 @@ export class PrizmInputLayoutComponent
   ngAfterViewInit(): void {
     this.actualizeStatusIcon();
 
-    if (this.control.defaultLabel && !this.label) {
+    if (this.control.defaultLabel && Compare.isNullish(this.label)) {
       this.label$.next(this.control.defaultLabel);
     }
 

--- a/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.html
+++ b/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.html
@@ -1,4 +1,4 @@
-<button class="switcher" [class.switcher_active]="!data?.disabled && isActive" [disabled]="data?.disabled">
+<button class="switcher" [class.switcher_active]="!isDisabled && isActive" [disabled]="isDisabled">
   <span class="switcher__icon" *ngIf="data?.icon as icon">
     <ng-container *polymorphOutlet="icon; let content">
       <prizm-icon [iconClass]="content"></prizm-icon>

--- a/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.ts
+++ b/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.ts
@@ -28,9 +28,17 @@ export class SwitcherItemComponent extends PrizmAbstractTestId {
   public isActive = false;
 
   @Input()
+  @prizmDefaultProp()
+  public disabled = false;
+
+  @Input()
   @HostBinding('class.full-width')
   @prizmDefaultProp()
   public fullWidth = false;
 
   override readonly testId_ = 'ui_switcher_item';
+
+  get isDisabled(): boolean {
+    return this.disabled || this.data?.disabled;
+  }
 }

--- a/libs/components/src/lib/components/switcher/switcher.component.html
+++ b/libs/components/src/lib/components/switcher/switcher.component.html
@@ -6,6 +6,7 @@
       [attr.first-child]="i === 0"
       [attr.last-child]="i === switchers.length - 1"
       [data]="switcher"
+      [disabled]="ngControl?.disabled"
       [isActive]="selectedSwitcherIdx === i"
       [type]="type"
       [size]="size"

--- a/libs/components/src/lib/components/switcher/switcher.component.spec.ts
+++ b/libs/components/src/lib/components/switcher/switcher.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SwitcherComponent } from './switcher.component';
+import { PrizmSwitcherComponent } from './switcher.component';
 
 describe('SwitcherComponent', () => {
-  let component: SwitcherComponent;
-  let fixture: ComponentFixture<SwitcherComponent>;
+  let component: PrizmSwitcherComponent;
+  let fixture: ComponentFixture<PrizmSwitcherComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [SwitcherComponent],
+      declarations: [PrizmSwitcherComponent],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SwitcherComponent);
+    fixture = TestBed.createComponent(PrizmSwitcherComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/libs/components/src/lib/components/switcher/switcher.component.ts
+++ b/libs/components/src/lib/components/switcher/switcher.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   HostBinding,
@@ -58,7 +59,10 @@ export class PrizmSwitcherComponent extends PrizmAbstractTestId implements Contr
 
   override readonly testId_ = 'ui_switcher';
 
-  constructor(public readonly injector: Injector, @Optional() @Self() public readonly ngControl: NgControl) {
+  constructor(
+    public readonly cdRef: ChangeDetectorRef,
+    @Optional() @Self() public readonly ngControl: NgControl
+  ) {
     super();
     if (this.ngControl != null) {
       this.ngControl.valueAccessor = this;
@@ -79,5 +83,9 @@ export class PrizmSwitcherComponent extends PrizmAbstractTestId implements Contr
   }
   public registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    this.cdRef.markForCheck();
   }
 }

--- a/libs/components/src/lib/components/switcher/switcher.component.ts
+++ b/libs/components/src/lib/components/switcher/switcher.component.ts
@@ -1,15 +1,32 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  HostBinding,
+  Injector,
+  Input,
+  Optional,
+  Output,
+  Self,
+} from '@angular/core';
 import { PrizmSwitcherItem, PrizmSwitcherSize, PrizmSwitcherType } from './switcher.interface';
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
+import { noop } from 'rxjs';
 
 @Component({
   selector: 'prizm-switcher',
   templateUrl: './switcher.component.html',
   styleUrls: ['./switcher.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [],
 })
-export class SwitcherComponent extends PrizmAbstractTestId {
+export class PrizmSwitcherComponent extends PrizmAbstractTestId implements ControlValueAccessor {
+  onChange: (v: number) => void = noop;
+  onTouched: () => void = noop;
+  private selectedSwitcherIdx_ = 0;
+
   @Input()
   @prizmDefaultProp()
   public size: PrizmSwitcherSize = 'l';
@@ -24,7 +41,13 @@ export class SwitcherComponent extends PrizmAbstractTestId {
 
   @Input()
   @prizmDefaultProp()
-  public selectedSwitcherIdx = 0;
+  public set selectedSwitcherIdx(idx: number) {
+    const item = this.switchers[idx];
+    if (item) this.selectSwitcher(item, idx);
+  }
+  get selectedSwitcherIdx() {
+    return this.selectedSwitcherIdx_;
+  }
 
   @Input()
   @HostBinding('class.full-width')
@@ -35,9 +58,26 @@ export class SwitcherComponent extends PrizmAbstractTestId {
 
   override readonly testId_ = 'ui_switcher';
 
+  constructor(public readonly injector: Injector, @Optional() @Self() public readonly ngControl: NgControl) {
+    super();
+    if (this.ngControl != null) {
+      this.ngControl.valueAccessor = this;
+    }
+  }
   public selectSwitcher(item: PrizmSwitcherItem, idx: number): void {
     if (item.disabled) return;
     if (this.selectedSwitcherIdx === idx) return;
-    this.selectedSwitcherIdxChange.emit((this.selectedSwitcherIdx = idx));
+    this.selectedSwitcherIdxChange.emit((this.selectedSwitcherIdx_ = idx));
+    this.onChange(this.selectedSwitcherIdx);
+  }
+
+  public writeValue(idx: string): void {
+    this.selectedSwitcherIdx = parseInt(idx);
+  }
+  public registerOnChange(fn: (value: number) => void): void {
+    this.onChange = fn;
+  }
+  public registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
   }
 }

--- a/libs/components/src/lib/components/switcher/switcher.component.ts
+++ b/libs/components/src/lib/components/switcher/switcher.component.ts
@@ -69,6 +69,7 @@ export class PrizmSwitcherComponent extends PrizmAbstractTestId implements Contr
     }
   }
   public selectSwitcher(item: PrizmSwitcherItem, idx: number): void {
+    if (this.ngControl?.disabled) return;
     if (item.disabled) return;
     if (this.selectedSwitcherIdx === idx) return;
     this.selectedSwitcherIdxChange.emit((this.selectedSwitcherIdx_ = idx));

--- a/libs/components/src/lib/components/switcher/switcher.module.ts
+++ b/libs/components/src/lib/components/switcher/switcher.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SwitcherComponent } from './switcher.component';
+import { PrizmSwitcherComponent } from './switcher.component';
 import { SwitcherItemComponent } from './components/switcher-item/switcher-item.component';
 import { PrizmIconModule } from '../icon';
 import { PrizmButtonModule } from '../button';
 import { PolymorphModule } from '../../directives';
 
 @NgModule({
-  declarations: [SwitcherComponent, SwitcherItemComponent],
+  declarations: [PrizmSwitcherComponent, SwitcherItemComponent],
   imports: [CommonModule, PrizmIconModule, PrizmButtonModule, PolymorphModule],
-  exports: [SwitcherComponent],
+  exports: [PrizmSwitcherComponent],
 })
 export class PrizmSwitcherModule {}

--- a/libs/components/src/lib/components/tabs/tabs.component.html
+++ b/libs/components/src/lib/components/tabs/tabs.component.html
@@ -12,7 +12,6 @@
       (prizmAfterViewInit)="tabsMoreDropdown = dropdownMore"
       prizmDropdownHostWidth="auto"
     >
-      +
       <prizm-icon
         class="control__settings"
         [class.control__settings_active]="openLeft"

--- a/libs/components/src/lib/components/tabs/tabs.component.less
+++ b/libs/components/src/lib/components/tabs/tabs.component.less
@@ -137,3 +137,7 @@
   flex-direction: column;
   background: var(--prizm-bg-body);
 }
+
+.control__chevron {
+  color: var(--prizm-text-subscript);
+}

--- a/libs/components/src/lib/directives/tooltip/tooltip.directive.ts
+++ b/libs/components/src/lib/directives/tooltip/tooltip.directive.ts
@@ -76,4 +76,9 @@ export class PrizmTooltipDirective extends PrizmHintDirective {
     if (!this.clickedInside) return;
     this.show$.next(clickOnTooltip);
   }
+
+  @HostListener('document:keydown.esc', ['$event'])
+  public closeOnEsc(): void {
+    if (this.show) this.show = false;
+  }
 }


### PR DESCRIPTION
## [2.1.2.next-3](https://github.com/zyfra/Prizm) (21-07-2023)

### Features

- feat(components/input-select): added new input transformer to transform value #514
- feat(components/switcher): added support form controllers #508
- feat(components/tooltip): added ability to close on esc pressed #307

### Bug fixes

- fix(components/input-layout): set empty value to input with default label #527
- fix(components/input-select): select most relevant when you passed object
- fix(components/tooltip): color of arrows on dark theme #479
- fix(components/breadcrumbs): color of dots on dark theme #480
