### PR TITLE
2.1.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
       - main
       - v14
       - v15
+      - v16
 jobs:
   doc_deploy:
     runs-on: ubuntu-latest

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -82,25 +82,25 @@ All notable changes to this project will be documented in this file.
 
 - fix(components/confirm-popup): prizmHintContext was renamed to prizmConfirmPopupContext
 - fix(components/confirm-popup): prizmHintCanShow was renamed to prizmConfirmPopupCanShow
-- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
-- fix(components/toast): testId corrected to standart prizm_toast_single > ui_toast_single
-- fix(components/paginator): testId corrected to standart prizm_paginator > ui_paginator
-- fix(components/indicator): testId corrected to standart prizm_paginator > ui_paginator
-- fix(components/dropdown-host): testId corrected to standart prizm_dropdown_host > ui_dropdown_host
-- fix(components/data-list): testId corrected to standart prizm_data_list > ui_data_list
-- fix(components/calendar-range): testId corrected to standart prizm_calendar_range > ui_calendar_range
-- fix(components/breadcrumbs): testId corrected to standart prizm_breadcrumbs > ui_breadcrumbs
-- fix(components/scroll-controls): testId corrected to standart prizm_scroll_controls > ui_scroll_controls
-- fix(components/scrollbar): testId corrected to standart prizm_scrollbar > ui_scrollbar
-- fix(components/spinner): testId corrected to standart prizm_loader > ui_spinner
-- fix(components/switcher): testId corrected to standart prizm_switcher > ui_switcher
-- fix(components/toast-single): testId corrected to standart prizm_toast_single > ui_toast_single
-- fix(components/tree-item-content): testId corrected to standart prizm_tree_item_content > ui_tree_item_content
-- fix(components/tree-item): testId corrected to standart prizm_tree_item > ui_tree--item
-- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
-- fix(components/cron): testId corrected to standart prizm_cron > ui_cron
-- fix(components/input-date): testId corrected to standart prizm_input_date > ui_input_date
-- fix(components/input-layout-date): testId corrected to standart prizm_input_date > ui_input_date
+- fix(components/tree): testId was corrected to standart prizm_tree > ui_tree
+- fix(components/toast): testId was corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/paginator): testId was corrected to standart prizm_paginator > ui_paginator
+- fix(components/indicator): testId was corrected to standart prizm_paginator > ui_paginator
+- fix(components/dropdown-host): testId was corrected to standart prizm_dropdown_host > ui_dropdown_host
+- fix(components/data-list): testId was corrected to standart prizm_data_list > ui_data_list
+- fix(components/calendar-range): testId was corrected to standart prizm_calendar_range > ui_calendar_range
+- fix(components/breadcrumbs): testId was corrected to standart prizm_breadcrumbs > ui_breadcrumbs
+- fix(components/scroll-controls): testId was corrected to standart prizm_scroll_controls > ui_scroll_controls
+- fix(components/scrollbar): testId was corrected to standart prizm_scrollbar > ui_scrollbar
+- fix(components/spinner): testId was corrected to standart prizm_loader > ui_spinner
+- fix(components/switcher): testId was corrected to standart prizm_switcher > ui_switcher
+- fix(components/toast-single): testId was corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/tree-item-content): testId was corrected to standart prizm_tree_item_content > ui_tree_item_content
+- fix(components/tree-item): testId was corrected to standart prizm_tree_item > ui_tree--item
+- fix(components/tree): testId was corrected to standart prizm_tree > ui_tree
+- fix(components/cron): testId was corrected to standart prizm_cron > ui_cron
+- fix(components/input-date): testId was corrected to standart prizm_input_date > ui_input_date
+- fix(components/input-layout-date): testId was corrected to standart prizm_input_date > ui_input_date
 
 ## [2.1.2.next-3](https://github.com/zyfra/Prizm) (24-07-2023)
 
@@ -181,25 +181,25 @@ All notable changes to this project will be documented in this file.
 
 ### BREAKING CHANGES
 
-- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
-- fix(components/toast): testId corrected to standart prizm_toast_single > ui_toast_single
-- fix(components/paginator): testId corrected to standart prizm_paginator > ui_paginator
-- fix(components/indicator): testId corrected to standart prizm_paginator > ui_paginator
-- fix(components/dropdown-host): testId corrected to standart prizm_dropdown_host > ui_dropdown_host
-- fix(components/data-list): testId corrected to standart prizm_data_list > ui_data_list
-- fix(components/calendar-range): testId corrected to standart prizm_calendar_range > ui_calendar_range
-- fix(components/breadcrumbs): testId corrected to standart prizm_breadcrumbs > ui_breadcrumbs
-- fix(components/scroll-controls): testId corrected to standart prizm_scroll_controls > ui_scroll_controls
-- fix(components/scrollbar): testId corrected to standart prizm_scrollbar > ui_scrollbar
-- fix(components/spinner): testId corrected to standart prizm_loader > ui_spinner
-- fix(components/switcher): testId corrected to standart prizm_switcher > ui_switcher
-- fix(components/toast-single): testId corrected to standart prizm_toast_single > ui_toast_single
-- fix(components/tree-item-content): testId corrected to standart prizm_tree_item_content > ui_tree_item_content
-- fix(components/tree-item): testId corrected to standart prizm_tree_item > ui_tree--item
-- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
-- fix(components/cron): testId corrected to standart prizm_cron > ui_cron
-- fix(components/input-date): testId corrected to standart prizm_input_date > ui_input_date
-- fix(components/input-layout-date): testId corrected to standart prizm_input_date > ui_input_date
+- fix(components/tree): testId was corrected to standart prizm_tree > ui_tree
+- fix(components/toast): testId was corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/paginator): testId was corrected to standart prizm_paginator > ui_paginator
+- fix(components/indicator): testId was corrected to standart prizm_paginator > ui_paginator
+- fix(components/dropdown-host): testId was corrected to standart prizm_dropdown_host > ui_dropdown_host
+- fix(components/data-list): testId was corrected to standart prizm_data_list > ui_data_list
+- fix(components/calendar-range): testId was corrected to standart prizm_calendar_range > ui_calendar_range
+- fix(components/breadcrumbs): testId was corrected to standart prizm_breadcrumbs > ui_breadcrumbs
+- fix(components/scroll-controls): testId was corrected to standart prizm_scroll_controls > ui_scroll_controls
+- fix(components/scrollbar): testId was corrected to standart prizm_scrollbar > ui_scrollbar
+- fix(components/spinner): testId was corrected to standart prizm_loader > ui_spinner
+- fix(components/switcher): testId was corrected to standart prizm_switcher > ui_switcher
+- fix(components/toast-single): testId was corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/tree-item-content): testId was corrected to standart prizm_tree_item_content > ui_tree_item_content
+- fix(components/tree-item): testId was corrected to standart prizm_tree_item > ui_tree--item
+- fix(components/tree): testId was corrected to standart prizm_tree > ui_tree
+- fix(components/cron): testId was corrected to standart prizm_cron > ui_cron
+- fix(components/input-date): testId was corrected to standart prizm_input_date > ui_input_date
+- fix(components/input-layout-date): testId was corrected to standart prizm_input_date > ui_input_date
 
 ## [2.1.2.next-1](https://github.com/zyfra/Prizm) (19-07-2023)
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2](https://github.com/zyfra/Prizm) (24-07-2023)
+
+### Features
+
+- feat(components/input-select): added new input transformer to transform value #514
+- feat(components/switcher): added support form controllers #508
+- feat(components/tooltip): added ability to close on esc pressed #307
+- feat(charts/area): add testId with ability to change postfix
+- feat(charts/bar): add testId with ability to change postfix
+- feat(charts/column): add testId with ability to change postfix
+- feat(charts/line): add testId with ability to change postfix
+- feat(charts/gauge): add testId with ability to change postfix
+- feat(charts/pie): add testId with ability to change postfix
+- feat(charts/radar): add testId with ability to change postfix
+- feat(charts/radial-bar): add testId with ability to change postfix
+- feat(charts/scatter): add testId with ability to change postfix
+- feat(charts/treemap): add testId with ability to change postfix
+- feat(charts/waterfall): add testId with ability to change postfix
+- chore: update CONTRIBUTING.md file
+- feat(doc): add ability to automatically add testId to apiPage
+- feat(components/icon): add input ot control color #524
+- feat(components/tabs): add ability to edit testId postfix
+- feat(components/accordion): add ability to edit testId postfix
+- feat(components/grid-item): add ability to edit testId postfix
+- feat(components/calendar-range): add ability to edit testId postfix
+- feat(components/calendar): add ability to edit testId postfix
+- feat(components/card): add ability to edit testId postfix
+- feat(components/data-list): add ability to edit testId postfix
+- feat(components/confirm-dialog): add ability to edit testId postfix
+- feat(components/dialog): add ability to edit testId postfix
+- feat(components/sidebar): add ability to edit testId postfix
+- feat(components/dropdown-host): add ability to edit testId postfix
+- feat(components/expand): add ability to edit testId postfix
+- feat(components/grid): add ability to edit testId postfix
+- feat(components/indicator): add ability to edit testId postfix
+- feat(components/input-icon-button): add ability to edit testId postfix
+- feat(components/primitive-calendar-range): add ability to edit testId postfix
+- feat(components/primitive-calendar): add ability to edit testId postfix
+- feat(components/primitive-month-picker): add ability to edit testId postfix
+- feat(components/primitive-year-month-pagination): add ability to edit testId postfix
+- feat(components/primitive-year-picker): add ability to edit testId postfix
+- feat(components/link): add ability to edit testId postfix
+- feat(components/loader): add ability to edit testId postfix
+- feat(components/paginator): add ability to edit testId postfix
+- feat(components/panel): add ability to edit testId postfix
+- feat(components/radio-button): add ability to edit testId postfix
+- feat(components/scroll-controlls): add ability to edit testId postfix
+- feat(components/scrollbar): add ability to edit testId postfix
+- feat(components/spinner): add ability to edit testId postfix
+- feat(components/switcher-item): add ability to edit testId postfix
+- feat(components/switcher): add ability to edit testId postfix
+- feat(components/tab): add ability to edit testId postfix
+- feat(components/toast-container): add ability to edit testId postfix
+- feat(components/toast-single): add ability to edit testId postfix
+- feat(components/toast-wrapper): add ability to edit testId postfix
+- feat(components/tree-item-content): add ability to edit testId postfix
+- feat(components/tree-item): add ability to edit testId postfix
+- feat(components/tree): add ability to edit testId postfix
+- feat(components/widget): add ability to edit testId postfix
+- feat(components/sticky): add class with direction #470
+- feat(components/i18n): add new init way to components with time
+- feat(components/i18n): add new init way to components with month
+- feat(components/i18n): add new init way to components with calendar
+- feat(components/i18n): add new init way to components with weeks
+
+### Bug fixes
+
+- fix(components/input-layout): set empty value to input with default label #527
+- fix(components/input-select): select most relevant when you passed object
+- fix(components/tooltip): color of arrows on dark theme #479
+- fix(components/breadcrumbs): color of dots on dark theme #480
+- fix(components/input-layout): too long header overlap the "asterisk" #493
+- fix(components/sticky): component becomes sticky even if it has all positions false #470
+
+### BREAKING CHANGES
+
+- fix(components/tree): correct testId to standart prizm_tree > ui_tree
+- fix(components/toast): correct testId to standart prizm_toast_single > ui_toast_single
+- fix(components/paginator): correct testId to standart prizm_paginator > ui_paginator
+- fix(components/indicator): correct testId to standart prizm_paginator > ui_paginator
+- fix(components/dropdown-host): correct testId to standart prizm_dropdown_host > ui_dropdown_host
+- fix(components/data-list): correct testId to standart prizm_data_list > ui_data_list
+- fix(components/calendar-range): correct testId to standart prizm_calendar_range > ui_calendar_range
+- fix(components/breadcrumbs): correct testId to standart prizm_breadcrumbs > ui_breadcrumbs
+- fix(components/scroll-controls): correct testId to standart prizm_scroll_controls > ui_scroll_controls
+- fix(components/scrollbar): correct testId to standart prizm_scrollbar > ui_scrollbar
+- fix(components/spinner): correct testId to standart prizm_loader > ui_spinner
+- fix(components/switcher): correct testId to standart prizm_switcher > ui_switcher
+- fix(components/toast-single): correct testId to standart prizm_toast_single > ui_toast_single
+- fix(components/tree-item-content): correct testId to standart prizm_tree_item_content > ui_tree_item_content
+- fix(components/tree-item): correct testId to standart prizm_tree_item > ui_tree--item
+- fix(components/tree): correct testId to standart prizm_tree > ui_tree
+- fix(components/cron): correct testId to standart prizm_cron > ui_cron
+- fix(components/input-date): correct testId to standart prizm_input_date > ui_input_date
+- fix(components/input-layout-date): correct testId to standart prizm_input_date > ui_input_date
+
 ## [2.1.2.next-3](https://github.com/zyfra/Prizm) (24-07-2023)
 
 ### Features

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -78,25 +78,25 @@ All notable changes to this project will be documented in this file.
 
 ### BREAKING CHANGES
 
-- fix(components/tree): correct testId to standart prizm_tree > ui_tree
-- fix(components/toast): correct testId to standart prizm_toast_single > ui_toast_single
-- fix(components/paginator): correct testId to standart prizm_paginator > ui_paginator
-- fix(components/indicator): correct testId to standart prizm_paginator > ui_paginator
-- fix(components/dropdown-host): correct testId to standart prizm_dropdown_host > ui_dropdown_host
-- fix(components/data-list): correct testId to standart prizm_data_list > ui_data_list
-- fix(components/calendar-range): correct testId to standart prizm_calendar_range > ui_calendar_range
-- fix(components/breadcrumbs): correct testId to standart prizm_breadcrumbs > ui_breadcrumbs
-- fix(components/scroll-controls): correct testId to standart prizm_scroll_controls > ui_scroll_controls
-- fix(components/scrollbar): correct testId to standart prizm_scrollbar > ui_scrollbar
-- fix(components/spinner): correct testId to standart prizm_loader > ui_spinner
-- fix(components/switcher): correct testId to standart prizm_switcher > ui_switcher
-- fix(components/toast-single): correct testId to standart prizm_toast_single > ui_toast_single
-- fix(components/tree-item-content): correct testId to standart prizm_tree_item_content > ui_tree_item_content
-- fix(components/tree-item): correct testId to standart prizm_tree_item > ui_tree--item
-- fix(components/tree): correct testId to standart prizm_tree > ui_tree
-- fix(components/cron): correct testId to standart prizm_cron > ui_cron
-- fix(components/input-date): correct testId to standart prizm_input_date > ui_input_date
-- fix(components/input-layout-date): correct testId to standart prizm_input_date > ui_input_date
+- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
+- fix(components/toast): testId corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/paginator): testId corrected to standart prizm_paginator > ui_paginator
+- fix(components/indicator): testId corrected to standart prizm_paginator > ui_paginator
+- fix(components/dropdown-host): testId corrected to standart prizm_dropdown_host > ui_dropdown_host
+- fix(components/data-list): testId corrected to standart prizm_data_list > ui_data_list
+- fix(components/calendar-range): testId corrected to standart prizm_calendar_range > ui_calendar_range
+- fix(components/breadcrumbs): testId corrected to standart prizm_breadcrumbs > ui_breadcrumbs
+- fix(components/scroll-controls): testId corrected to standart prizm_scroll_controls > ui_scroll_controls
+- fix(components/scrollbar): testId corrected to standart prizm_scrollbar > ui_scrollbar
+- fix(components/spinner): testId corrected to standart prizm_loader > ui_spinner
+- fix(components/switcher): testId corrected to standart prizm_switcher > ui_switcher
+- fix(components/toast-single): testId corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/tree-item-content): testId corrected to standart prizm_tree_item_content > ui_tree_item_content
+- fix(components/tree-item): testId corrected to standart prizm_tree_item > ui_tree--item
+- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
+- fix(components/cron): testId corrected to standart prizm_cron > ui_cron
+- fix(components/input-date): testId corrected to standart prizm_input_date > ui_input_date
+- fix(components/input-layout-date): testId corrected to standart prizm_input_date > ui_input_date
 
 ## [2.1.2.next-3](https://github.com/zyfra/Prizm) (24-07-2023)
 
@@ -177,25 +177,25 @@ All notable changes to this project will be documented in this file.
 
 ### BREAKING CHANGES
 
-- fix(components/tree): correct testId to standart prizm_tree > ui_tree
-- fix(components/toast): correct testId to standart prizm_toast_single > ui_toast_single
-- fix(components/paginator): correct testId to standart prizm_paginator > ui_paginator
-- fix(components/indicator): correct testId to standart prizm_paginator > ui_paginator
-- fix(components/dropdown-host): correct testId to standart prizm_dropdown_host > ui_dropdown_host
-- fix(components/data-list): correct testId to standart prizm_data_list > ui_data_list
-- fix(components/calendar-range): correct testId to standart prizm_calendar_range > ui_calendar_range
-- fix(components/breadcrumbs): correct testId to standart prizm_breadcrumbs > ui_breadcrumbs
-- fix(components/scroll-controls): correct testId to standart prizm_scroll_controls > ui_scroll_controls
-- fix(components/scrollbar): correct testId to standart prizm_scrollbar > ui_scrollbar
-- fix(components/spinner): correct testId to standart prizm_loader > ui_spinner
-- fix(components/switcher): correct testId to standart prizm_switcher > ui_switcher
-- fix(components/toast-single): correct testId to standart prizm_toast_single > ui_toast_single
-- fix(components/tree-item-content): correct testId to standart prizm_tree_item_content > ui_tree_item_content
-- fix(components/tree-item): correct testId to standart prizm_tree_item > ui_tree--item
-- fix(components/tree): correct testId to standart prizm_tree > ui_tree
-- fix(components/cron): correct testId to standart prizm_cron > ui_cron
-- fix(components/input-date): correct testId to standart prizm_input_date > ui_input_date
-- fix(components/input-layout-date): correct testId to standart prizm_input_date > ui_input_date
+- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
+- fix(components/toast): testId corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/paginator): testId corrected to standart prizm_paginator > ui_paginator
+- fix(components/indicator): testId corrected to standart prizm_paginator > ui_paginator
+- fix(components/dropdown-host): testId corrected to standart prizm_dropdown_host > ui_dropdown_host
+- fix(components/data-list): testId corrected to standart prizm_data_list > ui_data_list
+- fix(components/calendar-range): testId corrected to standart prizm_calendar_range > ui_calendar_range
+- fix(components/breadcrumbs): testId corrected to standart prizm_breadcrumbs > ui_breadcrumbs
+- fix(components/scroll-controls): testId corrected to standart prizm_scroll_controls > ui_scroll_controls
+- fix(components/scrollbar): testId corrected to standart prizm_scrollbar > ui_scrollbar
+- fix(components/spinner): testId corrected to standart prizm_loader > ui_spinner
+- fix(components/switcher): testId corrected to standart prizm_switcher > ui_switcher
+- fix(components/toast-single): testId corrected to standart prizm_toast_single > ui_toast_single
+- fix(components/tree-item-content): testId corrected to standart prizm_tree_item_content > ui_tree_item_content
+- fix(components/tree-item): testId corrected to standart prizm_tree_item > ui_tree--item
+- fix(components/tree): testId corrected to standart prizm_tree > ui_tree
+- fix(components/cron): testId corrected to standart prizm_cron > ui_cron
+- fix(components/input-date): testId corrected to standart prizm_input_date > ui_input_date
+- fix(components/input-layout-date): testId corrected to standart prizm_input_date > ui_input_date
 
 ## [2.1.2.next-1](https://github.com/zyfra/Prizm) (19-07-2023)
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -80,6 +80,8 @@ All notable changes to this project will be documented in this file.
 
 ### BREAKING CHANGES
 
+- fix(components/confirm-popup): prizmHintContext was renamed to prizmConfirmPopupContext
+- fix(components/confirm-popup): prizmHintCanShow was renamed to prizmConfirmPopupCanShow
 - fix(components/tree): testId corrected to standart prizm_tree > ui_tree
 - fix(components/toast): testId corrected to standart prizm_toast_single > ui_toast_single
 - fix(components/paginator): testId corrected to standart prizm_paginator > ui_paginator

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -6,66 +6,68 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- feat(components/file-upload): test-id was added with ability to change post fix
+- feat(components/error-page): test-id was added with ability to change post fix
 - feat(components/input-select): added new input transformer to transform value #514
 - feat(components/switcher): added support form controllers #508
 - feat(components/tooltip): added ability to close on esc pressed #307
-- feat(charts/area): add testId with ability to change postfix
-- feat(charts/bar): add testId with ability to change postfix
-- feat(charts/column): add testId with ability to change postfix
-- feat(charts/line): add testId with ability to change postfix
-- feat(charts/gauge): add testId with ability to change postfix
-- feat(charts/pie): add testId with ability to change postfix
-- feat(charts/radar): add testId with ability to change postfix
-- feat(charts/radial-bar): add testId with ability to change postfix
-- feat(charts/scatter): add testId with ability to change postfix
-- feat(charts/treemap): add testId with ability to change postfix
-- feat(charts/waterfall): add testId with ability to change postfix
+- feat(charts/area): test-id was added with ability to change postfix
+- feat(charts/bar): test-id was added with ability to change postfix
+- feat(charts/column): test-id was added with ability to change postfix
+- feat(charts/line): test-id was added with ability to change postfix
+- feat(charts/gauge): test-id was added with ability to change postfix
+- feat(charts/pie): test-id was added with ability to change postfix
+- feat(charts/radar): test-id was added with ability to change postfix
+- feat(charts/radial-bar): test-id was added with ability to change postfix
+- feat(charts/scatter): test-id was added with ability to change postfix
+- feat(charts/treemap): test-id was added with ability to change postfix
+- feat(charts/waterfall): test-id was added with ability to change postfix
 - chore: update CONTRIBUTING.md file
-- feat(doc): add ability to automatically add testId to apiPage
+- feat(doc): ability was added to automatically test-id was added to apiPage
 - feat(components/icon): add input ot control color #524
-- feat(components/tabs): add ability to edit testId postfix
-- feat(components/accordion): add ability to edit testId postfix
-- feat(components/grid-item): add ability to edit testId postfix
-- feat(components/calendar-range): add ability to edit testId postfix
-- feat(components/calendar): add ability to edit testId postfix
-- feat(components/card): add ability to edit testId postfix
-- feat(components/data-list): add ability to edit testId postfix
-- feat(components/confirm-dialog): add ability to edit testId postfix
-- feat(components/dialog): add ability to edit testId postfix
-- feat(components/sidebar): add ability to edit testId postfix
-- feat(components/dropdown-host): add ability to edit testId postfix
-- feat(components/expand): add ability to edit testId postfix
-- feat(components/grid): add ability to edit testId postfix
-- feat(components/indicator): add ability to edit testId postfix
-- feat(components/input-icon-button): add ability to edit testId postfix
-- feat(components/primitive-calendar-range): add ability to edit testId postfix
-- feat(components/primitive-calendar): add ability to edit testId postfix
-- feat(components/primitive-month-picker): add ability to edit testId postfix
-- feat(components/primitive-year-month-pagination): add ability to edit testId postfix
-- feat(components/primitive-year-picker): add ability to edit testId postfix
-- feat(components/link): add ability to edit testId postfix
-- feat(components/loader): add ability to edit testId postfix
-- feat(components/paginator): add ability to edit testId postfix
-- feat(components/panel): add ability to edit testId postfix
-- feat(components/radio-button): add ability to edit testId postfix
-- feat(components/scroll-controlls): add ability to edit testId postfix
-- feat(components/scrollbar): add ability to edit testId postfix
-- feat(components/spinner): add ability to edit testId postfix
-- feat(components/switcher-item): add ability to edit testId postfix
-- feat(components/switcher): add ability to edit testId postfix
-- feat(components/tab): add ability to edit testId postfix
-- feat(components/toast-container): add ability to edit testId postfix
-- feat(components/toast-single): add ability to edit testId postfix
-- feat(components/toast-wrapper): add ability to edit testId postfix
-- feat(components/tree-item-content): add ability to edit testId postfix
-- feat(components/tree-item): add ability to edit testId postfix
-- feat(components/tree): add ability to edit testId postfix
-- feat(components/widget): add ability to edit testId postfix
-- feat(components/sticky): add class with direction #470
-- feat(components/i18n): add new init way to components with time
-- feat(components/i18n): add new init way to components with month
-- feat(components/i18n): add new init way to components with calendar
-- feat(components/i18n): add new init way to components with weeks
+- feat(components/tabs): ability was added to edit testId postfix
+- feat(components/accordion): ability was added to edit testId postfix
+- feat(components/grid-item): ability was added to edit testId postfix
+- feat(components/calendar-range): ability was added to edit testId postfix
+- feat(components/calendar): ability was added to edit testId postfix
+- feat(components/card): ability was added to edit testId postfix
+- feat(components/data-list): ability was added to edit testId postfix
+- feat(components/confirm-dialog): ability was added to edit testId postfix
+- feat(components/dialog): ability was added to edit testId postfix
+- feat(components/sidebar): ability was added to edit testId postfix
+- feat(components/dropdown-host): ability was added to edit testId postfix
+- feat(components/expand): ability was added to edit testId postfix
+- feat(components/grid): ability was added to edit testId postfix
+- feat(components/indicator): ability was added to edit testId postfix
+- feat(components/input-icon-button): ability was added to edit testId postfix
+- feat(components/primitive-calendar-range): ability was added to edit testId postfix
+- feat(components/primitive-calendar): ability was added to edit testId postfix
+- feat(components/primitive-month-picker): ability was added to edit testId postfix
+- feat(components/primitive-year-month-pagination): ability was added to edit testId postfix
+- feat(components/primitive-year-picker): ability was added to edit testId postfix
+- feat(components/link): ability was added to edit testId postfix
+- feat(components/loader): ability was added to edit testId postfix
+- feat(components/paginator): ability was added to edit testId postfix
+- feat(components/panel): ability was added to edit testId postfix
+- feat(components/radio-button): ability was added to edit testId postfix
+- feat(components/scroll-controls): ability was added to edit testId postfix
+- feat(components/scrollbar): ability was added to edit testId postfix
+- feat(components/spinner): ability was added to edit testId postfix
+- feat(components/switcher-item): ability was added to edit testId postfix
+- feat(components/switcher): ability was added to edit testId postfix
+- feat(components/tab): ability was added to edit testId postfix
+- feat(components/toast-container): ability was added to edit testId postfix
+- feat(components/toast-single): ability was added to edit testId postfix
+- feat(components/toast-wrapper): ability was added to edit testId postfix
+- feat(components/tree-item-content): ability was added to edit testId postfix
+- feat(components/tree-item): ability was added to edit testId postfix
+- feat(components/tree): ability was added to edit testId postfix
+- feat(components/widget): ability was added to edit testId postfix
+- feat(components/sticky): class was added with direction #470
+- feat(components/i18n): new way to init was added to components with time
+- feat(components/i18n): new way to init was added to components with month
+- feat(components/i18n): new way to init was added to components with calendar
+- feat(components/i18n): new way to init was added to components with weeks
 
 ### Bug fixes
 
@@ -117,59 +119,59 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- feat(charts/area): add testId with ability to change postfix
-- feat(charts/bar): add testId with ability to change postfix
-- feat(charts/column): add testId with ability to change postfix
-- feat(charts/line): add testId with ability to change postfix
-- feat(charts/gauge): add testId with ability to change postfix
-- feat(charts/pie): add testId with ability to change postfix
-- feat(charts/radar): add testId with ability to change postfix
-- feat(charts/radial-bar): add testId with ability to change postfix
-- feat(charts/scatter): add testId with ability to change postfix
-- feat(charts/treemap): add testId with ability to change postfix
-- feat(charts/waterfall): add testId with ability to change postfix
+- feat(charts/area): test-id was added with ability to change postfix
+- feat(charts/bar): test-id was added with ability to change postfix
+- feat(charts/column): test-id was added with ability to change postfix
+- feat(charts/line): test-id was added with ability to change postfix
+- feat(charts/gauge): test-id was added with ability to change postfix
+- feat(charts/pie): test-id was added with ability to change postfix
+- feat(charts/radar): test-id was added with ability to change postfix
+- feat(charts/radial-bar): test-id was added with ability to change postfix
+- feat(charts/scatter): test-id was added with ability to change postfix
+- feat(charts/treemap): test-id was added with ability to change postfix
+- feat(charts/waterfall): test-id was added with ability to change postfix
 
 - chore: update CONTRIBUTING.md file
-- feat(doc): add ability to automatically add testId to apiPage
+- feat(doc): ability was added to automatically test-id was added to apiPage
 - feat(components/icon): add input ot control color #524
-- feat(components/tabs): add ability to edit testId postfix
-- feat(components/accordion): add ability to edit testId postfix
-- feat(components/grid-item): add ability to edit testId postfix
-- feat(components/calendar-range): add ability to edit testId postfix
-- feat(components/calendar): add ability to edit testId postfix
-- feat(components/card): add ability to edit testId postfix
-- feat(components/data-list): add ability to edit testId postfix
-- feat(components/confirm-dialog): add ability to edit testId postfix
-- feat(components/dialog): add ability to edit testId postfix
-- feat(components/sidebar): add ability to edit testId postfix
-- feat(components/dropdown-host): add ability to edit testId postfix
-- feat(components/expand): add ability to edit testId postfix
-- feat(components/grid): add ability to edit testId postfix
-- feat(components/indicator): add ability to edit testId postfix
-- feat(components/input-icon-button): add ability to edit testId postfix
-- feat(components/primitive-calendar-range): add ability to edit testId postfix
-- feat(components/primitive-calendar): add ability to edit testId postfix
-- feat(components/primitive-month-picker): add ability to edit testId postfix
-- feat(components/primitive-year-month-pagination): add ability to edit testId postfix
-- feat(components/primitive-year-picker): add ability to edit testId postfix
-- feat(components/link): add ability to edit testId postfix
-- feat(components/loader): add ability to edit testId postfix
-- feat(components/paginator): add ability to edit testId postfix
-- feat(components/panel): add ability to edit testId postfix
-- feat(components/radio-button): add ability to edit testId postfix
-- feat(components/scroll-controlls): add ability to edit testId postfix
-- feat(components/scrollbar): add ability to edit testId postfix
-- feat(components/spinner): add ability to edit testId postfix
-- feat(components/switcher-item): add ability to edit testId postfix
-- feat(components/switcher): add ability to edit testId postfix
-- feat(components/tab): add ability to edit testId postfix
-- feat(components/toast-container): add ability to edit testId postfix
-- feat(components/toast-single): add ability to edit testId postfix
-- feat(components/toast-wrapper): add ability to edit testId postfix
-- feat(components/tree-item-content): add ability to edit testId postfix
-- feat(components/tree-item): add ability to edit testId postfix
-- feat(components/tree): add ability to edit testId postfix
-- feat(components/widget): add ability to edit testId postfix
+- feat(components/tabs): ability was added to edit testId postfix
+- feat(components/accordion): ability was added to edit testId postfix
+- feat(components/grid-item): ability was added to edit testId postfix
+- feat(components/calendar-range): ability was added to edit testId postfix
+- feat(components/calendar): ability was added to edit testId postfix
+- feat(components/card): ability was added to edit testId postfix
+- feat(components/data-list): ability was added to edit testId postfix
+- feat(components/confirm-dialog): ability was added to edit testId postfix
+- feat(components/dialog): ability was added to edit testId postfix
+- feat(components/sidebar): ability was added to edit testId postfix
+- feat(components/dropdown-host): ability was added to edit testId postfix
+- feat(components/expand): ability was added to edit testId postfix
+- feat(components/grid): ability was added to edit testId postfix
+- feat(components/indicator): ability was added to edit testId postfix
+- feat(components/input-icon-button): ability was added to edit testId postfix
+- feat(components/primitive-calendar-range): ability was added to edit testId postfix
+- feat(components/primitive-calendar): ability was added to edit testId postfix
+- feat(components/primitive-month-picker): ability was added to edit testId postfix
+- feat(components/primitive-year-month-pagination): ability was added to edit testId postfix
+- feat(components/primitive-year-picker): ability was added to edit testId postfix
+- feat(components/link): ability was added to edit testId postfix
+- feat(components/loader): ability was added to edit testId postfix
+- feat(components/paginator): ability was added to edit testId postfix
+- feat(components/panel): ability was added to edit testId postfix
+- feat(components/radio-button): ability was added to edit testId postfix
+- feat(components/scroll-controls): ability was added to edit testId postfix
+- feat(components/scrollbar): ability was added to edit testId postfix
+- feat(components/spinner): ability was added to edit testId postfix
+- feat(components/switcher-item): ability was added to edit testId postfix
+- feat(components/switcher): ability was added to edit testId postfix
+- feat(components/tab): ability was added to edit testId postfix
+- feat(components/toast-container): ability was added to edit testId postfix
+- feat(components/toast-single): ability was added to edit testId postfix
+- feat(components/toast-wrapper): ability was added to edit testId postfix
+- feat(components/tree-item-content): ability was added to edit testId postfix
+- feat(components/tree-item): ability was added to edit testId postfix
+- feat(components/tree): ability was added to edit testId postfix
+- feat(components/widget): ability was added to edit testId postfix
 
 ### Bug fixes
 
@@ -201,11 +203,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- feat(components/sticky): add class with direction #470
-- feat(components/i18n): add new init way to components with time
-- feat(components/i18n): add new init way to components with month
-- feat(components/i18n): add new init way to components with calendar
-- feat(components/i18n): add new init way to components with weeks
+- feat(components/sticky): class was added with direction #470
+- feat(components/i18n): new way to init was added to components with time
+- feat(components/i18n): new way to init was added to components with month
+- feat(components/i18n): new way to init was added to components with calendar
+- feat(components/i18n): new way to init was added to components with weeks
 
 ### BUG FIXES
 
@@ -223,13 +225,13 @@ All notable changes to this project will be documented in this file.
 - feat(components/input-select): added ability to visibility control of scrollbar thumb for select components [491](https://github.com/zyfra/Prizm/issues/491)
 - feat(ast): update only when has changes in file for templates
 - feat(doc): now input/output getter can distinguish altered properties
-- feat(components/button): add ability to set postfix for test-id for button, toggle components [465](https://github.com/zyfra/Prizm/issues/465)
-- feat(components/select): add ability to set postfix for test-id for select components [465](https://github.com/zyfra/Prizm/issues/465)
-- feat(components/input-\*): add ability to set postfix for test-id for input components [465](https://github.com/zyfra/Prizm/issues/465)
+- feat(components/button): ability was added to set postfix for test-id for button, toggle components [465](https://github.com/zyfra/Prizm/issues/465)
+- feat(components/select): ability was added to set postfix for test-id for select components [465](https://github.com/zyfra/Prizm/issues/465)
+- feat(components/input-\*): ability was added to set postfix for test-id for input components [465](https://github.com/zyfra/Prizm/issues/465)
 - feat(doc): add example with passing innerHTML/customData [516](https://github.com/zyfra/Prizm/issues/516)
-- feat(components/sidebar): add ability pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
-- feat(components/confirm-dialog): add ability pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
-- feat(components/confirm-popup): add ability pass observable for buttons to control disabled, showLoader
+- feat(components/sidebar): ability was added pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
+- feat(components/confirm-dialog): ability was added pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
+- feat(components/confirm-popup): ability was added pass observable for buttons to control disabled, showLoader
 - feat(doc): now deprecated/new names in navigation stand out nicely
 
 ### BUG FIXES
@@ -277,13 +279,13 @@ All notable changes to this project will be documented in this file.
 - feat(components/input-select): added ability to visibility control of scrollbar thumb for select components [491](https://github.com/zyfra/Prizm/issues/491)
 - feat(ast): update only when has changes in file for templates
 - feat(doc): now input/output getter can distinguish altered properties
-- feat(components/button): add ability to set postfix for test-id for button, toggle components [465](https://github.com/zyfra/Prizm/issues/465)
-- feat(components/select): add ability to set postfix for test-id for select components [465](https://github.com/zyfra/Prizm/issues/465)
-- feat(components/input-\*): add ability to set postfix for test-id for input components [465](https://github.com/zyfra/Prizm/issues/465)
+- feat(components/button): ability was added to set postfix for test-id for button, toggle components [465](https://github.com/zyfra/Prizm/issues/465)
+- feat(components/select): ability was added to set postfix for test-id for select components [465](https://github.com/zyfra/Prizm/issues/465)
+- feat(components/input-\*): ability was added to set postfix for test-id for input components [465](https://github.com/zyfra/Prizm/issues/465)
 - feat(doc): add example with passing innerHTML/customData [516](https://github.com/zyfra/Prizm/issues/516)
-- feat(components/sidebar): add ability pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
-- feat(components/confirm-dialog): add ability pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
-- feat(components/confirm-popup): add ability pass observable for buttons to control disabled, showLoader
+- feat(components/sidebar): ability was added pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
+- feat(components/confirm-dialog): ability was added pass observable for buttons to control disabled, showLoader [497](https://github.com/zyfra/Prizm/issues/497)
+- feat(components/confirm-popup): ability was added pass observable for buttons to control disabled, showLoader
 - feat(doc): now deprecated/new names in navigation stand out nicely
 
 ### BUG FIXES
@@ -331,13 +333,13 @@ All notable changes to this project will be documented in this file.
 - feat(components/input-select): added ability to visibility control of scrollbar thumb for select components #491
 - feat(ast): update only when has changes in file for templates
 - feat(doc): now input/output getter can distinguish altered properties
-- feat(components/button): add ability to set postfix for test-id for button, toggle components #465
-- feat(components/select): add ability to set postfix for test-id for select components #465
-- feat(components/input-\*): add ability to set postfix for test-id for input components #465
+- feat(components/button): ability was added to set postfix for test-id for button, toggle components #465
+- feat(components/select): ability was added to set postfix for test-id for select components #465
+- feat(components/input-\*): ability was added to set postfix for test-id for input components #465
 - feat(doc): add example with passing innerHTML/customData [516](https://github.com/zyfra/Prizm/issues/516)
-- feat(components/sidebar): add ability pass observable for buttons to control disabled, showLoader #497
-- feat(components/confirm-dialog): add ability pass observable for buttons to control disabled, showLoader #497
-- feat(components/confirm-popup): add ability pass observable for buttons to control disabled, showLoader
+- feat(components/sidebar): ability was added pass observable for buttons to control disabled, showLoader #497
+- feat(components/confirm-dialog): ability was added pass observable for buttons to control disabled, showLoader #497
+- feat(components/confirm-popup): ability was added pass observable for buttons to control disabled, showLoader
 - feat(doc): now deprecated/new names in navigation stand out nicely
 
 ### BUG FIXES
@@ -672,9 +674,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- feat(input-layout): add ability to show status messages from controls
+- feat(input-layout): ability was added to show status messages from controls
 - chore: splitted angular file to seperated project
-- feat(components/dropdown-host): add ability to control auto close on outside click
+- feat(components/dropdown-host): ability was added to control auto close on outside click
 - feat(components/select-input): we deprecated old prizm-select, and created new prizm-select-input which you can use with our layout
 - feat(components/input-layout): add support directives from control to support components with dropdown
 - feat(doc/select-input): update api page
@@ -827,7 +829,7 @@ All notable changes to this project will be documented in this file.
 - feat(components/navigation-menu): replace deprecated menu
 - feat(components/button): now you can pass polymorph content as icon to use any icon set [151](https://github.com/zyfra/Prizm/issues/151)
 - feat(doc/icon-button): add example with you custom icon [151](https://github.com/zyfra/Prizm/issues/151)
-- feat(components/sidebar): add ability to hide footer [153](https://github.com/zyfra/Prizm/issues/153)
+- feat(components/sidebar): ability was added to hide footer [153](https://github.com/zyfra/Prizm/issues/153)
 
 ### BUG FIXES
 
@@ -845,7 +847,7 @@ All notable changes to this project will be documented in this file.
 
 - feat(ast): new library for help to write you migrator and code updater
 - feat(cb3-to-prizm): new migrator for help to migrate to prizm from pervious component base 3
-- feat(ci): add ability for work with forked pull requests
+- feat(ci): ability was added for work with forked pull requests
 - feat(doc/dialog): add example with close in template buttons [123](https://github.com/zyfra/Prizm/issues/123)
 - feat(components/table): added example with new `PrizmTableDataSource`  [133](https://github.com/zyfra/Prizm/issues/133)
 - feat(components/table): added  `PrizmTableDataSource` class [133](https://github.com/zyfra/Prizm/issues/133)
@@ -1219,7 +1221,7 @@ Migrate PrizmThemeModule > prizm/theme
 
 ### BUG FIXES
 
-- fix(components): add testId
+- fix(components): test-id was added
 - fix(components/textarea) Textarea fix
 
 ### Features

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+- fix(components/dropdown-host): when the component was destroyed, the extra method was called #532
 - fix(components/input-layout): set empty value to input with default label #527
 - fix(components/input-select): select most relevant when you passed object
 - fix(components/tooltip): color of arrows on dark theme #479

--- a/apps/doc/src/app/components/confirm-popup/confirm-popup.component.html
+++ b/apps/doc/src/app/components/confirm-popup/confirm-popup.component.html
@@ -29,7 +29,7 @@
   <ng-template prizmDocPageTab prizmDocHost>
     <prizm-doc-demo>
       <button
-        #element
+        #element="prizmConfirmPopup"
         [prizmDocHostElement]="element"
         [prizmConfirmPopup]="content"
         [prizmAutoReposition]="prizmAutoReposition"
@@ -39,220 +39,145 @@
         [prizmConfirmPopupHideDelay]="prizmConfirmPopupHideDelay"
         [prizmConfirmPopupHost]="prizmConfirmPopupHost"
         [size]="size"
-        [icon]="icon"
-        [iconRight]="iconRight"
-        [appearanceType]="appearanceType"
-        [appearance]="appearance"
-        [disabled]="disabled"
-        [showLoader]="showLoader"
-        [focusable]="focusable"
-        [pseudoState]="pseudoState"
         prizmButton
       >
         Button
       </button>
     </prizm-doc-demo>
     <prizm-doc-documentation [hasTestId]="false">
-      <!-- <ng-template
-        documentationPropertyName="prizmConfirmPopup"
-        documentationPropertyType="string"
-        documentationPropertyMode="input"
+      <ng-template
         [(documentationPropertyValue)]="content"
+        documentationPropertyName="prizmConfirmPopup"
+        documentationPropertyType="PolymorphContent"
+        documentationPropertyMode="input"
       >
         Content
-      </ng-template> -->
+      </ng-template>
 
-      <!-- <ng-template
-        documentationPropertyName="prizmAutoReposition"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmAutoReposition"
-      >
-        Auto Reposition
-      </ng-template> -->
-
-      <!-- <ng-template
-        documentationPropertyName="prizmConfirmPopupDirection"
-        documentationPropertyType="PrizmOverlayOutsidePlacement"
-        documentationPropertyMode="input"
-        [documentationPropertyValues]="prizmConfirmPopupDirectionVariants"
-        [(documentationPropertyValue)]="prizmConfirmPopupDirection"
-      >
-        ConfirmPopup Direction
-      </ng-template> -->
-
-      <!-- <ng-template
-        documentationPropertyName="prizmConfirmPopupId"
-        documentationPropertyType="string"
-        documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmConfirmPopupId"
-      >
-        ConfirmPopup Id
-      </ng-template> -->
-
-      <!-- <ng-template
-        documentationPropertyName="prizmConfirmPopupShowDelay"
-        documentationPropertyType="number"
-        documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmConfirmPopupShowDelay"
-      >
-        Show Delay
-      </ng-template> -->
-
-      <!-- <ng-template
-        documentationPropertyName="prizmConfirmPopupHideDelay"
-        documentationPropertyType="number"
-        documentationPropertyMode="input"
-        [(documentationPropertyValue)]="prizmConfirmPopupHideDelay"
-      >
-        Hide Delay
-      </ng-template> -->
-
-      <!-- <ng-template
+      <ng-template
         documentationPropertyName="prizmConfirmPopupHost"
-        documentationPropertyType="HtmlElement"
+        documentationPropertyType="HTMLElement | null"
         documentationPropertyMode="input"
       >
-        Host
-      </ng-template> -->
-
-      <ng-template
-        [(documentationPropertyValue)]="appearance"
-        [documentationPropertyValues]="appearanceVariants"
-        documentationPropertyName="appearance"
-        documentationPropertyType="PrizmAppearance"
-        documentationPropertyMode="input"
-      >
-        Appearance
+        Element relative to which the tooltip will appear (default: current)
       </ng-template>
 
       <ng-template
-        [(documentationPropertyValue)]="appearanceType"
-        [documentationPropertyValues]="appearanceTypeVariants"
-        documentationPropertyName="appearanceType"
-        documentationPropertyType="PrizmAppearanceType"
-        documentationPropertyMode="input"
-      >
-        AppearanceType
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="size"
-        [documentationPropertyValues]="sizeVariants"
         documentationPropertyName="size"
-        documentationPropertyType="PrizmDialogSize"
+        documentationPropertyType=" PrizmSizeM | PrizmSizeL"
         documentationPropertyMode="input"
       >
         Size
       </ng-template>
+
       <ng-template
-        [(documentationPropertyValue)]="icon"
-        [documentationPropertyValues]="iconVariants"
-        documentationPropertyName="icon"
-        documentationPropertyType="PrizmContent"
+        documentationPropertyName="prizmConfirmPopupContext"
+        documentationPropertyType="Record<stiring, unknown>"
         documentationPropertyMode="input"
       >
-        Icon
+        Context which will be passed to popup
       </ng-template>
 
       <ng-template
-        [(documentationPropertyValue)]="iconRight"
-        [documentationPropertyValues]="iconVariants"
-        documentationPropertyName="iconRight"
-        documentationPropertyType="PrizmContent"
-        documentationPropertyMode="input"
-      >
-        Right Icon
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="disabled"
-        documentationPropertyName="disabled"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-      >
-        Disabled
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="showLoader"
-        documentationPropertyName="showLoader"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-      >
-        Show Loader
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="pseudoHovered"
-        documentationPropertyName="pseudoHovered"
-        documentationPropertyType="boolean | null"
-        documentationPropertyMode="input"
-      >
-        Pseudo Hovered
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pseudoPressed"
-        documentationPropertyName="pseudoPressed"
-        documentationPropertyType="boolean | null"
-        documentationPropertyMode="input"
-      >
-        Pseudo Pressed
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pseudoFocused"
-        documentationPropertyName="pseudoFocused"
-        documentationPropertyType="boolean | null"
-        documentationPropertyMode="input"
-      >
-        Pseudo Focused
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="focusable"
-        documentationPropertyName="focusable"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="input"
-      >
-        Focusable
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pseudoState"
-        documentationPropertyName="pseudoState"
+        documentationPropertyName="prizmConfirmPopupTitle"
         documentationPropertyType="string"
         documentationPropertyMode="input"
       >
-        Pseudo State
+        Title
       </ng-template>
+
       <ng-template
-        [(documentationPropertyValue)]="focusedChange"
-        documentationPropertyName="focusedChange"
+        documentationPropertyName="confirmButton"
+        documentationPropertyType="PrizmConfirmPopupButton | string"
+        documentationPropertyMode="input"
+      >
+        Confirm Button
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="prizmConfirmPopupCanShow"
+        documentationPropertyType="boolean"
+        documentationPropertyMode="input"
+      >
+        Can popup show
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="supportButton"
+        documentationPropertyType="PrizmConfirmPopupButton | string"
+        documentationPropertyMode="input"
+      >
+        Support Button
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="cancelButton"
+        documentationPropertyType="PrizmConfirmPopupButton | string"
+        documentationPropertyMode="input"
+      >
+        Cancel Button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmConfirmPopupHideDelay"
+        documentationPropertyName="prizmConfirmPopupHideDelay"
+        documentationPropertyType="number"
+        documentationPropertyMode="input"
+      >
+        Delay to hide popup
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmConfirmPopupShowDelay"
+        documentationPropertyName="prizmConfirmPopupShowDelay"
+        documentationPropertyType="number"
+        documentationPropertyMode="input"
+      >
+        Delay to show popup
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmConfirmPopupId"
+        documentationPropertyName="prizmConfirmPopupId"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Popup ID
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmConfirmPopupDirection"
+        [documentationPropertyValues]="prizmConfirmPopupDirectionVariants"
+        documentationPropertyName="prizmConfirmPopupDirection"
+        documentationPropertyType="PrizmTooltipOptions['direction']"
+        documentationPropertyMode="input"
+      >
+        Direction
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmAutoReposition"
+        documentationPropertyName="prizmAutoReposition"
+        documentationPropertyType="boolean"
+        documentationPropertyMode="input"
+      >
+        Auto recalculate positioning
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="completeWith"
+        documentationPropertyType="unknown"
+        documentationPropertyMode="output"
+      >
+        On complete Can pass any value
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="prizmConfirmPopupShowed"
         documentationPropertyType="boolean"
         documentationPropertyMode="output"
       >
-        Focused Change
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="pressedChange"
-        documentationPropertyName="pressedChange"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="output"
-      >
-        Pressed Change
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="hoveredChange"
-        documentationPropertyName="hoveredChange"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="output"
-      >
-        Hovered Change
-      </ng-template>
-      <ng-template
-        [(documentationPropertyValue)]="focusVisibleChange"
-        documentationPropertyName="focusVisibleChange"
-        documentationPropertyType="boolean"
-        documentationPropertyMode="output"
-      >
-        Focus Visible Change
+        Trigger when popup was showed
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/components/confirm-popup/confirm-popup.component.ts
+++ b/apps/doc/src/app/components/confirm-popup/confirm-popup.component.ts
@@ -5,13 +5,8 @@ import {
   PRIZM_CONFIRM_POPUP_DEFAULT_OPTIONS,
   PRIZM_HINT_DEFAULT_OPTIONS,
   PrizmConfirmPopupOptions,
-  PrizmOverlayOutsidePlacement,
-  PrizmAppearance,
-  PrizmAppearanceType,
-  PrizmContent,
-  IconDefs,
   PrizmDialogSize,
-  PrizmSize,
+  PrizmOverlayOutsidePlacement,
 } from '@prizm-ui/components';
 
 @Component({
@@ -23,45 +18,15 @@ import {
 export class ConfirmPopupComponent {
   public sizeVariants: PrizmDialogSize[] = ['m', 'l'];
   size: PrizmDialogSize = this.sizeVariants[0];
-  public pseudoHovered = false;
-  public pseudoPressed = false;
-  public pseudoFocused = false;
-  public pseudoState = '';
-  public focusable = false;
-
-  public focusedChange = false;
-  public pressedChange = false;
-  public hoveredChange = false;
-  public focusVisibleChange = false;
-
-  iconVariants: ReadonlyArray<PolymorphContent<{ size: PrizmSize }>> = [
-    '',
-    ...IconDefs.reduce((a, c) => a.concat(c.data), []),
-  ];
-  icon: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
-  iconRight: PolymorphContent<{ size: PrizmSize }> = this.iconVariants[0];
-  appearanceVariants: ReadonlyArray<PrizmAppearance> = [
-    'primary',
-    'secondary',
-    'success',
-    'warning',
-    'danger',
-  ];
-  appearance: PrizmAppearance = this.appearanceVariants[0];
-
-  appearanceTypeVariants: ReadonlyArray<PrizmAppearanceType> = ['fill', 'outline', 'ghost'];
-  appearanceType: PrizmAppearanceType = this.appearanceTypeVariants[0];
-  disabled = false;
-  showLoader = false;
-
-  public content = 'Тестовое содержимое';
-  public prizmAutoReposition = false;
 
   public readonly prizmConfirmPopupDirectionVariants: ReadonlyArray<PrizmConfirmPopupOptions['direction']> =
     Object.values(PrizmOverlayOutsidePlacement);
 
   public prizmConfirmPopupDirection: PrizmConfirmPopupOptions['direction'] =
     PRIZM_HINT_DEFAULT_OPTIONS.direction;
+
+  public content = 'Тестовое содержимое';
+  public prizmAutoReposition = false;
 
   public prizmConfirmPopupId = 'confirm-id';
 

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
@@ -57,8 +57,7 @@
 
     <ng-template #footerTemp let-observer> Footer из <i (click)="observer.next(1)">шаблона</i> </ng-template>
 
-    <prizm-doc-documentation [hasTestId]="false"
-      >>
+    <prizm-doc-documentation [hasTestId]="false">
       <ng-template
         [(documentationPropertyValue)]="position"
         [documentationPropertyValues]="positionVariants"

--- a/apps/doc/src/app/components/shadow/shadow.component.html
+++ b/apps/doc/src/app/components/shadow/shadow.component.html
@@ -14,7 +14,7 @@
         {{ value }}
       </div>
     </prizm-doc-demo>
-    <prizm-doc-documentation>
+    <prizm-doc-documentation [hasTestId]="false">
       <ng-template
         [(documentationPropertyValue)]="value"
         [documentationPropertyValues]="valueVariants"

--- a/apps/doc/src/app/components/skeleton/skeleton.component.html
+++ b/apps/doc/src/app/components/skeleton/skeleton.component.html
@@ -69,7 +69,7 @@
         </div>
       </div>
     </prizm-doc-demo>
-    <prizm-doc-documentation>
+    <prizm-doc-documentation [hasTestId]="false">
       <ng-template
         [(documentationPropertyValue)]="active"
         documentationPropertyName="prizmSkeleton"

--- a/apps/doc/src/app/components/sticky/sticky.component.html
+++ b/apps/doc/src/app/components/sticky/sticky.component.html
@@ -13,7 +13,7 @@
 
   <ng-template prizmDocPageTab prizmDocHost>
     <!--    <prizm-doc-documentation heading="PrizmStickyRelativeDirective"> </prizm-doc-documentation>-->
-    <prizm-doc-documentation [showValues]="false" heading="PrizmStickyDirective">
+    <prizm-doc-documentation [hasTestId]="false" [showValues]="false" heading="PrizmStickyDirective">
       <ng-template
         documentationPropertyName="prizmStickyLeft"
         documentationPropertyType="boolean"

--- a/apps/doc/src/app/components/table/table-example.component.html
+++ b/apps/doc/src/app/components/table/table-example.component.html
@@ -116,7 +116,7 @@
         </table>
       </prizm-scrollbar>
     </prizm-doc-demo>
-    <prizm-doc-documentation heading="PrizmTrComponent">
+    <prizm-doc-documentation [hasTestId]="false" heading="PrizmTrComponent">
       <ng-template
         documentationPropertyName="status"
         documentationPropertyType="PrizmTableCellStatus"
@@ -158,7 +158,7 @@
         Row cursor
       </ng-template>
     </prizm-doc-documentation>
-    <prizm-doc-documentation heading="PrizmTbodyComponent">
+    <prizm-doc-documentation [hasTestId]="false" heading="PrizmTbodyComponent">
       <ng-template
         documentationPropertyName="data"
         documentationPropertyType="Record<string, any>"
@@ -181,7 +181,7 @@
         Opened
       </ng-template>
     </prizm-doc-documentation>
-    <prizm-doc-documentation>
+    <prizm-doc-documentation [hasTestId]="false" heading="PrizmTableDirective">
       <ng-template
         [(documentationPropertyValue)]="size"
         [documentationPropertyValues]="sizeVariants"

--- a/apps/doc/src/app/tools/to-observable/to-observable.component.html
+++ b/apps/doc/src/app/tools/to-observable/to-observable.component.html
@@ -8,8 +8,7 @@
     </prizm-doc-example>
   </ng-template>
 
-  <ng-template prizmDocPageTab> </ng-template>
-  <ng-template prizmDocPageTab>
+  <ng-template prizmDocPageTab="Setup">
     <ol class="b-demo-steps">
       <li>
         <p>

--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -100,6 +100,9 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
   @Input() set isOpen(state: boolean) {
     this.isOpen$.next(state);
   }
+  get isOpen(): boolean {
+    return this.isOpen$.value;
+  }
 
   @Input() dropdownStyles: Record<string, string | number> = {};
 
@@ -167,12 +170,12 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
 
   public close(): void {
     this.overlay?.close();
-    this.isOpenChange.emit(false);
+    if (this.isOpen) this.isOpenChange.emit(false);
   }
 
   public open(): void {
     this.overlay?.open();
-    this.isOpenChange.emit(true);
+    if (!this.isOpen) this.isOpenChange.emit(true);
   }
 
   private initOverlay(): void {

--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -104,7 +104,7 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
     return this.isOpen$.value;
   }
 
-  opened: boolean;
+  private lastEmittedState: boolean;
 
   @Input() dropdownStyles: Record<string, string | number> = {};
 
@@ -172,12 +172,12 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
 
   public close(): void {
     this.overlay?.close();
-    if (this.opened) this.isOpenChange.emit((this.opened = false));
+    if (this.lastEmittedState) this.isOpenChange.emit((this.lastEmittedState = false));
   }
 
   public open(): void {
     this.overlay?.open();
-    if (!this.opened) this.isOpenChange.emit((this.opened = true));
+    if (!this.lastEmittedState) this.isOpenChange.emit((this.lastEmittedState = true));
   }
 
   private initOverlay(): void {

--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -104,6 +104,8 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
     return this.isOpen$.value;
   }
 
+  opened: boolean;
+
   @Input() dropdownStyles: Record<string, string | number> = {};
 
   @ViewChild('temp') temp: TemplateRef<HTMLDivElement>;
@@ -170,12 +172,12 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
 
   public close(): void {
     this.overlay?.close();
-    if (this.isOpen) this.isOpenChange.emit(false);
+    if (this.opened) this.isOpenChange.emit((this.opened = false));
   }
 
   public open(): void {
     this.overlay?.open();
-    if (!this.isOpen) this.isOpenChange.emit(true);
+    if (!this.opened) this.isOpenChange.emit((this.opened = true));
   }
 
   private initOverlay(): void {

--- a/libs/components/src/lib/components/error-page/error-page.component.ts
+++ b/libs/components/src/lib/components/error-page/error-page.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { PrizmAbstractTestId } from '@prizm-ui/core';
 
 @Component({
   selector: 'prizm-error-page',
@@ -6,7 +7,8 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
   styleUrls: ['error-page.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PrizmErrorPageComponent {
+export class PrizmErrorPageComponent extends PrizmAbstractTestId {
   @Input() code!: number;
   @Input() title!: string;
+  override readonly testId_ = 'ui_error-page';
 }

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -24,6 +24,7 @@ import { PRIZM_FILE_UPLOAD } from '../../tokens';
 import { Observable } from 'rxjs';
 import { PrizmLanguageFileUpload } from '@prizm-ui/i18n';
 import { prizmI18nInitWithKey } from '../../services';
+import { PrizmAbstractTestId } from '@prizm-ui/core';
 
 @Component({
   selector: 'prizm-file-upload',
@@ -32,8 +33,10 @@ import { prizmI18nInitWithKey } from '../../services';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [PrizmDestroyService, ...prizmI18nInitWithKey(PRIZM_FILE_UPLOAD, 'fileUpload')],
 })
-export class PrizmFileUploadComponent implements AfterViewInit, OnDestroy {
+export class PrizmFileUploadComponent extends PrizmAbstractTestId implements AfterViewInit, OnDestroy {
   @ViewChild('dropzone') dropzoneElementRef!: ElementRef<HTMLDivElement>;
+
+  override readonly testId_ = 'ui_file_upload';
 
   options: PrizmFileUploadOptions = { ...prizmFileUploadDefaultOptions };
   constructor(
@@ -41,6 +44,7 @@ export class PrizmFileUploadComponent implements AfterViewInit, OnDestroy {
     @Inject(PRIZM_FILE_UPLOAD) public readonly fileUpload$: Observable<PrizmLanguageFileUpload['fileUpload']>,
     @Optional() @Inject(PRIZM_FILEUPLOAD_OPTIONS) customOptions: PrizmFileUploadOptions
   ) {
+    super();
     this.options = { ...this.options, ...customOptions };
   }
 

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
@@ -83,9 +83,21 @@ export class PrizmConfirmPopupDirective<
   @prizmDefaultProp()
   prizmConfirmPopupTitle = '';
 
+  @Input('prizmConfirmPopupContext')
+  @prizmDefaultProp()
+  override prizmHintContext: Record<string, unknown> = {};
+
+  @Input('prizmConfirmPopupCanShow')
+  @prizmDefaultProp()
+  override prizmHintCanShow = true;
+
   @Input() confirmButton?: PrizmConfirmPopupButton | string;
   @Input() supportButton?: PrizmConfirmPopupButton | string;
   @Input() cancelButton?: PrizmConfirmPopupButton | string;
+
+  // eslint-disable-next-line @angular-eslint/no-output-rename
+  @Output('prizmConfirmPopupShowed')
+  override prizmHintShowed = new EventEmitter<boolean>();
 
   protected override readonly containerComponent = PrizmConfirmPopupContainerComponent;
   protected override readonly onHoverActive = false;


### PR DESCRIPTION
## [2.1.2](https://github.com/zyfra/Prizm) (24-07-2023)

### Features

- feat(components/file-upload): test-id was added with ability to change post fix
- feat(components/error-page): test-id was added with ability to change post fix
- feat(components/input-select): added new input transformer to transform value #514
- feat(components/switcher): added support form controllers #508
- feat(components/tooltip): added ability to close on esc pressed #307
- feat(charts/area): test-id was added with ability to change postfix
- feat(charts/bar): test-id was added with ability to change postfix
- feat(charts/column): test-id was added with ability to change postfix
- feat(charts/line): test-id was added with ability to change postfix
- feat(charts/gauge): test-id was added with ability to change postfix
- feat(charts/pie): test-id was added with ability to change postfix
- feat(charts/radar): test-id was added with ability to change postfix
- feat(charts/radial-bar): test-id was added with ability to change postfix
- feat(charts/scatter): test-id was added with ability to change postfix
- feat(charts/treemap): test-id was added with ability to change postfix
- feat(charts/waterfall): test-id was added with ability to change postfix
- chore: update CONTRIBUTING.md file
- feat(doc): ability was added to automatically test-id was added to apiPage
- feat(components/icon): add input ot control color #524
- feat(components/tabs): ability was added to edit testId postfix
- feat(components/accordion): ability was added to edit testId postfix
- feat(components/grid-item): ability was added to edit testId postfix
- feat(components/calendar-range): ability was added to edit testId postfix
- feat(components/calendar): ability was added to edit testId postfix
- feat(components/card): ability was added to edit testId postfix
- feat(components/data-list): ability was added to edit testId postfix
- feat(components/confirm-dialog): ability was added to edit testId postfix
- feat(components/dialog): ability was added to edit testId postfix
- feat(components/sidebar): ability was added to edit testId postfix
- feat(components/dropdown-host): ability was added to edit testId postfix
- feat(components/expand): ability was added to edit testId postfix
- feat(components/grid): ability was added to edit testId postfix
- feat(components/indicator): ability was added to edit testId postfix
- feat(components/input-icon-button): ability was added to edit testId postfix
- feat(components/primitive-calendar-range): ability was added to edit testId postfix
- feat(components/primitive-calendar): ability was added to edit testId postfix
- feat(components/primitive-month-picker): ability was added to edit testId postfix
- feat(components/primitive-year-month-pagination): ability was added to edit testId postfix
- feat(components/primitive-year-picker): ability was added to edit testId postfix
- feat(components/link): ability was added to edit testId postfix
- feat(components/loader): ability was added to edit testId postfix
- feat(components/paginator): ability was added to edit testId postfix
- feat(components/panel): ability was added to edit testId postfix
- feat(components/radio-button): ability was added to edit testId postfix
- feat(components/scroll-controls): ability was added to edit testId postfix
- feat(components/scrollbar): ability was added to edit testId postfix
- feat(components/spinner): ability was added to edit testId postfix
- feat(components/switcher-item): ability was added to edit testId postfix
- feat(components/switcher): ability was added to edit testId postfix
- feat(components/tab): ability was added to edit testId postfix
- feat(components/toast-container): ability was added to edit testId postfix
- feat(components/toast-single): ability was added to edit testId postfix
- feat(components/toast-wrapper): ability was added to edit testId postfix
- feat(components/tree-item-content): ability was added to edit testId postfix
- feat(components/tree-item): ability was added to edit testId postfix
- feat(components/tree): ability was added to edit testId postfix
- feat(components/widget): ability was added to edit testId postfix
- feat(components/sticky): class was added with direction #470
- feat(components/i18n): new way to init was added to components with time
- feat(components/i18n): new way to init was added to components with month
- feat(components/i18n): new way to init was added to components with calendar
- feat(components/i18n): new way to init was added to components with weeks

### Bug fixes

- fix(components/dropdown-host): when the component was destroyed, the extra method was called #532
- fix(components/input-layout): set empty value to input with default label #527
- fix(components/input-select): select most relevant when you passed object
- fix(components/tooltip): color of arrows on dark theme #479
- fix(components/breadcrumbs): color of dots on dark theme #480
- fix(components/input-layout): too long header overlap the "asterisk" #493
- fix(components/sticky): component becomes sticky even if it has all positions false #470

### BREAKING CHANGES

- fix(components/confirm-popup): prizmHintContext was renamed to prizmConfirmPopupContext
- fix(components/confirm-popup): prizmHintCanShow was renamed to prizmConfirmPopupCanShow
- fix(components/tree): testId was corrected to standart prizm_tree > ui_tree
- fix(components/toast): testId was corrected to standart prizm_toast_single > ui_toast_single
- fix(components/paginator): testId was corrected to standart prizm_paginator > ui_paginator
- fix(components/indicator): testId was corrected to standart prizm_paginator > ui_paginator
- fix(components/dropdown-host): testId was corrected to standart prizm_dropdown_host > ui_dropdown_host
- fix(components/data-list): testId was corrected to standart prizm_data_list > ui_data_list
- fix(components/calendar-range): testId was corrected to standart prizm_calendar_range > ui_calendar_range
- fix(components/breadcrumbs): testId was corrected to standart prizm_breadcrumbs > ui_breadcrumbs
- fix(components/scroll-controls): testId was corrected to standart prizm_scroll_controls > ui_scroll_controls
- fix(components/scrollbar): testId was corrected to standart prizm_scrollbar > ui_scrollbar
- fix(components/spinner): testId was corrected to standart prizm_loader > ui_spinner
- fix(components/switcher): testId was corrected to standart prizm_switcher > ui_switcher
- fix(components/toast-single): testId was corrected to standart prizm_toast_single > ui_toast_single
- fix(components/tree-item-content): testId was corrected to standart prizm_tree_item_content > ui_tree_item_content
- fix(components/tree-item): testId was corrected to standart prizm_tree_item > ui_tree--item
- fix(components/tree): testId was corrected to standart prizm_tree > ui_tree
- fix(components/cron): testId was corrected to standart prizm_cron > ui_cron
- fix(components/input-date): testId was corrected to standart prizm_input_date > ui_input_date
- fix(components/input-layout-date): testId was corrected to standart prizm_input_date > ui_input_date
