### PR TITLE
2.1.3-next.3

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.3-next.3](https://github.com/zyfra/Prizm) (28-07-2023)
+
+### Features
+
+- feat(components/autoresize): added directive and example how to use in textarea #544
+
+### Bug fixes
+
+- fix(components/dropdown-host): wrong position of dropdown #394
+- fix(components/dropdown-host): flickering on scroll #495
+- fix(components/tabs): automatically close after select from menu #482
+- fix(components/input-number): block not number symbols #486
+
 ## [2.1.3-next.2](https://github.com/zyfra/Prizm) (27-07-2023)
 
 ### Features

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.html
@@ -157,6 +157,7 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
+      [hasTestId]="false"
       heading="PrizmInputNumberDefaultControlsComponent"
       hostComponentKey="PrizmInputNumberDefaultControlsComponent"
     >
@@ -170,6 +171,7 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
+      [hasTestId]="false"
       heading="prizmInputNumberAuxiliaryControl"
       hostComponentKey="prizmInputNumberAuxiliaryControl"
     >

--- a/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.component.html
@@ -1,3 +1,3 @@
 <prizm-input-layout label="Заголовок">
-  <textarea prizmInput autoSize placeholder="Введите заголовок"></textarea>
+  <textarea [prizmAutoResize]="true" prizmInput placeholder="Введите заголовок"></textarea>
 </prizm-input-layout>

--- a/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.module.ts
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAutoResizeModule, PrizmInputTextModule } from '@prizm-ui/components';
+import { TextareAautosizeExampleComponent } from './textarea-autosize-example.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    PrizmAddonDocModule,
+    ReactiveFormsModule,
+    FormsModule,
+    PrizmInputTextModule,
+    PrizmAutoResizeModule,
+  ],
+  declarations: [TextareAautosizeExampleComponent],
+  exports: [TextareAautosizeExampleComponent],
+})
+export class TextareaAutosizeExampleModule {}

--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.html
@@ -1,10 +1,10 @@
 <prizm-doc-page header="Textarea">
   <ng-template prizmDocPageTab>
-    <prizm-doc-example [content]="zyfraTextareaBasicExample" heading="Basic example">
+    <prizm-doc-example [content]="textareaBasicExample" heading="Basic example">
       <prizm-textarea-basic-example></prizm-textarea-basic-example>
     </prizm-doc-example>
 
-    <prizm-doc-example [content]="zyfraTextareaAutosizeExample" heading="Autosize example">
+    <prizm-doc-example [content]="textareaAutosizeExample" heading="Autoresize example">
       <prizm-textarea-autosize-example></prizm-textarea-autosize-example>
     </prizm-doc-example>
   </ng-template>

--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.ts
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.ts
@@ -32,13 +32,14 @@ export class TextareaExampleComponent {
   public forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   public forceClear = this.forceClearVariants[0];
 
-  public readonly zyfraTextareaBasicExample: TuiDocExample = {
+  public readonly textareaBasicExample: TuiDocExample = {
     TypeScript: import('./examples/textarea-basic-example/textarea-basic-example.component.ts?raw'),
     HTML: import('./examples/textarea-basic-example/textarea-basic-example.component.html?raw'),
   };
 
-  public readonly zyfraTextareaAutosizeExample: TuiDocExample = {
+  public readonly textareaAutosizeExample: TuiDocExample = {
     TypeScript: import('./examples/textarea-autosize-example/textarea-autosize-example.component.ts?raw'),
+    Module: import('./examples/textarea-autosize-example/textarea-autosize-example.module.ts?raw'),
     HTML: import('./examples/textarea-autosize-example/textarea-autosize-example.component.html?raw'),
   };
 

--- a/apps/doc/src/app/components/input/textarea/textarea-example.module.ts
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 
 import { TextareaBasicExampleComponent } from './examples/textarea-basic-example/textarea-basic-example.component';
 import { TextareaExampleComponent } from './textarea-example.component';
 import { PrizmInputTextModule } from '@prizm-ui/components';
-import { TextareAautosizeExampleComponent } from './examples/textarea-autosize-example/textarea-autosize-example.component';
+import { TextareaAutosizeExampleModule } from './examples/textarea-autosize-example/textarea-autosize-example.module';
 
 @NgModule({
   imports: [
@@ -17,8 +17,9 @@ import { TextareAautosizeExampleComponent } from './examples/textarea-autosize-e
     ReactiveFormsModule,
     FormsModule,
     PrizmInputTextModule,
+    TextareaAutosizeExampleModule,
   ],
-  declarations: [TextareaExampleComponent, TextareaBasicExampleComponent, TextareAautosizeExampleComponent],
+  declarations: [TextareaExampleComponent, TextareaBasicExampleComponent],
   exports: [TextareaExampleComponent],
 })
 export class TextareaExampleModule {}

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -97,6 +97,7 @@
     &-center {
       padding: 0;
       left: 50%;
+      justify-content: center;
       transform: translateX(-50%);
     }
   }

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.html
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.html
@@ -22,7 +22,7 @@
 </prizm-dropdown-host>
 
 <ng-template #dropdown>
-  <ul class="prizm-datepicker-relative-menu" (prizmAfterViewInit)="markAsTouched()" role="listbox">
+  <ul class="prizm-datepicker-relative-menu" role="listbox">
     <ng-container *ngTemplateOutlet="menuItemsTemplate; context: { items: timeItems }"></ng-container>
     <li class="relative-menu-item-divider"></li>
     <ng-container *ngTemplateOutlet="menuItemsTemplate; context: { items: directionItems }"></ng-container>

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -104,6 +104,9 @@ export class PrizmInputLayoutDateRelativeComponent
     super(injector);
   }
 
+  public override isEmpty(value: any): boolean {
+    return !value && !this.nativeFocusableElement?.value;
+  }
   public override ngOnInit(): void {
     super.ngOnInit();
     this.rightButtons$ = this.extraButtonInjector.get(PRIZM_DATE_RIGHT_BUTTONS);
@@ -176,6 +179,7 @@ export class PrizmInputLayoutDateRelativeComponent
       period: this.activePeriodId,
     });
 
+    this.controlMarkAsTouched();
     this.updateValue(stringValue);
   }
 
@@ -183,6 +187,7 @@ export class PrizmInputLayoutDateRelativeComponent
     this.parseInputValue('');
     this.updateValue(null);
     this.actualizeMenu();
+    if (this.nativeFocusableElement) this.nativeFocusableElement.value = '';
   }
 
   /**

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -104,9 +104,9 @@ export class PrizmInputLayoutDateRelativeComponent
     super(injector);
   }
 
-  public override isEmpty(value: any): boolean {
-    return !value && !this.nativeFocusableElement?.value;
-  }
+  // public override isEmpty(value: any): boolean {
+  //   return !value && !this.nativeFocusableElement?.value;
+  // }
   public override ngOnInit(): void {
     super.ngOnInit();
     this.rightButtons$ = this.extraButtonInjector.get(PRIZM_DATE_RIGHT_BUTTONS);
@@ -115,6 +115,7 @@ export class PrizmInputLayoutDateRelativeComponent
   public valueChange(value: string) {
     this.parseInputValue(value);
     this.actualizeMenu();
+    this.actualizeInput();
   }
 
   public ngOnDestroy(): void {
@@ -179,7 +180,7 @@ export class PrizmInputLayoutDateRelativeComponent
       period: this.activePeriodId,
     });
 
-    this.controlMarkAsTouched();
+    this.markAsTouched();
     this.updateValue(stringValue);
   }
 

--- a/libs/components/src/lib/components/input/input-number/input-number.directive.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.directive.ts
@@ -1,6 +1,8 @@
 import { Directive, ElementRef, Host, HostBinding, HostListener, Input } from '@angular/core';
 import { PrizmInputTextComponent } from '../input-text/input-text.component';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
+import { timer } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 @Directive({
   selector: 'input[prizmInputNumber], input[type=number][prizmInput]',
@@ -17,6 +19,11 @@ export class PrizmInputNumberDirective extends PrizmAbstractTestId {
   get disabled() {
     return this.prizmInputText.disabled;
   }
+
+  @HostListener('keydown', ['$event']) public stopValue(ev: KeyboardEvent) {
+    return !['e', '-', '+'].includes(ev.key?.toLowerCase());
+  }
+
   constructor(
     @Host() private readonly el: ElementRef<HTMLInputElement>,
     @Host() private readonly prizmInputText: PrizmInputTextComponent

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -18,7 +18,7 @@ import { UntypedFormControl, NgControl, Validators } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
-import { interval } from 'rxjs';
+import { interval, timer } from 'rxjs';
 
 @Component({
   selector:

--- a/libs/components/src/lib/components/tabs/tabs.component.html
+++ b/libs/components/src/lib/components/tabs/tabs.component.html
@@ -62,6 +62,7 @@
               [closable]="tab.closable"
               [disabled]="tab.disabled"
               [attr.dropdown-tab]="true"
+              (click)="clickTab(i)"
               (closeTab)="closeTab(tabElement.idx)"
             >
             </prizm-tab>

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -193,4 +193,8 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
     this.tabsService.getTabByIdx(idx)?.closeTab.emit();
     this.reCalculatePositions();
   }
+
+  public clickTab(idx: number): void {
+    this.openLeft = this.openRight = false;
+  }
 }

--- a/libs/components/src/lib/directives/auto-resize/autoresize.directive.ts
+++ b/libs/components/src/lib/directives/auto-resize/autoresize.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, ElementRef, HostListener, Input, OnInit } from '@angular/core';
+
+@Directive({
+  selector: `[prizmAutoResize]`,
+})
+export class PrizmAutoResizeDirective implements OnInit {
+  @Input() prizmAutoResize = true;
+
+  constructor(private elementRef: ElementRef) {}
+
+  @HostListener(':input')
+  private onInput() {
+    if (!this.prizmAutoResize) return;
+    this.resize();
+  }
+
+  public ngOnInit(): void {
+    if (!this.prizmAutoResize) return;
+    if (this.elementRef.nativeElement.scrollHeight) {
+      setTimeout(() => this.resize());
+    }
+  }
+
+  public resize(): void {
+    this.elementRef.nativeElement.style.height = '0';
+    this.elementRef.nativeElement.style.height = this.elementRef.nativeElement.scrollHeight + 'px';
+  }
+}

--- a/libs/components/src/lib/directives/auto-resize/autoresize.module.ts
+++ b/libs/components/src/lib/directives/auto-resize/autoresize.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { PrizmAutoResizeDirective } from './autoresize.directive';
+
+@NgModule({
+  declarations: [PrizmAutoResizeDirective],
+  exports: [PrizmAutoResizeDirective],
+})
+export class PrizmAutoResizeModule {}

--- a/libs/components/src/lib/directives/auto-resize/handlers/abstract.handler.ts
+++ b/libs/components/src/lib/directives/auto-resize/handlers/abstract.handler.ts
@@ -1,0 +1,24 @@
+import { Directive, ElementRef } from '@angular/core';
+import {
+  PrizmFocusableElementAccessor,
+  PrizmNativeFocusableElement,
+} from '../../../types/focusable-element-accessor';
+import { PrizmAutofocusHandler } from '../autoresize.options';
+
+@Directive()
+export abstract class AbstractPrizmAutofocusHandler implements PrizmAutofocusHandler {
+  protected constructor(
+    protected readonly prizmFocusableComponent: PrizmFocusableElementAccessor | null,
+    protected readonly elementRef: ElementRef<HTMLElement>
+  ) {}
+
+  protected get element(): PrizmNativeFocusableElement {
+    return this.prizmFocusableComponent?.nativeFocusableElement || this.elementRef.nativeElement;
+  }
+
+  protected get isTextFieldElement(): boolean {
+    return this.element.matches(`input, textarea`);
+  }
+
+  public abstract setFocus(): void;
+}

--- a/libs/components/src/lib/directives/auto-resize/handlers/default.handler.ts
+++ b/libs/components/src/lib/directives/auto-resize/handlers/default.handler.ts
@@ -1,0 +1,41 @@
+import { Directive, ElementRef, Inject, Optional, Self } from '@angular/core';
+import { ANIMATION_FRAME } from '@ng-web-apis/common';
+import { Observable, race, timer } from 'rxjs';
+import { map, skipWhile, take, throttleTime } from 'rxjs/operators';
+import { PRIZM_POLLING_TIME } from '../../../constants/polling-time';
+import { PRIZM_FOCUSABLE_ITEM_ACCESSOR } from '../../../tokens/focusable-item-accessor';
+import { PrizmFocusableElementAccessor } from '../../../types/focusable-element-accessor';
+import { AbstractPrizmAutofocusHandler } from './abstract.handler';
+
+const TIMEOUT = 1000;
+const NG_ANIMATION_SELECTOR = `.ng-animating`;
+
+@Directive()
+export class PrizmDefaultAutofocusHandler extends AbstractPrizmAutofocusHandler {
+  constructor(
+    @Optional()
+    @Self()
+    @Inject(PRIZM_FOCUSABLE_ITEM_ACCESSOR)
+    prizmFocusableComponent: PrizmFocusableElementAccessor | null,
+    @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+    @Inject(ANIMATION_FRAME) private readonly animationFrame$: Observable<number>
+  ) {
+    super(prizmFocusableComponent, elementRef);
+  }
+
+  public setFocus(): void {
+    if (this.isTextFieldElement) {
+      race(
+        timer(TIMEOUT),
+        this.animationFrame$.pipe(
+          throttleTime(PRIZM_POLLING_TIME),
+          map(() => this.element.closest(NG_ANIMATION_SELECTOR)),
+          skipWhile(Boolean),
+          take(1)
+        )
+      ).subscribe(() => this.element.focus());
+    } else {
+      this.element.focus();
+    }
+  }
+}

--- a/libs/components/src/lib/directives/auto-resize/handlers/ios.handler.ts
+++ b/libs/components/src/lib/directives/auto-resize/handlers/ios.handler.ts
@@ -1,0 +1,123 @@
+import { Directive, ElementRef, Inject, NgZone, Optional, Renderer2, Self } from '@angular/core';
+import { WINDOW } from '@ng-web-apis/common';
+import { PRIZM_FOCUSABLE_ITEM_ACCESSOR } from '../../../tokens/focusable-item-accessor';
+import { PrizmFocusableElementAccessor } from '../../../types/focusable-element-accessor';
+import { AbstractPrizmAutofocusHandler } from './abstract.handler';
+import { prizmPx } from '@prizm-ui/core';
+
+@Directive()
+export class PrizmIosAutofocusHandler extends AbstractPrizmAutofocusHandler {
+  constructor(
+    @Optional()
+    @Self()
+    @Inject(PRIZM_FOCUSABLE_ITEM_ACCESSOR)
+    prizmFocusableComponent: PrizmFocusableElementAccessor | null,
+    @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+    @Inject(Renderer2) private readonly renderer: Renderer2,
+    @Inject(NgZone) private readonly ngZone: NgZone,
+    @Inject(WINDOW) private readonly windowRef: Window
+  ) {
+    super(prizmFocusableComponent, elementRef);
+    this.patchCssStyles();
+  }
+
+  public setFocus(): void {
+    if (this.isTextFieldElement) {
+      this.ngZone.runOutsideAngular(() => this.iosWebkitAutofocus());
+    } else {
+      this.element.focus();
+    }
+  }
+
+  private iosWebkitAutofocus(): void {
+    const fakeInput: HTMLInputElement = this.makeFakeInput();
+    const duration = this.getDurationTimeBeforeFocus();
+    let fakeFocusTimeoutId = 0;
+    let elementFocusTimeoutId = 0;
+
+    const blurHandler = (): void => fakeInput.focus({ preventScroll: true });
+    const focusHandler = (): void => {
+      clearTimeout(fakeFocusTimeoutId);
+
+      fakeFocusTimeoutId = this.windowRef.setTimeout(() => {
+        clearTimeout(elementFocusTimeoutId);
+
+        fakeInput.removeEventListener(`blur`, blurHandler);
+        fakeInput.removeEventListener(`focus`, focusHandler);
+
+        elementFocusTimeoutId = this.windowRef.setTimeout(() => {
+          this.element.focus({ preventScroll: false });
+          fakeInput.remove();
+        }, duration);
+      });
+    };
+
+    fakeInput.addEventListener(`blur`, blurHandler, { once: true });
+    fakeInput.addEventListener(`focus`, focusHandler);
+
+    if (this.insideDialog()) {
+      this.windowRef.document.body.appendChild(fakeInput);
+    } else {
+      this.element.parentElement?.appendChild(fakeInput);
+    }
+
+    fakeInput.focus({ preventScroll: true });
+  }
+
+  /**
+   * @note:
+   * emulate textfield position in layout with cursor
+   * before focus to real textfield element
+   */
+  private makeFakeInput(): HTMLInputElement {
+    const fakeInput: HTMLInputElement = this.renderer.createElement(`input`);
+    const rect: DOMRect = this.element.getBoundingClientRect();
+
+    fakeInput.style.height = prizmPx(rect.height);
+    fakeInput.style.width = prizmPx(rect.width / 2);
+    fakeInput.style.position = `fixed`;
+    fakeInput.style.opacity = `0`;
+    fakeInput.style.fontSize = prizmPx(16); // disable possible auto zoom
+    fakeInput.readOnly = true; // prevent keyboard for fake input
+
+    // @note: emulate position cursor before focus to real textfield element
+    fakeInput.style.top = prizmPx(rect.top);
+    fakeInput.style.left = prizmPx(rect.left);
+
+    return fakeInput;
+  }
+
+  private getDurationTimeBeforeFocus(): number {
+    return (
+      parseFloat(this.windowRef.getComputedStyle(this.element).getPropertyValue(`--prizm-duration`)) || 0
+    );
+  }
+
+  /**
+   * @note:
+   * unfortunately, in older versions of iOS
+   * there is a bug that the fake input cursor
+   * will move along with the dialog animation
+   * and then that dialog will be shaking
+   */
+  private insideDialog(): boolean {
+    return !!this.element.closest(`prizm-dialog`);
+  }
+
+  /**
+   * @note:
+   * This is necessary so that the viewport isn't recalculated
+   * and then the dialogs don't shake.
+   *
+   * Also, we need to fixed height viewport,
+   * so that when focusing the dialogs don't shake
+   */
+  private patchCssStyles(): void {
+    const documentRef = this.windowRef.document;
+
+    for (const element of [documentRef.documentElement, documentRef.body]) {
+      element.style.setProperty(`overflow`, `auto`);
+      element.style.setProperty(`height`, `100%`);
+    }
+  }
+}

--- a/libs/components/src/lib/directives/auto-resize/index.ts
+++ b/libs/components/src/lib/directives/auto-resize/index.ts
@@ -1,0 +1,2 @@
+export * from './autoresize.directive';
+export * from './autoresize.module';

--- a/libs/components/src/lib/directives/index.ts
+++ b/libs/components/src/lib/directives/index.ts
@@ -28,3 +28,4 @@ export * from './value-accessor';
 export * from './wrapper';
 export * from './sticky';
 export * from './native-value';
+export * from './auto-resize';


### PR DESCRIPTION
## [2.1.3-next.3](https://github.com/zyfra/Prizm) (28-07-2023)

### Features

- feat(components/autoresize): added directive and example how to use in textarea #544

### Bug fixes

- fix(components/dropdown-host): wrong position of dropdown #394
- fix(components/dropdown-host): flickering on scroll #495
- fix(components/tabs): automatically close after select from menu #482
- fix(components/input-number): block not number symbols #486
