### PR TITLE
1.4.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,7 +47,7 @@ Dependencies:
 ```
 ➜ npm ls @prizm-ui/components
 
-@prizm-ui/components 2.1.2
+@prizm-ui/components 1.4.1
 ```
 
 ```

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -33,7 +33,7 @@ v16.13.0
 
 Dependencies:
 
-`@prizm-ui/components 2.1.2`
+`@prizm-ui/components 1.4.1`
 
 Операционная ситема:
 

--- a/.github/workflows/draft-publish.yml
+++ b/.github/workflows/draft-publish.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-node_modules_ng_14-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node_modules_ng_15-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules_ng_14-
+            ${{ runner.os }}-node_modules_ng_15-
 
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -52,7 +52,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_draft_version=$(
-            npm view @prizm-ui/components versions --tag draft --json | jq '([.[] | select(startswith("1.4.0-draft"))] | last // "1.4.0-draft.0")' 2>/dev/null || echo '1.4.0-draft.0'
+            npm view @prizm-ui/components versions --tag draft --json | jq '([.[] | select(startswith("1.4.1-draft"))] | last // "1.4.1-draft.0")' 2>/dev/null || echo '1.4.1-draft.0'
           )
           echo "LAST_DRAFT_VERSION=${last_draft_version}" >> $GITHUB_ENV
 
@@ -80,5 +80,5 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRIZMUI }}'
           projectId: prizmui
-          channelId: v1-4-0
+          channelId: live
           target: draft

--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-node_modules_ng_14-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node_modules_ng_15-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules_ng_14-
+            ${{ runner.os }}-node_modules_ng_15-
 
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -67,5 +67,5 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRIZMUI }}'
           projectId: prizmui
-          channelId: v1-4-0
+          channelId: live
           target: main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-node_modules_ng_14-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node_modules_ng_15-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules_ng_14-
+            ${{ runner.os }}-node_modules_ng_15-
 
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -83,9 +83,9 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-node_modules_ng_14-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node_modules_ng_15-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules_ng_14-
+            ${{ runner.os }}-node_modules_ng_15-
 
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-node_modules_ng_14-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node_modules_ng_15-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules_ng_14-
+            ${{ runner.os }}-node_modules_ng_15-
 
       - name: Install dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -52,7 +52,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_next_version=$(
-            npm view @prizm-ui/components versions --tag next --json | jq '([.[] | select(startswith("1.4.0-next"))] | last // "1.4.0-next.0")' 2>/dev/null || echo '1.4.0-next.0'
+            npm view @prizm-ui/components versions --tag next --json | jq '([.[] | select(startswith("1.4.1-next"))] | last // "1.4.1-next.0")' 2>/dev/null || echo '1.4.1-next.0'
           )
           echo "LAST_NEXT_VERSION=${last_next_version}" >> $GITHUB_ENV
 
@@ -80,5 +80,5 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_PRIZMUI }}'
           projectId: prizmui
-          channelId: v1-4-0
+          channelId: live
           target: next

--- a/.github/workflows/prereleased.yml
+++ b/.github/workflows/prereleased.yml
@@ -18,6 +18,6 @@ jobs:
     needs: pre_draft_release
 
   check_package_install:
-    uses: zyfra/Prizm/.github/workflows/check-build-in-real-project-ng-15.yml@main
+    uses: zyfra/Prizm/.github/workflows/check-build-in-real-project-ng-14.yml@main
     secrets: inherit
     needs: pre_draft_release

--- a/.github/workflows/released.yml
+++ b/.github/workflows/released.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
 
   check_package_install:
-    uses: zyfra/Prizm/.github/workflows/check-build-in-real-project-ng-15.yml@main
+    uses: zyfra/Prizm/.github/workflows/check-build-in-real-project-ng-14.yml@main
     secrets: inherit
     needs: pre_draft_release
 

--- a/.gitlab/issue_templates/bug.md
+++ b/.gitlab/issue_templates/bug.md
@@ -31,7 +31,7 @@ Dependencies:
 ```
 ➜ npm ls @prizm-ui/zyfra-components
 
-@prizm-ui/zyfra-components 2.1.2
+@prizm-ui/zyfra-components 1.4.1
 ```
 
 ```

--- a/.gitlab/issue_templates/question.md
+++ b/.gitlab/issue_templates/question.md
@@ -20,7 +20,7 @@ v16.13.0
 
 Dependencies:
 
-`@prizm-ui/components 2.1.2`
+`@prizm-ui/components 1.4.1`
 
 Операционная ситема:
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,114 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1](https://github.com/zyfra/Prizm) (31-07-2023)
+
+### Features
+
+- feat(components/autoresize): added directive and example how to use in textarea #544
+- feat(components/sidebar): ability was added to control styles of wrapper elements #541
+- feat(components/table): ability was added to control tree rows #366
+- feat(components/dropdown-host): ability was added to control classes for dropdown #536
+- feat(components/input-select): ability was added to control classes and styles for dropdown #536
+- feat(components/input-multi-select): ability was added to control classes and styles for dropdown #536
+- feat(components/breadcrumbs): added ability to work with projections #464
+- feat(components/overlay): added new logic for detecting events from dynamic elements #411
+- feat(helpers/rxjs): 'raceEmit' operator was added to detect first emit in the transmitted time interval between source streams
+- feat(components/tabs): add full width underline #539
+
+### Bug fixes
+
+- fix(components/input-layout): problems with layout in outer #537
+- fix(components/table): prizmThGroup throws an error together with structure directives #510
+- fix(components/table): prizmThGroup throws an error together with structure directives #510
+- fix(components/tabs): after build the color changes #543
+- fix(components/overlay): the initial positioning of the window does not take right place #387
+- fix(components/dropdown-host): wrong position of dropdown #394
+- fix(components/dropdown-host): flickering on scroll #495
+- fix(components/tabs): automatically close after select from menu #482
+- fix(components/input-number): block not number symbols #486
+- fix(components/widget): fixed the height in component prizm-widget-base-example #484
+- fix(components/skeleton): styles are not removed when the skeleton is disabled #304
+- fix(doc): font fixes #280 #302 #303 #460
+
+## [2.1.3](https://github.com/zyfra/Prizm) (31-07-2023)
+
+### Features
+
+- feat(components/autoresize): added directive and example how to use in textarea #544
+- feat(components/sidebar): ability was added to control styles of wrapper elements #541
+- feat(components/table): ability was added to control tree rows #366
+- feat(components/dropdown-host): ability was added to control classes for dropdown #536
+- feat(components/input-select): ability was added to control classes and styles for dropdown #536
+- feat(components/input-multi-select): ability was added to control classes and styles for dropdown #536
+- feat(components/breadcrumbs): added ability to work with projections #464
+- feat(components/overlay): added new logic for detecting events from dynamic elements #411
+- feat(helpers/rxjs): 'raceEmit' operator was added to detect first emit in the transmitted time interval between source streams
+- feat(components/tabs): add full width underline #539
+
+### Bug fixes
+
+- fix(components/input-layout): problems with layout in outer #537
+- fix(components/table): prizmThGroup throws an error together with structure directives #510
+- fix(components/table): prizmThGroup throws an error together with structure directives #510
+- fix(components/tabs): after build the color changes #543
+- fix(components/overlay): the initial positioning of the window does not take right place #387
+- fix(components/dropdown-host): wrong position of dropdown #394
+- fix(components/dropdown-host): flickering on scroll #495
+- fix(components/tabs): automatically close after select from menu #482
+- fix(components/input-number): block not number symbols #486
+- fix(components/widget): fixed the height in component prizm-widget-base-example #484
+- fix(components/skeleton): styles are not removed when the skeleton is disabled #304
+- fix(doc): font fixes #280 #302 #303 #460
+
+## [2.1.3-next.3](https://github.com/zyfra/Prizm) (28-07-2023)
+
+### Features
+
+- feat(components/autoresize): added directive and example how to use in textarea #544
+
+### Bug fixes
+
+- fix(components/dropdown-host): wrong position of dropdown #394
+- fix(components/dropdown-host): flickering on scroll #495
+- fix(components/tabs): automatically close after select from menu #482
+- fix(components/input-number): block not number symbols #486
+
+## [2.1.3-next.2](https://github.com/zyfra/Prizm) (27-07-2023)
+
+### Features
+
+- feat(components/sidebar): ability was added to control styles of wrapper elements #541
+- feat(components/table): ability was added to control tree rows #366
+- feat(components/dropdown-host): ability was added to control classes for dropdown #536
+- feat(components/input-select): ability was added to control classes and styles for dropdown #536
+- feat(components/input-multi-select): ability was added to control classes and styles for dropdown #536
+
+### Bug fixes
+
+- fix(components/tabs): after build the color changes #543
+- fix(components/overlay): the initial positioning of the window does not take right place #387
+
+## [2.1.3-next.1](https://github.com/zyfra/Prizm) (26-07-2023)
+
+### Features
+
+- feat(components/breadcrumbs): added ability to work with projections #464
+- feat(components/overlay): added new logic for detecting events from dynamic elements #411
+- feat(helpers/rxjs): 'raceEmit' operator was added to detect first emit in the transmitted time interval between source streams
+- feat(components/tabs): add full width underline #539
+
+### Bug fixes
+
+- fix(components/input-layout): problems with layout in outer #537
+- fix(components/table): prizmThGroup throws an error together with structure directives #510
+- fix(components/table): prizmThGroup throws an error together with structure directives #510
+- fix(doc/select): set default value in example with transformer
+
+### For testers
+
+- !!! need check all overlay elements (sidebars, dialogs, confirms and so on) and overlay in tools. We changed core logic
+
 ## [1.4.0](https://github.com/zyfra/Prizm) (24-07-2023)
 
 ### Features

--- a/apps/doc/src/app/components/breadcrumbs/breadcrumbs-example.component.html
+++ b/apps/doc/src/app/components/breadcrumbs/breadcrumbs-example.component.html
@@ -10,6 +10,13 @@
     <prizm-doc-example id="icon" [content]="breadcrumbsWithIconExample" heading="With Icon">
       <prizm-breadcrumbs-example-with-icon></prizm-breadcrumbs-example-with-icon>
     </prizm-doc-example>
+    <prizm-doc-example
+      id="with-projection"
+      [content]="breadcrumbsProjectionExample"
+      heading="With Projection"
+    >
+      <prizm-breadcrumbs-example-projection></prizm-breadcrumbs-example-projection>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/breadcrumbs/breadcrumbs-example.component.ts
+++ b/apps/doc/src/app/components/breadcrumbs/breadcrumbs-example.component.ts
@@ -19,17 +19,22 @@ export class BreadcrumbsExampleComponent {
   ];
 
   public readonly breadcrumbsBasicExample: TuiDocExample = {
-    TypeScript: import('.//examples/breadcrumbs-example-basic/breadcrumbs-example-basic.component?raw'),
-    HTML: import('.//examples/breadcrumbs-example-basic/breadcrumbs-example-basic.component.html?raw'),
+    TypeScript: import('./examples/breadcrumbs-example-basic/breadcrumbs-example-basic.component?raw'),
+    HTML: import('./examples/breadcrumbs-example-basic/breadcrumbs-example-basic.component.html?raw'),
   };
 
   public readonly breadcrumbsWithIconExample: TuiDocExample = {
     TypeScript: import(
-      './/examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component?raw'
+      './examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component?raw'
     ),
-    HTML: import(
-      './/examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component.html?raw'
+    HTML: import('./examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component.html?raw'),
+  };
+
+  public readonly breadcrumbsProjectionExample: TuiDocExample = {
+    TypeScript: import(
+      './examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component?raw'
     ),
+    HTML: import('./examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.html?raw'),
   };
 
   public readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');

--- a/apps/doc/src/app/components/breadcrumbs/breadcrumbs-example.module.ts
+++ b/apps/doc/src/app/components/breadcrumbs/breadcrumbs-example.module.ts
@@ -3,19 +3,22 @@ import { CommonModule } from '@angular/common';
 import { BreadcrumbsExampleComponent } from './breadcrumbs-example.component';
 import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
-import { PrizmBreadcrumbsModule } from '@prizm-ui/components';
+import { PrizmBreadcrumbsModule, PrizmDropdownHostModule } from '@prizm-ui/components';
 import { BreadcrumbsExampleBasicComponent } from './examples/breadcrumbs-example-basic/breadcrumbs-example-basic.component';
 import { BreadcrumbsExampleWithIconComponent } from './examples/breadcrumbs-example-with-icon/breadcrumbs-example-with-icon.component';
+import { BreadcrumbsExampleProjectionComponent } from './examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component';
 
 @NgModule({
   declarations: [
     BreadcrumbsExampleComponent,
     BreadcrumbsExampleBasicComponent,
     BreadcrumbsExampleWithIconComponent,
+    BreadcrumbsExampleProjectionComponent,
   ],
   imports: [
     CommonModule,
     PrizmAddonDocModule,
+    PrizmDropdownHostModule,
     RouterModule.forChild(prizmDocGenerateRoutes(BreadcrumbsExampleComponent)),
     PrizmBreadcrumbsModule,
   ],

--- a/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.html
+++ b/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.html
@@ -1,0 +1,7 @@
+<prizm-breadcrumbs>
+  <ng-container *ngFor="let item of breadcrumbs">
+    <a *prizmBreadcrumb [routerLink]="item.link">
+      {{ item.name }}
+    </a>
+  </ng-container>
+</prizm-breadcrumbs>

--- a/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.less
+++ b/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.less
@@ -1,0 +1,11 @@
+a {
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--prizm-text-subscript);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--prizm-index-plan);
+  }
+}

--- a/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.ts
+++ b/apps/doc/src/app/components/breadcrumbs/examples/breadcrumbs-projection-basic/breadcrumbs-example-projection.component.ts
@@ -1,0 +1,22 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { IBreadcrumb } from '@prizm-ui/components';
+
+@Component({
+  selector: 'prizm-breadcrumbs-example-projection',
+  templateUrl: './breadcrumbs-example-projection.component.html',
+  styleUrls: ['./breadcrumbs-example-projection.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BreadcrumbsExampleProjectionComponent {
+  public breadcrumbs = [
+    { link: '/components/button', name: 'Button' },
+    { link: '/components/split-button', name: 'Split' },
+    { link: '/components/icon-button', name: 'Icon' },
+  ];
+
+  private currentBreadcrumb: IBreadcrumb = null;
+
+  public breadcrumbChange(current: IBreadcrumb): void {
+    this.currentBreadcrumb = current;
+  }
+}

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/custom-wrapper-style/custom-wrapper-style.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/custom-wrapper-style/custom-wrapper-style.component.html
@@ -1,0 +1,5 @@
+<button (click)="show()" type="button" prizmButton>Show SideBar</button>
+
+<ng-template #contentExample>
+  <div style="height: 100%; display: flex; align-items: center">Custom Padding For Content Wrapper</div>
+</ng-template>

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/custom-wrapper-style/custom-wrapper-style.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/custom-wrapper-style/custom-wrapper-style.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
+import { PrizmOverlayInsidePlacement, PrizmSidebarService } from '@prizm-ui/components';
+
+@Component({
+  selector: 'prizm-sidebar-custom-wrapper-style-example',
+  templateUrl: './custom-wrapper-style.component.html',
+})
+export class PrizmSidebarCustomWrapperStyleExampleComponent {
+  @ViewChild('contentExample') contentExample: TemplateRef<any>;
+  public backdrop = false;
+  public dismissible = false;
+
+  constructor(@Inject(PrizmSidebarService) private readonly sidebarService: PrizmSidebarService) {}
+
+  public show(): void {
+    this.sidebarService
+      .open(this.contentExample, {
+        closeable: true,
+        header: 'Header',
+        width: '400px',
+        cancelButton: 'Закрыть',
+        position: PrizmOverlayInsidePlacement.LEFT,
+        confirmButton: 'OK',
+        backdrop: this.backdrop,
+        styleVars: {
+          sidebarContentPadding: 0,
+        },
+        dismissible: this.dismissible,
+        size: 'm',
+      })
+      .subscribe();
+  }
+}

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
@@ -26,6 +26,14 @@
     <prizm-doc-example id="custom-button" [content]="exampleCustomButton" heading="Custom Button">
       <prizm-sidebar-custom-button-template-example></prizm-sidebar-custom-button-template-example>
     </prizm-doc-example>
+
+    <prizm-doc-example
+      id="custom-wrapper-style"
+      [content]="exampleCustomWrapperStyle"
+      heading="Custom Style Vars For Overlay Wrapper"
+    >
+      <prizm-sidebar-custom-wrapper-style-example></prizm-sidebar-custom-wrapper-style-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.ts
@@ -109,6 +109,11 @@ export class SidebarComponent {
     HTML: import('./examples/custom-button/custom-button-template.component.html?raw'),
   };
 
+  public readonly exampleCustomWrapperStyle: TuiDocExample = {
+    TypeScript: import('./examples/custom-wrapper-style/custom-wrapper-style.component.ts?raw'),
+    HTML: import('./examples/custom-wrapper-style/custom-wrapper-style.component.html?raw'),
+  };
+
   constructor(@Inject(PrizmSidebarService) private readonly sidebarService: PrizmSidebarService) {}
 
   @prizmPure

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.module.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.module.ts
@@ -18,6 +18,7 @@ import { PrizmSidebarHiddenFooterExampleComponent } from './examples/hidden-foot
 import { PrizmSidebarCustomCloseGuardExampleComponent } from './examples/custom-close-guard/custom-close-guard.component';
 import { PrizmSidebarCustomHeaderTemplateExampleComponent } from './examples/custom-header-template/custom-header-template.component';
 import { PrizmSidebarCustomButtonTemplateExampleComponent } from './examples/custom-button/custom-button-template.component';
+import { PrizmSidebarCustomWrapperStyleExampleComponent } from './examples/custom-wrapper-style/custom-wrapper-style.component';
 
 @NgModule({
   imports: [
@@ -34,6 +35,7 @@ import { PrizmSidebarCustomButtonTemplateExampleComponent } from './examples/cus
     RouterModule.forChild(prizmDocGenerateRoutes(SidebarComponent)),
   ],
   declarations: [
+    PrizmSidebarCustomWrapperStyleExampleComponent,
     PrizmSidebarCustomHeaderTemplateExampleComponent,
     PrizmSidebarCustomCloseGuardExampleComponent,
     PrizmSidebarCustomButtonTemplateExampleComponent,

--- a/apps/doc/src/app/components/dropdowns/dropdown-host/dropdown-host.component.html
+++ b/apps/doc/src/app/components/dropdowns/dropdown-host/dropdown-host.component.html
@@ -48,6 +48,8 @@
         [canOpen]="canOpen"
         [closeOnOutsideClick]="closeOnOutsideClick"
         [closeByEsc]="closeByEsc"
+        [dropdownClasses]="dropdownClasses"
+        [dropdownStyles]="dropdownStyles"
         [prizmDropdownHostCloseOnBackdropClick]="prizmDropdownHostCloseOnBackdropClick"
         style="display: inline-block; width: auto"
       >
@@ -59,8 +61,8 @@
           <prizm-data-list>
             <ng-container header>Заголовок блока</ng-container>
             <div class="box">
-              <button prizmButton appearanceType="outline">Кнопка 1</button>
-              <button prizmButton appearanceType="outline">Кнопка 2</button>
+              <button prizmButton appearanceType="fill">Кнопка 1</button>
+              <button prizmButton appearanceType="fill">Кнопка 2</button>
             </div>
             <ng-container footer>
               <button (click)="isOpen = false; cdRef.markForCheck()" prizmButton>Закрыть</button>
@@ -72,8 +74,8 @@
       <ng-template #withHeader>
         <prizm-data-list>
           <div class="box">
-            <button prizmButton appearanceType="outline">Кнопка 1</button>
-            <button prizmButton appearanceType="outline">Кнопка 2</button>
+            <button prizmButton appearanceType="fill">Кнопка 1</button>
+            <button prizmButton appearanceType="fill">Кнопка 2</button>
           </div>
           <ng-container footer>
             <button (click)="isOpen = false; cdRef.markForCheck()" prizmButton>Закрыть</button>
@@ -85,8 +87,8 @@
         <prizm-data-list>
           <ng-container header>Заголовок блока</ng-container>
           <div class="box">
-            <button prizmButton appearanceType="outline">Кнопка 1</button>
-            <button prizmButton appearanceType="outline">Кнопка 2</button>
+            <button prizmButton appearanceType="fill">Кнопка 1</button>
+            <button prizmButton appearanceType="fill">Кнопка 2</button>
           </div>
         </prizm-data-list>
       </ng-template>
@@ -94,8 +96,8 @@
       <ng-template #onlyContent>
         <prizm-data-list>
           <div class="box">
-            <button prizmButton appearanceType="outline">Кнопка 1</button>
-            <button prizmButton appearanceType="outline">Кнопка 2</button>
+            <button prizmButton appearanceType="fill">Кнопка 1</button>
+            <button prizmButton appearanceType="fill">Кнопка 2</button>
           </div>
         </prizm-data-list>
       </ng-template>
@@ -107,7 +109,7 @@
         documentationPropertyType="string"
         documentationPropertyMode="input"
       >
-        Host Witdh
+        Host Width
       </ng-template>
       <ng-template
         documentationPropertyName="prizmDropdownCustomContext"
@@ -127,11 +129,23 @@
       </ng-template>
 
       <ng-template
+        [(documentationPropertyValue)]="dropdownStyles"
+        [documentationPropertyValues]="dropdownStylesVariants"
         documentationPropertyName="dropdownStyles"
-        documentationPropertyType="Record<string, string | number>"
+        documentationPropertyType="PrizmDropdownHostStyles"
         documentationPropertyMode="input"
       >
         Styles for dropdown modal window
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="dropdownClasses"
+        [documentationPropertyValues]="dropdownClassesVariants"
+        documentationPropertyName="dropdownClasses"
+        documentationPropertyType="PrizmDropdownHostClasses"
+        documentationPropertyMode="input"
+      >
+        Classes for dropdown modal window
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/dropdowns/dropdown-host/dropdown-host.component.less
+++ b/apps/doc/src/app/components/dropdowns/dropdown-host/dropdown-host.component.less
@@ -8,3 +8,8 @@
 prizm-data-list [prizmButton] {
   width: 100%;
 }
+
+::ng-deep .extraDropdownClass {
+  --prizm-data-list-background: green;
+  --prizm-data-list-header-text: white;
+}

--- a/apps/doc/src/app/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/apps/doc/src/app/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -1,6 +1,11 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, TemplateRef, ViewChild } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
-import { PolymorphContent, PrizmOverlayOutsidePlacement } from '@prizm-ui/components';
+import {
+  PolymorphContent,
+  PrizmDropdownHostClasses,
+  PrizmDropdownHostStyles,
+  PrizmOverlayOutsidePlacement,
+} from '@prizm-ui/components';
 import { prizmGenerateId } from '@prizm-ui/helpers';
 
 @Component({
@@ -10,6 +15,21 @@ import { prizmGenerateId } from '@prizm-ui/helpers';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DropdownHostComponent {
+  public dropdownStylesVariants: ReadonlyArray<PrizmDropdownHostStyles> = [
+    null,
+    {
+      '--prizm-data-list-background': 'gray',
+      '--prizm-data-list-header-text': 'white',
+    },
+  ];
+  public dropdownStyles: PrizmDropdownHostStyles;
+  public dropdownClassesVariants: ReadonlyArray<PrizmDropdownHostStyles> = [
+    null,
+    {
+      extraDropdownClass: true,
+    },
+  ];
+  public dropdownClasses: PrizmDropdownHostClasses;
   public prizmDropdownHostId = 'dropdownHostId_' + prizmGenerateId();
   public delay = 0;
   public canOpen = true;

--- a/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.html
+++ b/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.html
@@ -50,6 +50,8 @@
           [placeholder]="placeholder"
           [emptyContent]="emptyContent"
           [isChipsDeletable]="isChipsDeletable"
+          [dropdownStyles]="dropdownStyles"
+          [dropdownClasses]="dropdownClasses"
           [formControl]="valueControl"
           [icon]="icon"
           [items]="items"
@@ -67,6 +69,26 @@
       [hostComponentKey]="selectKey"
       [control]="valueControl"
     >
+      <ng-template
+        [(documentationPropertyValue)]="dropdownStyles"
+        [documentationPropertyValues]="dropdownStylesVariants"
+        documentationPropertyName="dropdownStyles"
+        documentationPropertyType="PrizmDropdownHostStyles"
+        documentationPropertyMode="input"
+      >
+        Styles for dropdown modal window
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="dropdownClasses"
+        [documentationPropertyValues]="dropdownClassesVariants"
+        documentationPropertyName="dropdownClasses"
+        documentationPropertyType="PrizmDropdownHostClasses"
+        documentationPropertyMode="input"
+      >
+        Classes for dropdown modal window
+      </ng-template>
+
       <ng-template
         [(documentationPropertyValue)]="dropdownScroll"
         [documentationPropertyValues]="dropdownScrollVariants"

--- a/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.less
+++ b/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.less
@@ -1,0 +1,6 @@
+::ng-deep .extraDropdownClass {
+  --prizm-data-list-background: green;
+  --prizm-select-item-background: green;
+  --prizm-select-item-hover-background: yellow;
+  --prizm-data-list-header-text: white;
+}

--- a/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.ts
+++ b/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.ts
@@ -3,6 +3,7 @@ import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
 import {
   PolymorphContent,
   PrizmContextWithImplicit,
+  PrizmDropdownHostStyles,
   PrizmInputPosition,
   PrizmInputSize,
   PrizmInputStatus,
@@ -19,6 +20,22 @@ import { prizmPure } from '@prizm-ui/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InputInputMultiSelectComponent {
+  dropdownStylesVariants: ReadonlyArray<PrizmDropdownHostStyles> = [
+    null,
+    {
+      '--prizm-data-list-background': 'gray',
+      '--prizm-select-item-background': 'gray',
+      '--prizm-data-list-header-text': 'white',
+    },
+  ];
+  public dropdownStyles: PrizmDropdownHostStyles;
+  public dropdownClassesVariants: ReadonlyArray<PrizmDropdownHostStyles> = [
+    null,
+    {
+      extraDropdownClass: true,
+    },
+  ];
+  public dropdownClasses: PrizmDropdownHostStyles;
   readonly layoutKey = 'PrizmInputLayoutComponent';
   readonly selectKey = 'PrizmMultiSelectInputComponent';
   public border = false;

--- a/apps/doc/src/app/components/input/input-number/examples/input-number-basic-example/input-number-basic-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/examples/input-number-basic-example/input-number-basic-example.component.html
@@ -2,7 +2,6 @@
   <input
     #inputText
     #inputNumber="prizmInputNumber"
-    [value]="2"
     [step]="2"
     [formControl]="requiredInputControl"
     type="number"

--- a/apps/doc/src/app/components/input/input-number/examples/input-number-basic-example/input-number-basic-example.component.ts
+++ b/apps/doc/src/app/components/input/input-number/examples/input-number-basic-example/input-number-basic-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 
 @Component({
@@ -8,5 +8,5 @@ import { UntypedFormControl, Validators } from '@angular/forms';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InputNumberBasicExampleComponent {
-  public requiredInputControl = new UntypedFormControl('', Validators.required);
+  public requiredInputControl = new UntypedFormControl(2, Validators.required);
 }

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.html
@@ -157,6 +157,7 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
+      [hasTestId]="false"
       heading="PrizmInputNumberDefaultControlsComponent"
       hostComponentKey="PrizmInputNumberDefaultControlsComponent"
     >
@@ -170,6 +171,7 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
+      [hasTestId]="false"
       heading="prizmInputNumberAuxiliaryControl"
       hostComponentKey="prizmInputNumberAuxiliaryControl"
     >

--- a/apps/doc/src/app/components/input/input-select/examples/with-transformer/select-with-transformer-example.component.ts
+++ b/apps/doc/src/app/components/input/input-select/examples/with-transformer/select-with-transformer-example.component.ts
@@ -45,6 +45,6 @@ export class PrizmSelectWithTransformerExampleComponent {
   };
 
   public setDefaultValue(): void {
-    this.valueControl.setValue(this.items[0]);
+    this.valueControl.setValue(this.items[0].id);
   }
 }

--- a/apps/doc/src/app/components/input/input-select/input-select.component.html
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.html
@@ -65,6 +65,8 @@
           [searchMatcher]="searchMatcher"
           [formControl]="control"
           [searchable]="searchable"
+          [dropdownStyles]="dropdownStyles"
+          [dropdownClasses]="dropdownClasses"
           [dropdownScroll]="dropdownScroll"
           [emptyContent]="emptyContent"
           [minDropdownHeight]="minDropdownHeight"
@@ -82,6 +84,26 @@
       [hostComponentKey]="selectKey"
       [control]="control"
     >
+      <ng-template
+        [(documentationPropertyValue)]="dropdownStyles"
+        [documentationPropertyValues]="dropdownStylesVariants"
+        documentationPropertyName="dropdownStyles"
+        documentationPropertyType="PrizmDropdownHostStyles"
+        documentationPropertyMode="input"
+      >
+        Styles for dropdown modal window
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="dropdownClasses"
+        [documentationPropertyValues]="dropdownClassesVariants"
+        documentationPropertyName="dropdownClasses"
+        documentationPropertyType="PrizmDropdownHostClasses"
+        documentationPropertyMode="input"
+      >
+        Classes for dropdown modal window
+      </ng-template>
+
       <ng-template
         [(documentationPropertyValue)]="dropdownScroll"
         [documentationPropertyValues]="dropdownScrollVariants"

--- a/apps/doc/src/app/components/input/input-select/input-select.component.less
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.less
@@ -4,3 +4,10 @@
   align-items: center;
   gap: 1rem;
 }
+
+::ng-deep .extraDropdownClass {
+  --prizm-data-list-background: green;
+  --prizm-select-item-hover-background: yellow;
+  --prizm-data-list-header-text: white;
+  --prizm-select-item-background: green;
+}

--- a/apps/doc/src/app/components/input/input-select/input-select.component.ts
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.ts
@@ -2,6 +2,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
 import {
   PolymorphContent,
+  PrizmDropdownHostClasses,
+  PrizmDropdownHostStyles,
   PrizmInputPosition,
   PrizmInputSize,
   PrizmInputStatus,
@@ -18,6 +20,23 @@ import { prizmPure } from '@prizm-ui/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InputSelectComponent {
+  public dropdownStylesVariants: ReadonlyArray<PrizmDropdownHostStyles> = [
+    null,
+    {
+      '--prizm-data-list-background': 'gray',
+      '--prizm-select-item-background': 'gray',
+      '--prizm-data-list-header-text': 'white',
+    },
+  ];
+  public dropdownStyles: PrizmDropdownHostStyles;
+  public dropdownClassesVariants: ReadonlyArray<PrizmDropdownHostStyles> = [
+    null,
+    {
+      extraDropdownClass: true,
+    },
+  ];
+  public dropdownClasses: PrizmDropdownHostClasses;
+
   readonly layoutKey = 'PrizmInputLayoutComponent';
   readonly selectKey = 'PrizmSelectInputComponent';
   public readOnly = false;

--- a/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.component.html
@@ -1,3 +1,3 @@
 <prizm-input-layout label="Заголовок">
-  <textarea prizmInput autoSize placeholder="Введите заголовок"></textarea>
+  <textarea [prizmAutoResize]="true" prizmInput placeholder="Введите заголовок"></textarea>
 </prizm-input-layout>

--- a/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.module.ts
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-autosize-example/textarea-autosize-example.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAutoResizeModule, PrizmInputTextModule } from '@prizm-ui/components';
+import { TextareAautosizeExampleComponent } from './textarea-autosize-example.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    PrizmAddonDocModule,
+    ReactiveFormsModule,
+    FormsModule,
+    PrizmInputTextModule,
+    PrizmAutoResizeModule,
+  ],
+  declarations: [TextareAautosizeExampleComponent],
+  exports: [TextareAautosizeExampleComponent],
+})
+export class TextareaAutosizeExampleModule {}

--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.html
@@ -1,10 +1,10 @@
 <prizm-doc-page header="Textarea">
   <ng-template prizmDocPageTab>
-    <prizm-doc-example [content]="zyfraTextareaBasicExample" heading="Basic example">
+    <prizm-doc-example [content]="textareaBasicExample" heading="Basic example">
       <prizm-textarea-basic-example></prizm-textarea-basic-example>
     </prizm-doc-example>
 
-    <prizm-doc-example [content]="zyfraTextareaAutosizeExample" heading="Autosize example">
+    <prizm-doc-example [content]="textareaAutosizeExample" heading="Autoresize example">
       <prizm-textarea-autosize-example></prizm-textarea-autosize-example>
     </prizm-doc-example>
   </ng-template>

--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.ts
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.ts
@@ -32,13 +32,14 @@ export class TextareaExampleComponent {
   public forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   public forceClear = this.forceClearVariants[0];
 
-  public readonly zyfraTextareaBasicExample: TuiDocExample = {
+  public readonly textareaBasicExample: TuiDocExample = {
     TypeScript: import('./examples/textarea-basic-example/textarea-basic-example.component.ts?raw'),
     HTML: import('./examples/textarea-basic-example/textarea-basic-example.component.html?raw'),
   };
 
-  public readonly zyfraTextareaAutosizeExample: TuiDocExample = {
+  public readonly textareaAutosizeExample: TuiDocExample = {
     TypeScript: import('./examples/textarea-autosize-example/textarea-autosize-example.component.ts?raw'),
+    Module: import('./examples/textarea-autosize-example/textarea-autosize-example.module.ts?raw'),
     HTML: import('./examples/textarea-autosize-example/textarea-autosize-example.component.html?raw'),
   };
 

--- a/apps/doc/src/app/components/input/textarea/textarea-example.module.ts
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 
 import { TextareaBasicExampleComponent } from './examples/textarea-basic-example/textarea-basic-example.component';
 import { TextareaExampleComponent } from './textarea-example.component';
 import { PrizmInputTextModule } from '@prizm-ui/components';
-import { TextareAautosizeExampleComponent } from './examples/textarea-autosize-example/textarea-autosize-example.component';
+import { TextareaAutosizeExampleModule } from './examples/textarea-autosize-example/textarea-autosize-example.module';
 
 @NgModule({
   imports: [
@@ -17,8 +17,9 @@ import { TextareAautosizeExampleComponent } from './examples/textarea-autosize-e
     ReactiveFormsModule,
     FormsModule,
     PrizmInputTextModule,
+    TextareaAutosizeExampleModule,
   ],
-  declarations: [TextareaExampleComponent, TextareaBasicExampleComponent, TextareAautosizeExampleComponent],
+  declarations: [TextareaExampleComponent, TextareaBasicExampleComponent],
   exports: [TextareaExampleComponent],
 })
 export class TextareaExampleModule {}

--- a/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.html
@@ -1,3 +1,8 @@
+<div>
+  Показать поиск:
+  <prizm-toggle [formControl]="control"></prizm-toggle>
+</div>
+<br />
 <prizm-scrollbar class="scrollable" visibility="hidden">
   <table class="table" [columns]="columns" prizmTable>
     <thead>
@@ -7,7 +12,7 @@
         <th *prizmHead="'category'" rowspan="2" prizmTh>Категория</th>
         <th *prizmHead="'count'" rowspan="2" prizmTh>Количество</th>
       </tr>
-      <tr prizmThGroup>
+      <tr *ngIf="control.value" prizmThGroup>
         <th class="extra-border search-cell" [resizable]="true" prizmTh>
           <input #input (enter)="search($event, 'name')" prizmInput placeholder="Поиск" />
           <button

--- a/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.ts
+++ b/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.ts
@@ -1,6 +1,8 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ITableProduct } from '../table-basic-example/table-basic-example.component';
 import { TABLE_EXAMPLE_DATA_SEARCH } from '../../table-example.const';
+import { FormControl } from '@angular/forms';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'prizm-table-search-example',
@@ -8,16 +10,26 @@ import { TABLE_EXAMPLE_DATA_SEARCH } from '../../table-example.const';
   styleUrls: ['./table-search-example.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TableSearchExampleComponent {
+export class TableSearchExampleComponent implements OnInit {
   public columns: string[] = ['code', 'name', 'category', 'count'];
   public products: ITableProduct[] = TABLE_EXAMPLE_DATA_SEARCH;
   public searchString: string = null;
   public searchAllowedProducts: ITableProduct[] = this.products;
-
+  public readonly control = new FormControl(false);
   public search<T extends keyof ITableProduct>(value: string, key: T): void {
     this.searchString = value.toLowerCase();
     this.searchAllowedProducts = this.products.filter(product =>
       (product[key] as string).toLowerCase().includes(this.searchString)
     );
+  }
+
+  ngOnInit(): void {
+    this.control.valueChanges
+      .pipe(
+        tap(() => {
+          this.searchAllowedProducts = [...this.products];
+        })
+      )
+      .subscribe();
   }
 }

--- a/apps/doc/src/app/components/table/examples/table-tree-example/table-tree-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-tree-example/table-tree-example.component.html
@@ -4,9 +4,34 @@
   <prizm-toggle [(ngModel)]="showFormatNumber" [ngModelOptions]="{ standalone: true }" size="m">
   </prizm-toggle>
 </div>
+<div>
+  show/hide all rows
+  <prizm-toggle
+    [ngModel]="false"
+    [ngModelOptions]="{ standalone: true }"
+    (ngModelChange)="
+      $event ? prizmTableElement.tree.showAllChildren() : prizmTableElement.tree.hideAllChildren()
+    "
+    size="m"
+  >
+  </prizm-toggle>
+</div>
+
+<div>
+  show/hide row by idx 0
+  <prizm-toggle
+    [ngModel]="false"
+    [ngModelOptions]="{ standalone: true }"
+    (ngModelChange)="
+      $event ? prizmTableElement.tree.showAllChildren(0) : prizmTableElement.tree.hideAllChildren(0)
+    "
+    size="m"
+  >
+  </prizm-toggle>
+</div>
 <br />
 <prizm-scrollbar class="scrollable">
-  <table class="table" prizmTable size="s">
+  <table class="table" #prizmTableElement="prizmTable" prizmTable size="s">
     <thead>
       <tr prizmThGroup>
         <th prizmTh>Наименование</th>

--- a/apps/doc/src/app/components/tree/examples/in-modal/tree-in-modal-example.component.html
+++ b/apps/doc/src/app/components/tree/examples/in-modal/tree-in-modal-example.component.html
@@ -1,0 +1,27 @@
+<button (click)="open()" prizmButton>Show tree</button>
+
+<ng-template #someTemplate>
+  <div class="box">
+    <div>SOME CONTENT</div>
+    <i>Can close also on backdrop click</i>
+    <ng-container [prizmTreeController]="true">
+      <prizm-tree-item>
+        Fruits
+        <prizm-tree-item>
+          Apples
+          <prizm-tree-item>Granny Smith</prizm-tree-item>
+          <prizm-tree-item>Red Delicious</prizm-tree-item>
+        </prizm-tree-item>
+        <prizm-tree-item>Oranges</prizm-tree-item>
+      </prizm-tree-item>
+      <prizm-tree-item>
+        Animals
+        <prizm-tree-item>Cats</prizm-tree-item>
+        <prizm-tree-item>Dogs</prizm-tree-item>
+      </prizm-tree-item>
+    </ng-container>
+    <br />
+    <br />
+    <button class="modal-button" (click)="close()" prizmButton>Close</button>
+  </div>
+</ng-template>

--- a/apps/doc/src/app/components/tree/examples/in-modal/tree-in-modal-example.component.ts
+++ b/apps/doc/src/app/components/tree/examples/in-modal/tree-in-modal-example.component.ts
@@ -1,0 +1,67 @@
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+import {
+  PrizmOverlayControl,
+  PrizmOverlayService,
+  PrizmOverlaySlidePlacement,
+  PrizmOverlaySlidePosition,
+} from '@prizm-ui/components';
+
+export interface TreeNode {
+  readonly text: string;
+  readonly icon?: string;
+  readonly children?: readonly TreeNode[];
+}
+
+@Component({
+  selector: 'prizm-tree-in-modal-example',
+  templateUrl: './tree-in-modal-example.component.html',
+  styles: [
+    `
+      .box {
+        height: 100%;
+        padding: 1rem;
+        min-width: 300px;
+        background-color: white;
+        border-right: 1px solid black;
+      }
+
+      .modal-button {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class TreeInModalExampleComponent {
+  @ViewChild('someTemplate', { read: TemplateRef, static: true })
+  templateRef: TemplateRef<unknown>;
+
+  private control: PrizmOverlayControl;
+  constructor(private readonly overlay: PrizmOverlayService) {}
+
+  ngOnInit() {
+    const position = new PrizmOverlaySlidePosition({
+      // Pass position placement
+      placement: PrizmOverlaySlidePlacement.LEFT,
+    });
+
+    this.control = this.overlay
+      .position(position)
+      .config({
+        closeOnDocClick: true,
+      })
+      .content(this.templateRef)
+      .create();
+  }
+
+  public open(): void {
+    this.control.open();
+  }
+
+  public close(): void {
+    this.control.close();
+  }
+
+  public toggle(): void {
+    this.control.toggle();
+  }
+}

--- a/apps/doc/src/app/components/tree/tree.component.html
+++ b/apps/doc/src/app/components/tree/tree.component.html
@@ -34,6 +34,10 @@
     <prizm-doc-example id="padding-indent" [content]="examplePaddingIndent" heading="Padding indent">
       <prizm-tree-padding-indent-example></prizm-tree-padding-indent-example>
     </prizm-doc-example>
+
+    <prizm-doc-example id="in-modal" [content]="exampleTemplate" heading="In Modal">
+      <prizm-tree-in-modal-example></prizm-tree-in-modal-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/tree/tree.component.ts
+++ b/apps/doc/src/app/components/tree/tree.component.ts
@@ -67,5 +67,9 @@ export class TreeComponent {
     'folder.less': import('./examples/component/folder.component.less?raw'),
   };
 
+  public readonly exampleInModal: TuiDocExample = {
+    TypeScript: import('./examples/in-modal/tree-in-modal-example.component.ts?raw'),
+    HTML: import('./examples/in-modal/tree-in-modal-example.component.html?raw'),
+  };
   readonly handler: PrizmHandler<TreeNode, readonly TreeNode[]> = item => item.children || PRIZM_EMPTY_ARRAY;
 }

--- a/apps/doc/src/app/components/tree/tree.module.ts
+++ b/apps/doc/src/app/components/tree/tree.module.ts
@@ -3,7 +3,12 @@ import { CommonModule } from '@angular/common';
 import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { TreeComponent } from './tree.component';
-import { PrizmIconModule, PrizmTreeModule } from '@prizm-ui/components';
+import {
+  PrizmButtonModule,
+  PrizmIconModule,
+  PrizmSidebarModule,
+  PrizmTreeModule,
+} from '@prizm-ui/components';
 import { TreeBaseExampleComponent } from './examples/base/tree-base-example.component';
 import { TreeArrayExampleComponent } from './examples/array/tree-array-example.component';
 import { TreeTemplateExampleComponent } from './examples/template/tree-template-example.component';
@@ -12,6 +17,7 @@ import { TreeComponentExampleComponent } from './examples/component/tree-compone
 import { TreeTemplateCheckboxExampleModule } from './examples/template-checkbox/tree-template-example.module';
 import { TreeTemplateLazyExampleModule } from './examples/lazy/tree-template-lazy-example.module';
 import { TreePaddingInputExampleComponent } from './examples/padding-indent/tree-padding-indent-example.component';
+import { TreeInModalExampleComponent } from './examples/in-modal/tree-in-modal-example.component';
 
 @NgModule({
   imports: [
@@ -21,9 +27,12 @@ import { TreePaddingInputExampleComponent } from './examples/padding-indent/tree
     TreeTemplateLazyExampleModule,
     TreeTemplateCheckboxExampleModule,
     PrizmIconModule,
+    PrizmButtonModule,
+    PrizmSidebarModule,
     RouterModule.forChild(prizmDocGenerateRoutes(TreeComponent)),
   ],
   declarations: [
+    TreeInModalExampleComponent,
     TreeBaseExampleComponent,
     TreeArrayExampleComponent,
     TreeTemplateExampleComponent,

--- a/apps/doc/src/app/components/widget/examples/base/widget-base-example.component.ts
+++ b/apps/doc/src/app/components/widget/examples/base/widget-base-example.component.ts
@@ -6,13 +6,11 @@ import { Component } from '@angular/core';
   styles: [
     `
       prizm-widget {
-        padding: 16px;
         color: var(--prizm-text-main);
         font-style: normal;
         font-weight: 400;
         font-size: 14px;
         display: block;
-        height: 300px;
       }
     `,
   ],

--- a/apps/doc/src/app/components/widget/examples/with-buttons/widget-with-buttons-example.component.ts
+++ b/apps/doc/src/app/components/widget/examples/with-buttons/widget-with-buttons-example.component.ts
@@ -6,7 +6,6 @@ import { Component } from '@angular/core';
   styles: [
     `
       prizm-widget {
-        padding: 16px;
         color: var(--prizm-text-main);
         font-style: normal;
         font-weight: 400;

--- a/apps/doc/src/app/components/widget/widget.component.less
+++ b/apps/doc/src/app/components/widget/widget.component.less
@@ -1,7 +1,7 @@
 prizm-widget {
-  padding: 16px;
   color: var(--prizm-text-main);
   font-style: normal;
   font-weight: 400;
   font-size: 14px;
+  display: block;
 }

--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -6,7 +6,7 @@ export interface PrizmVersionMeta {
 
 export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
   {
-    label: '2.1.2',
+    label: '1.4.1',
     baseHref: 'http://prizm.site/',
   },
   {

--- a/apps/doc/src/styles.less
+++ b/apps/doc/src/styles.less
@@ -26,6 +26,10 @@ prizm-input-time {
   width: 20rem;
 }
 
+* {
+  font-family: 'Inter', sans-serif;
+}
+
 body {
   --prizm-input-layout-width: 20rem;
 }

--- a/libs/ast/package.json
+++ b/libs/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/ast",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/libs/charts/base/package.json
+++ b/libs/charts/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/charts",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -10,8 +10,8 @@
   "peerDependencies": {
     "@angular/common": "^14.2.12",
     "@angular/core": "^14.2.12",
-    "@prizm-ui/theme": "^1.4.0",
-    "@prizm-ui/helpers": "^1.4.0",
+    "@prizm-ui/theme": "^1.4.1",
+    "@prizm-ui/helpers": "^1.4.1",
     "@antv/g2plot": "^2.4.22"
   },
   "dependencies": {

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/components",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Prizm UI system design components library http://prizm.zyfra.com",
   "license": "MIT",
   "private": false,
@@ -16,10 +16,10 @@
     "@ng-web-apis/resize-observer": "^1.0.3",
     "@ng-web-apis/intersection-observer": "^3.0.0",
     "@ng-web-apis/mutation-observer": "2.0.0",
-    "@prizm-ui/helpers": "^1.4.0",
-    "@prizm-ui/core": "^1.4.0",
-    "@prizm-ui/i18n": "^1.4.0",
-    "@prizm-ui/theme": "^1.4.0"
+    "@prizm-ui/helpers": "^1.4.1",
+    "@prizm-ui/core": "^1.4.1",
+    "@prizm-ui/i18n": "^1.4.1",
+    "@prizm-ui/theme": "^1.4.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/components/src/lib/abstract/dialog.service.ts
+++ b/libs/components/src/lib/abstract/dialog.service.ts
@@ -92,6 +92,7 @@ export abstract class AbstractPrizmDialogService<
   protected getConfig(dialog: PrizmBaseDialogContext<any, any>): Partial<PrizmOverlayConfig> {
     return {
       backdrop: dialog.backdrop ?? true,
+      styleVars: dialog.styleVars,
       containerClass: dialog.containerClass ?? '',
       backdropClass: [dialog.backdrop && PRIZM_OVERLAY_BACKDROP_NO_POINTERS, dialog.backdropClass]
         .filter(Boolean)

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.html
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.html
@@ -1,4 +1,30 @@
 <div class="container" #container>
+  <div class="breadcrumbs" *ngFor="let item of breadcrumbsItem; let i = index">
+    <prizm-icon
+      class="breadcrumbs__chevron"
+      *ngIf="i !== 0"
+      [size]="16"
+      iconClass="chevrons-right"
+    ></prizm-icon>
+
+    <div class="breadcrumb breadcrumb__name">
+      <ng-container [ngTemplateOutlet]="item.template" [ngTemplateOutletContext]="{ idx: i }"></ng-container>
+    </div>
+
+    <prizm-dropdown-host
+      class="breadcrumbs__dots"
+      *ngIf="i === 0 && this.isContainerOverflowed"
+      [(isOpen)]="isDropdownOpened"
+      [content]="dropdown"
+      prizmDropdownHostWidth="auto"
+    >
+      <div class="dropdown-inner">
+        <prizm-icon class="breadcrumbs__chevron" [size]="16" iconClass="chevrons-right"></prizm-icon>
+        <button class="dots-buttons" (click)="isDropdownOpened = !isDropdownOpened">...</button>
+      </div>
+    </prizm-dropdown-host>
+  </div>
+
   <ng-container>
     <div class="breadcrumbs" #breadcrumb *ngFor="let breadcrumb of breadcrumbsToShow$ | async; let i = index">
       <prizm-icon

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { BreadcrumbsComponent } from './breadcrumbs.component';
+import { PrizmBreadcrumbsComponent } from './breadcrumbs.component';
 import { PrizmDropdownHostModule } from '../dropdowns/dropdown-host/dropdown-host.module';
 import { PrizmIconModule } from '../icon/icon.module';
 
 describe('BreadcrumbsComponent', () => {
-  let component: BreadcrumbsComponent<any>;
-  let fixture: ComponentFixture<BreadcrumbsComponent<any>>;
+  let component: PrizmBreadcrumbsComponent<any>;
+  let fixture: ComponentFixture<PrizmBreadcrumbsComponent<any>>;
   class ResizeObserver {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public disconnect(): void {}
@@ -20,13 +20,13 @@ describe('BreadcrumbsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [BreadcrumbsComponent],
+      declarations: [PrizmBreadcrumbsComponent],
       imports: [PrizmDropdownHostModule, PrizmIconModule],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(BreadcrumbsComponent);
+    fixture = TestBed.createComponent(PrizmBreadcrumbsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,24 +1,25 @@
 import {
-  Component,
-  ChangeDetectionStrategy,
-  Input,
-  Output,
-  EventEmitter,
-  OnDestroy,
-  ViewChild,
-  ElementRef,
-  ViewChildren,
-  QueryList,
-  ChangeDetectorRef,
-  OnInit,
   AfterViewInit,
-  HostBinding,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  QueryList,
+  ViewChild,
+  ViewChildren,
 } from '@angular/core';
 import { IBreadcrumb } from './breadcrumb.interface';
 import { animationFrameScheduler, BehaviorSubject, merge, Subject } from 'rxjs';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { debounceTime, observeOn, takeUntil, tap } from 'rxjs/operators';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
+import { PrizmBreadcrumbDirective } from './breadcrumbs.directive';
 
 @Component({
   selector: 'prizm-breadcrumbs',
@@ -27,7 +28,7 @@ import { PrizmAbstractTestId } from '../../abstract/interactive';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [PrizmDestroyService],
 })
-export class BreadcrumbsComponent<Breadcrumb extends IBreadcrumb>
+export class PrizmBreadcrumbsComponent<Breadcrumb extends IBreadcrumb>
   extends PrizmAbstractTestId
   implements OnInit, OnDestroy, AfterViewInit
 {
@@ -45,6 +46,7 @@ export class BreadcrumbsComponent<Breadcrumb extends IBreadcrumb>
   @ViewChild('container', { static: true }) public containerRef: ElementRef;
   @ViewChild('breadcrumbsFake', { static: true }) public fakeBreadcrumbContainer: ElementRef;
   @ViewChildren('breadcrumb', { read: ElementRef }) public breadcrumbsList: QueryList<ElementRef>;
+  @ContentChildren(PrizmBreadcrumbDirective) public breadcrumbsItem: QueryList<PrizmBreadcrumbDirective>;
 
   public breadcrumbs$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);
   public breadcrumbsToShow$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.directive.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.directive.ts
@@ -1,0 +1,17 @@
+import { Directive, Inject, OnDestroy, TemplateRef, ViewContainerRef } from '@angular/core';
+import { PrizmDestroyService } from '@prizm-ui/helpers';
+
+@Directive({
+  selector: 'ng-template[prizmBreadcrumb]',
+  providers: [PrizmDestroyService],
+})
+export class PrizmBreadcrumbDirective implements OnDestroy {
+  constructor(
+    @Inject(TemplateRef) readonly template: TemplateRef<any>,
+    private readonly viewContainer: ViewContainerRef
+  ) {}
+
+  public ngOnDestroy(): void {
+    this.viewContainer.clear();
+  }
+}

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.module.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.module.ts
@@ -1,12 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BreadcrumbsComponent } from './breadcrumbs.component';
+import { PrizmBreadcrumbsComponent } from './breadcrumbs.component';
 import { PrizmIconModule } from '../icon';
 import { PrizmDropdownHostModule } from '../dropdowns/dropdown-host';
+import { PrizmBreadcrumbDirective } from './breadcrumbs.directive';
 
 @NgModule({
-  declarations: [BreadcrumbsComponent],
-  imports: [CommonModule, PrizmIconModule, PrizmDropdownHostModule],
-  exports: [BreadcrumbsComponent],
+  declarations: [PrizmBreadcrumbsComponent, PrizmBreadcrumbDirective],
+  imports: [
+    CommonModule,
+    // TODO !ng16 change all icon module to svg module
+    PrizmIconModule,
+    PrizmDropdownHostModule,
+  ],
+  exports: [PrizmBreadcrumbsComponent, PrizmBreadcrumbDirective],
 })
 export class PrizmBreadcrumbsModule {}

--- a/libs/components/src/lib/components/breadcrumbs/index.ts
+++ b/libs/components/src/lib/components/breadcrumbs/index.ts
@@ -1,3 +1,4 @@
 export * from './breadcrumb.interface';
 export * from './breadcrumbs.component';
 export * from './breadcrumbs.module';
+export * from './breadcrumbs.directive';

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
@@ -32,6 +32,7 @@ export interface PrizmDialogBaseOptions {
   readonly overscroll?: PrizmOverscrollMode;
   readonly dismissible?: boolean;
   readonly position: PrizmOverlayInsidePlacement;
+  readonly styleVars?: Record<string, unknown>;
 }
 
 export interface PrizmDialogOptions<O = unknown, DATA = unknown> extends PrizmDialogBaseOptions {

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
@@ -3,7 +3,7 @@
 .content {
   .ellipsis();
   flex: 1 1 0;
-  padding: var(--prizm-sidebar-padding, 32px 16px);
+  padding: var(--prizm-sidebar-padding, var(--prizm-sidebar-content-padding, 32px 16px));
   color: var(--prizm-text-main);
   overflow: hidden;
   max-width: 100%;
@@ -12,16 +12,15 @@
 .header {
   flex: 0 0 auto;
   border-bottom: 1px solid var(--prizm-border-widget);
-  padding: var(--prizm-sidebar-padding, 14px 16px);
+  padding: var(--prizm-sidebar-padding, var(--prizm-sidebar-header-padding, 14px 16px));
   display: flex;
   justify-content: space-between;
   max-width: 100%;
   overflow: hidden;
-
-  font-style: normal;
-  font-weight: 600;
-  font-size: var(--prizm-sidebar-font-size, 14px);
-  color: var(--prizm-text-contrast);
+  font-style: var(--prizm-sidebar-header-font-style, var(--prizm-text-contrast, normal));
+  font-weight: var(--prizm-sidebar-header-font-size, var(--prizm-text-contrast, 600));
+  font-size: var(--prizm-sidebar-header-font-size, var(--prizm-text-contrast, 14px));
+  color: var(--prizm-sidebar-header-color, var(--prizm-text-contrast, 200px));
 
   prizm-scrollbar {
     max-height: 150px;
@@ -89,9 +88,9 @@
 
 .footer {
   border-top: 1px solid var(--prizm-border-widget);
-  padding: var(--prizm-sidebar-padding, 14px 16px);
+  padding: var(--prizm-sidebar-padding, var(--prizm-sidebar-footer-padding, 14px 16px));
   max-width: 100%;
-  max-height: 200px;
+  max-height: var(--prizm-sidebar-footer-max-height, 200px);
   overflow: hidden;
   text-overflow: ellipsis;
 

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.models.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.models.ts
@@ -17,6 +17,8 @@ export interface PrizmSidebarOptions<DATA = unknown> extends PrizmDialogBaseOpti
   confirmButton?: PrizmSidebarButton | string;
   supportButton?: PrizmSidebarButton | string;
   cancelButton?: PrizmSidebarButton | string;
+  styleVars?: Record<string, unknown>;
+  overlayStyleVars?: Record<string, unknown>;
   showByVertical?: boolean;
   data?: DATA;
   size?: PrizmDialogSize;

--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.html
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.html
@@ -13,6 +13,7 @@
     <div
       class="prizm-dropdown-host-modal"
       [ngStyle]="dropdownStyles"
+      [ngClass]="dropdownClasses"
       [id]="prizmDropdownHostId"
       [attr.position]="position$ | async"
       (zoneOutsideEvent)="outsideClick()"

--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -5,7 +5,6 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  HostBinding,
   HostListener,
   Inject,
   Injector,
@@ -26,7 +25,13 @@ import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
 import { DOCUMENT } from '@angular/common';
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { PRIZM_DROPDOWN_HOST_OPTIONS, PrizmDropdownHostOptions } from './dropdown-host.options';
-import { PrizmDropdownHostContext, PrizmDropdownHostCustomContext, PrizmDropdownHostWidth } from './models';
+import {
+  PrizmDropdownHostClasses,
+  PrizmDropdownHostContext,
+  PrizmDropdownHostCustomContext,
+  PrizmDropdownHostStyles,
+  PrizmDropdownHostWidth,
+} from './models';
 import { PrizmOverlayOutsidePlacement } from '../../../modules/overlay/models';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
 
@@ -106,12 +111,11 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
 
   private lastEmittedState: boolean;
 
-  @Input() dropdownStyles: Record<string, string | number> = {};
-
+  @Input() dropdownStyles: PrizmDropdownHostStyles;
+  @Input() dropdownClasses: PrizmDropdownHostClasses;
   @ViewChild('temp') temp: TemplateRef<HTMLDivElement>;
 
   @Output() readonly isOpenChange = new EventEmitter<boolean>();
-
   private overlay: PrizmOverlayControl;
   protected isOpen$ = new BehaviorSubject(false);
 

--- a/libs/components/src/lib/components/dropdowns/dropdown-host/models.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/models.ts
@@ -1,7 +1,20 @@
-import { PrizmDropdownZoneDirective } from '../../../directives/event-zone/event-zone.directive';
-
 export type PrizmDropdownHostWidth = string | number | null;
 export type PrizmDropdownHostContext = {
   custom: PrizmDropdownHostCustomContext;
 };
 export type PrizmDropdownHostCustomContext = Record<string, unknown>;
+export type PrizmDropdownHostStyles =
+  | {
+      [klass: string]: any;
+    }
+  | null
+  | undefined;
+export type PrizmDropdownHostClasses =
+  | string
+  | string[]
+  | Set<string>
+  | {
+      [klass: string]: boolean;
+    }
+  | null
+  | undefined;

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
@@ -6,6 +6,8 @@
   [prizmDropdownHostWidth]="dropdownWidth"
   [prizmDropdownMinHeight]="minDropdownHeight"
   [prizmDropdownMaxHeight]="maxDropdownHeight"
+  [dropdownStyles]="dropdownStyles"
+  [dropdownClasses]="dropdownClasses"
   [ngSwitch]="layoutComponent.outer"
   (isOpenChange)="$event && searchInputControl.setValue(''); opened$$.next($event)"
 >

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
@@ -20,7 +20,11 @@ import { prizmIsNativeFocused, prizmIsTextOverflow$ } from '../../../util';
 import { debounceTime, map, shareReplay, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { BehaviorSubject, combineLatest, Observable, Subject, timer } from 'rxjs';
 import { prizmDefaultProp } from '@prizm-ui/core';
-import { PrizmDropdownHostComponent } from '../dropdown-host';
+import {
+  PrizmDropdownHostClasses,
+  PrizmDropdownHostComponent,
+  PrizmDropdownHostStyles,
+} from '../dropdown-host';
 import {
   PrizmMultiSelectIdentityMatcher,
   PrizmMultiSelectItemStringifyFunc,
@@ -66,7 +70,8 @@ export class PrizmInputMultiSelectComponent<T> extends PrizmInputNgControl<T[]> 
   @Input()
   @prizmDefaultProp()
   dropdownScroll: PrizmScrollbarVisibility = 'auto';
-
+  @Input() dropdownStyles: PrizmDropdownHostStyles;
+  @Input() dropdownClasses: PrizmDropdownHostClasses;
   @Input()
   @prizmDefaultProp()
   icon = this.options.icon;

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -6,6 +6,8 @@
   [prizmDropdownHostWidth]="dropdownWidth"
   [prizmDropdownMinHeight]="minDropdownHeight"
   [prizmDropdownMaxHeight]="maxDropdownHeight"
+  [dropdownStyles]="dropdownStyles"
+  [dropdownClasses]="dropdownClasses"
   (isOpenChange)="opened$$.next($event)"
 >
   <input

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -27,7 +27,11 @@ import {
   PrizmSelectValueTransformver,
 } from './select.model';
 import { prizmDefaultProp } from '@prizm-ui/core';
-import { PrizmDropdownHostComponent } from '../dropdown-host';
+import {
+  PrizmDropdownHostClasses,
+  PrizmDropdownHostComponent,
+  PrizmDropdownHostStyles,
+} from '../dropdown-host';
 import { PrizmOverlayOutsidePlacement } from '../../../modules/overlay';
 import { PrizmInputNgControl } from '../../input/common/base/input-ng-control.class';
 import { PrizmScrollbarVisibility } from '../../scrollbar';
@@ -65,6 +69,9 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   @Input()
   @prizmDefaultProp()
   dropdownScroll: PrizmScrollbarVisibility = 'auto';
+
+  @Input() dropdownStyles: PrizmDropdownHostStyles;
+  @Input() dropdownClasses: PrizmDropdownHostClasses;
 
   @Input()
   @prizmDefaultProp()

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -46,7 +46,6 @@
 }
 
 .prizm-input-label {
-  display: block;
   font-weight: 600;
   font-size: 12px;
   color: var(--prizm-text-subscript);
@@ -55,6 +54,9 @@
   margin-bottom: 4px;
   transition: top 200ms ease 0s;
   pointer-events: none;
+  width: 100%;
+  display: flex;
+  gap: 4px;
 
   &-required {
     color: var(--prizm-index-danger);
@@ -95,6 +97,7 @@
     &-center {
       padding: 0;
       left: 50%;
+      justify-content: center;
       transform: translateX(-50%);
     }
   }

--- a/libs/components/src/lib/components/input/common/services/input-invalid-subtext.service.ts
+++ b/libs/components/src/lib/components/input/common/services/input-invalid-subtext.service.ts
@@ -7,6 +7,7 @@ import { Injectable } from '@angular/core';
 export class PrizmInputValidationTexts {
   private readonly invalidTextMap = new Map<string, string>([
     ['required', 'Обязательное поле'],
+    ['pattern', 'Неправильный формат'],
     ['min', 'Значение слишком маленькое'],
     ['max', 'Значение слишком большое'],
   ]);

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.html
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.html
@@ -22,7 +22,7 @@
 </prizm-dropdown-host>
 
 <ng-template #dropdown>
-  <ul class="prizm-datepicker-relative-menu" (prizmAfterViewInit)="markAsTouched()" role="listbox">
+  <ul class="prizm-datepicker-relative-menu" role="listbox">
     <ng-container *ngTemplateOutlet="menuItemsTemplate; context: { items: timeItems }"></ng-container>
     <li class="relative-menu-item-divider"></li>
     <ng-container *ngTemplateOutlet="menuItemsTemplate; context: { items: directionItems }"></ng-container>

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -104,6 +104,9 @@ export class PrizmInputLayoutDateRelativeComponent
     super(injector);
   }
 
+  // public override isEmpty(value: any): boolean {
+  //   return !value && !this.nativeFocusableElement?.value;
+  // }
   public override ngOnInit(): void {
     super.ngOnInit();
     this.rightButtons$ = this.extraButtonInjector.get(PRIZM_DATE_RIGHT_BUTTONS);
@@ -112,6 +115,7 @@ export class PrizmInputLayoutDateRelativeComponent
   public valueChange(value: string) {
     this.parseInputValue(value);
     this.actualizeMenu();
+    this.actualizeInput();
   }
 
   public ngOnDestroy(): void {
@@ -176,6 +180,7 @@ export class PrizmInputLayoutDateRelativeComponent
       period: this.activePeriodId,
     });
 
+    this.markAsTouched();
     this.updateValue(stringValue);
   }
 
@@ -183,6 +188,7 @@ export class PrizmInputLayoutDateRelativeComponent
     this.parseInputValue('');
     this.updateValue(null);
     this.actualizeMenu();
+    if (this.nativeFocusableElement) this.nativeFocusableElement.value = '';
   }
 
   /**

--- a/libs/components/src/lib/components/input/input-date-time-range/input-date-range-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-date-range-time.component.ts
@@ -33,6 +33,7 @@ import {
   PRIZM_DATE_TEXTS,
   PRIZM_IS_MOBILE,
   PRIZM_MOBILE_CALENDAR,
+  PRIZM_TIME_TEXTS,
 } from '../../../tokens';
 import { PrizmDialogService } from '../../dialogs/dialog';
 import { PRIZM_DATE_FORMAT, PRIZM_DATE_SEPARATOR, PrizmDayRange, PrizmTime } from '../../../@core';
@@ -41,12 +42,20 @@ import { Observable } from 'rxjs';
 import { PrizmInputSize } from '../common/models/prizm-input.models';
 import { takeUntil } from 'rxjs/operators';
 import { PrizmDestroyService, PrizmFormControlHelpers } from '@prizm-ui/helpers';
+import { prizmI18nInitWithKeys } from '../../../services';
 
 @Component({
   selector: `prizm-input-date-time-range`,
   templateUrl: `./input-date-range-time.component.html`,
   styleUrls: [`./input-date-range-time.component.less`],
-  providers: [...PRIZM_INPUT_DATE_TIME_RANGE_PROVIDERS, PrizmDestroyService],
+  providers: [
+    ...prizmI18nInitWithKeys({
+      time: PRIZM_TIME_TEXTS,
+      dateTexts: PRIZM_DATE_TEXTS,
+    }),
+    ...PRIZM_INPUT_DATE_TIME_RANGE_PROVIDERS,
+    PrizmDestroyService,
+  ],
 })
 export class PrizmInputDateTimeRangeComponent
   extends AbstractPrizmNullableControl<PrizmDateTimeRange>

--- a/libs/components/src/lib/components/input/input-number/index.ts
+++ b/libs/components/src/lib/components/input/input-number/index.ts
@@ -1,4 +1,5 @@
 export * from './input-number.module';
 export * from './input-number-auxiliary-control.directive';
 export * from './input-number.directive';
+export * from './input-number-validator';
 export * from './input-number-auxiliary-controls.component';

--- a/libs/components/src/lib/components/input/input-number/input-number-validator.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number-validator.ts
@@ -1,0 +1,25 @@
+import { AbstractControl, NG_VALIDATORS, Validator, Validators } from '@angular/forms';
+import { Directive, ElementRef } from '@angular/core';
+
+const ValidationPattern = /^\s*[+-]?(\d+|\d*\.\d+|\d+\.\d*)([Ee][+-]?\d+)?\s*$/;
+
+@Directive({
+  selector: 'input[prizmInputNumber], input[type=number][prizmInput]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: PrizmInputNumberValidatorDirective,
+      multi: true,
+    },
+  ],
+})
+export class PrizmInputNumberValidatorDirective implements Validator {
+  constructor(private elementRef: ElementRef) {}
+  public validate(control: AbstractControl): { [key: string]: any } | null {
+    return ValidationPattern.exec(this.elementRef.nativeElement.value)
+      ? null
+      : {
+          pattern: this.elementRef.nativeElement.value,
+        };
+  }
+}

--- a/libs/components/src/lib/components/input/input-number/input-number.directive.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.directive.ts
@@ -1,6 +1,8 @@
 import { Directive, ElementRef, Host, HostBinding, HostListener, Input } from '@angular/core';
 import { PrizmInputTextComponent } from '../input-text/input-text.component';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
+import { timer } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 @Directive({
   selector: 'input[prizmInputNumber], input[type=number][prizmInput]',
@@ -17,11 +19,21 @@ export class PrizmInputNumberDirective extends PrizmAbstractTestId {
   get disabled() {
     return this.prizmInputText.disabled;
   }
+
+  @HostListener('keydown', ['$event']) public stopValue(ev: KeyboardEvent) {
+    if ((ev.ctrlKey || ev.metaKey) && ['c', 'v', 'a', 'x'].includes(ev.key)) return true;
+    if (
+      ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Backspace', 'Enter', 'Space', '.'].includes(ev.key)
+    )
+      return true;
+    return !ev.key.match(/[^0-9]/);
+  }
+
   constructor(
     @Host() private readonly el: ElementRef<HTMLInputElement>,
     @Host() private readonly prizmInputText: PrizmInputTextComponent
   ) {
-    el.nativeElement.type = 'number';
+    el.nativeElement.type = 'text';
     super();
   }
 

--- a/libs/components/src/lib/components/input/input-number/input-number.module.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.module.ts
@@ -4,11 +4,13 @@ import { PrizmInputTextModule } from '../input-text/input-text.module';
 import { PrizmInputNumberAuxiliaryControlDirective } from './input-number-auxiliary-control.directive';
 import { PrizmInputNumberDefaultControlsComponent } from './input-number-auxiliary-controls.component';
 import { PrizmInputNumberDirective } from './input-number.directive';
+import { PrizmInputNumberValidatorDirective } from './input-number-validator';
 
 @NgModule({
   imports: [PrizmInputCommonModule, PrizmInputTextModule],
   declarations: [
     PrizmInputNumberDirective,
+    PrizmInputNumberValidatorDirective,
     PrizmInputNumberAuxiliaryControlDirective,
     PrizmInputNumberDefaultControlsComponent,
   ],
@@ -16,6 +18,7 @@ import { PrizmInputNumberDirective } from './input-number.directive';
     PrizmInputNumberAuxiliaryControlDirective,
     PrizmInputCommonModule,
     PrizmInputNumberDirective,
+    PrizmInputNumberValidatorDirective,
     PrizmInputTextModule,
     PrizmInputNumberDefaultControlsComponent,
   ],

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -1,11 +1,9 @@
 import {
-  Attribute,
   ChangeDetectorRef,
   Component,
   DoCheck,
   ElementRef,
   EventEmitter,
-  HostBinding,
   HostListener,
   Input,
   OnDestroy,
@@ -14,11 +12,10 @@ import {
   Output,
   Self,
 } from '@angular/core';
-import { UntypedFormControl, NgControl, Validators } from '@angular/forms';
+import { NgControl, UntypedFormControl, Validators } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
-import { interval } from 'rxjs';
 
 @Component({
   selector:
@@ -143,7 +140,7 @@ export class PrizmInputTextComponent extends PrizmInputControl<string> implement
   constructor(
     @Optional() @Self() public readonly ngControl: NgControl,
     public readonly elementRef: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
-    private readonly prizmDestroyService: PrizmDestroyService,
+    private readonly destroy: PrizmDestroyService,
     private readonly cdr: ChangeDetectorRef
   ) {
     super();
@@ -199,7 +196,7 @@ export class PrizmInputTextComponent extends PrizmInputControl<string> implement
           this.updateErrorState();
           this.cdr.markForCheck();
         }),
-        takeUntil(this.prizmDestroyService)
+        takeUntil(this.destroy)
       )
       .subscribe();
 
@@ -210,7 +207,7 @@ export class PrizmInputTextComponent extends PrizmInputControl<string> implement
           this.updateErrorState();
           this.stateChanges.next();
         }),
-        takeUntil(this.prizmDestroyService)
+        takeUntil(this.destroy)
       )
       .subscribe();
 
@@ -219,7 +216,7 @@ export class PrizmInputTextComponent extends PrizmInputControl<string> implement
         tap(() => {
           this.stateChanges.next();
         }),
-        takeUntil(this.prizmDestroyService)
+        takeUntil(this.destroy)
       )
       .subscribe();
   }

--- a/libs/components/src/lib/components/table/directives/row-init.directive.ts
+++ b/libs/components/src/lib/components/table/directives/row-init.directive.ts
@@ -10,18 +10,21 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { PrizmTableRowService } from '../service/row.service';
+import { PrizmTableTreeService } from '../service/tree.service';
+import { PrizmTableRowContext } from '../table.types';
 
 @Directive({
   selector: `ng-template[prizmTableRowInit]`,
 })
 export class PrizmTableRowInitDirective implements OnInit, OnDestroy, OnChanges {
-  @Input() context: Record<string, unknown>;
+  @Input() context: PrizmTableRowContext;
   @Input() template: TemplateRef<any>;
   public embeddedRef: EmbeddedViewRef<any>;
   private idx: number;
   constructor(
     public readonly viewContainer: ViewContainerRef,
-    public readonly tableRowService: PrizmTableRowService
+    public readonly tableRowService: PrizmTableRowService,
+    public readonly treeService: PrizmTableTreeService
   ) {}
 
   public ngOnDestroy(): void {
@@ -31,11 +34,16 @@ export class PrizmTableRowInitDirective implements OnInit, OnDestroy, OnChanges 
   public ngOnInit(): void {
     this.generateIdx();
     this.embeddedRef = this.viewContainer.createEmbeddedView(this.template, this.getContext());
+    this.treeService.init(this.idx);
   }
 
   private generateIdx(): void {
     this.tableRowService.incrementIdx();
     this.idx = this.tableRowService.getIdx();
+
+    if ('parentIdx' in this.context) {
+      this.treeService.addChildToParent(this.idx, this.context.parentIdx);
+    }
   }
 
   public updateContextIfCan() {
@@ -46,7 +54,7 @@ export class PrizmTableRowInitDirective implements OnInit, OnDestroy, OnChanges 
     this.embeddedRef.markForCheck();
   }
 
-  private getContext(): Record<string, any> {
+  private getContext(): PrizmTableRowContext {
     const odd = this.idx % 2 !== 0;
     return {
       ...this.context,

--- a/libs/components/src/lib/components/table/directives/table.directive.ts
+++ b/libs/components/src/lib/components/table/directives/table.directive.ts
@@ -17,10 +17,12 @@ import { AbstractPrizmController } from '../abstract/controller';
 import { Observable } from 'rxjs';
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { PrizmTableCellSorter, PrizmTableSorterService } from '../service';
+import { PrizmTableTreeService } from '../service/tree.service';
+import { PrizmTableRowService } from '../service/row.service';
 
 @Directive({
   selector: `table[prizmTable]`,
-  providers: PRIZM_TABLE_PROVIDERS,
+  providers: [...PRIZM_TABLE_PROVIDERS, PrizmTableTreeService, PrizmTableRowService],
   // eslint-disable-next-line @angular-eslint/no-host-metadata-property
   host: {
     style: `border-collapse: separate; border-spacing: 0`,
@@ -70,6 +72,7 @@ export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
   readonly sortChange: Observable<PrizmTableCellSorter<T>[]> = this.sorterService.changes$;
 
   constructor(
+    public readonly tree: PrizmTableTreeService,
     public readonly sorterService: PrizmTableSorterService<T>,
     @Inject(IntersectionObserverService)
     readonly entries$: Observable<IntersectionObserverEntry[]>,

--- a/libs/components/src/lib/components/table/table.types.ts
+++ b/libs/components/src/lib/components/table/table.types.ts
@@ -11,7 +11,7 @@ export type PrizmTableCellStatus = 'default' | 'success' | 'warning' | 'danger';
 
 export type PrizmTableBorderStyle = 'grid' | 'horizontal' | 'vertical';
 
-export interface PrizmTableRowContext<T> extends PrizmContextWithImplicit<T> {
+export interface PrizmTableRowContext<T = Record<string, unknown>> extends PrizmContextWithImplicit<T> {
   readonly index: number;
   readonly first: boolean;
   readonly last: boolean;

--- a/libs/components/src/lib/components/table/tbody/tbody.component.html
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.html
@@ -30,16 +30,18 @@
           trackBy: row.prizmRowTrackBy
         "
         [template]="templateRowElement"
-        [context]="{
-          item: item,
-          index: index,
-          odd: odd,
-          even: even,
-          first: first,
-          last: last,
-          count: count,
-          deepLevel: 0
-        }"
+        [context]="
+          $any({
+            item: item,
+            index: index,
+            odd: odd,
+            even: even,
+            first: first,
+            last: last,
+            count: count,
+            deepLevel: 0
+          })
+        "
         prizmTableRowInit
       ></ng-template>
     </ng-container>
@@ -135,15 +137,17 @@
           trackBy: row.prizmRowTrackBy
         "
         [template]="templateRowElement"
-        [context]="{
-          item: childItem,
-          parentIdx: index,
-          parentItem: item,
-          deepLevel: (deepLevel ?? 0) + 1,
-          first: childFirst,
-          last: childLast,
-          count: childCount + count
-        }"
+        [context]="
+          $any({
+            item: childItem,
+            parentIdx: index,
+            parentItem: item,
+            deepLevel: (deepLevel ?? 0) + 1,
+            first: childFirst,
+            last: childLast,
+            count: childCount + count
+          })
+        "
         prizmTableRowInit
       >
       </ng-template>

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -40,7 +40,7 @@ import { PrizmTableRowService } from '../service/row.service';
   templateUrl: `./tbody.component.html`,
   styleUrls: [`./tbody.component.less`],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [...PRIZM_TABLE_PROVIDER, PrizmTableTreeService, PrizmTableRowService],
+  providers: PRIZM_TABLE_PROVIDER,
 })
 export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   implements CollectionViewer, AfterViewInit, OnDestroy

--- a/libs/components/src/lib/components/table/th-group/th-group.template.html
+++ b/libs/components/src/lib/components/table/th-group/th-group.template.html
@@ -1,4 +1,6 @@
 <ng-content selector="th[prizmTh]"></ng-content>
 <ng-container *ngIf="heads$ | async as headings">
-  <ng-container *ngFor="let head of headings" [ngTemplateOutlet]=" head.template"> </ng-container>
+  <ng-container *ngFor="let head of headings">
+    <ng-container *ngIf="head?.template" [ngTemplateOutlet]="head.template"></ng-container>
+  </ng-container>
 </ng-container>

--- a/libs/components/src/lib/components/tabs/components/tab.component.less
+++ b/libs/components/src/lib/components/tabs/components/tab.component.less
@@ -1,7 +1,8 @@
 :host {
   height: 100%;
   display: inline-flex;
-
+  position: relative;
+  z-index: 2;
   button {
     border: none;
     outline: none;
@@ -87,7 +88,7 @@
       border-bottom: 2px solid var(--prizm-grey-g10-g4);
 
       &:focus {
-        border-bottom-color: rgb(51 126 255 / 75%);
+        border-bottom-color: rgba(51, 126, 255, 75%);
       }
 
       &_active:not(:disabled) {

--- a/libs/components/src/lib/components/tabs/tabs.component.html
+++ b/libs/components/src/lib/components/tabs/tabs.component.html
@@ -1,4 +1,5 @@
 <div class="container">
+  <div class="line" *ngIf="showLine$ | async"></div>
   <div class="control" [class.control_active]="isLeftBtnActive">
     <button class="control__chevron" (click)="decrease()">
       <prizm-icon class="control__icon" [size]="16" iconClass="arrows-chevron-left"></prizm-icon>
@@ -61,6 +62,7 @@
               [closable]="tab.closable"
               [disabled]="tab.disabled"
               [attr.dropdown-tab]="true"
+              (click)="clickTab(i)"
               (closeTab)="closeTab(tabElement.idx)"
             >
             </prizm-tab>

--- a/libs/components/src/lib/components/tabs/tabs.component.less
+++ b/libs/components/src/lib/components/tabs/tabs.component.less
@@ -7,12 +7,21 @@
 
   .container {
     height: 100%;
-
+    width: 100%;
     display: flex;
     align-items: center;
 
     position: relative;
     overflow: hidden;
+
+    .line {
+      position: absolute;
+      height: 2px;
+      background-color: var(--prizm-grey-g10-g4);
+      width: 100%;
+      z-index: 1;
+      bottom: 0;
+    }
 
     .tabs {
       height: 100%;

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -15,8 +15,8 @@ import {
   ViewChild,
 } from '@angular/core';
 import { PrizmTabSize } from './tabs.interface';
-import { animationFrameScheduler, Subject, Subscription } from 'rxjs';
-import { debounceTime, filter, observeOn, takeUntil, tap } from 'rxjs/operators';
+import { animationFrameScheduler, Observable, Subject, Subscription } from 'rxjs';
+import { debounceTime, filter, map, observeOn, takeUntil, tap } from 'rxjs/operators';
 import { PrizmTabsService } from './tabs.service';
 import { PrizmTabComponent } from './components/tab.component';
 import { PrizmTabMenuItemDirective } from './tab-menu-item.directive';
@@ -57,6 +57,12 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
   public menuElements: QueryList<TemplateRef<PrizmTabComponent>>;
 
   override readonly testId_ = 'ui_tabs';
+  readonly showLine$: Observable<boolean> = this.tabsService.tabs$.pipe(
+    map(tabMap => {
+      const last = [...tabMap.values()].pop();
+      return last.type === 'line';
+    })
+  );
 
   public openLeft = false;
   public openRight = false;
@@ -186,5 +192,9 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
   public closeTab(idx: number): void {
     this.tabsService.getTabByIdx(idx)?.closeTab.emit();
     this.reCalculatePositions();
+  }
+
+  public clickTab(idx: number): void {
+    this.openLeft = this.openRight = false;
   }
 }

--- a/libs/components/src/lib/components/widget/widget.component.html
+++ b/libs/components/src/lib/components/widget/widget.component.html
@@ -1,4 +1,4 @@
-<prizm-card [shadow]="shadow" ш>
+<prizm-card [shadow]="shadow">
   <div class="header prizm-font-title-h4">
     <ng-container *polymorphOutlet="header">
       <div class="title">

--- a/libs/components/src/lib/directives/auto-resize/autoresize.directive.ts
+++ b/libs/components/src/lib/directives/auto-resize/autoresize.directive.ts
@@ -1,0 +1,58 @@
+import { AfterViewInit, Directive, ElementRef, HostListener, Input, OnDestroy, OnInit } from '@angular/core';
+import { Subject, timer } from 'rxjs';
+import { PrizmDestroyService, prizmFromMutationObserver$ } from '@prizm-ui/helpers';
+import { skip, switchMap, takeUntil, tap, throttleTime } from 'rxjs/operators';
+
+@Directive({
+  selector: `[prizmAutoResize]`,
+})
+export class PrizmAutoResizeDirective implements OnInit, AfterViewInit {
+  @Input() prizmAutoResize = true;
+  private readonly subject = new Subject<void>();
+  get scrollHeight(): number {
+    return this.elementRef.nativeElement.scrollHeight;
+  }
+  constructor(private elementRef: ElementRef, private destroy: PrizmDestroyService) {}
+
+  @HostListener(':input')
+  private onInput() {
+    this.resizeIfActive();
+  }
+
+  private resizeIfActive(): void {
+    if (!this.prizmAutoResize) return;
+    this.resize();
+  }
+
+  public ngOnInit(): void {
+    if (!this.prizmAutoResize) return;
+    if (this.elementRef.nativeElement.scrollHeight) {
+      setTimeout(() => this.resize());
+    }
+  }
+
+  public resize(): void {
+    this.elementRef.nativeElement.style.height = '0';
+    this.elementRef.nativeElement.style.height = this.scrollHeight + 'px';
+  }
+
+  ngAfterViewInit(): void {
+    timer(0)
+      .pipe(
+        switchMap(() =>
+          prizmFromMutationObserver$(this.elementRef.nativeElement, {
+            attributes: true,
+            characterData: true,
+          }).pipe(
+            // guard for infinite re invokes
+            throttleTime(100),
+            tap(() => {
+              this.resizeIfActive();
+            })
+          )
+        ),
+        takeUntil(this.destroy)
+      )
+      .subscribe();
+  }
+}

--- a/libs/components/src/lib/directives/auto-resize/autoresize.module.ts
+++ b/libs/components/src/lib/directives/auto-resize/autoresize.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { PrizmAutoResizeDirective } from './autoresize.directive';
+
+@NgModule({
+  declarations: [PrizmAutoResizeDirective],
+  exports: [PrizmAutoResizeDirective],
+})
+export class PrizmAutoResizeModule {}

--- a/libs/components/src/lib/directives/auto-resize/index.ts
+++ b/libs/components/src/lib/directives/auto-resize/index.ts
@@ -1,0 +1,2 @@
+export * from './autoresize.directive';
+export * from './autoresize.module';

--- a/libs/components/src/lib/directives/index.ts
+++ b/libs/components/src/lib/directives/index.ts
@@ -28,3 +28,4 @@ export * from './value-accessor';
 export * from './wrapper';
 export * from './sticky';
 export * from './native-value';
+export * from './auto-resize';

--- a/libs/components/src/lib/directives/skeleton/skeleton.directive.ts
+++ b/libs/components/src/lib/directives/skeleton/skeleton.directive.ts
@@ -6,17 +6,14 @@ import { prizmDefaultProp } from '@prizm-ui/core';
 })
 export class PrizmSkeletonDirective {
   @Input('prizmSkeletonText')
-  @HostBinding('class.prizm-skeleton_text')
   @prizmDefaultProp()
   isText = false;
 
   @Input('prizmSkeletonRounded')
-  @HostBinding('class.prizm-skeleton_rounded')
   @prizmDefaultProp()
   isRounded = false;
 
   @Input('prizmSkeletonShort')
-  @HostBinding('class.prizm-skeleton_short')
   @prizmDefaultProp()
   isShort = false;
 
@@ -24,4 +21,14 @@ export class PrizmSkeletonDirective {
   @HostBinding('class.prizm-skeleton')
   @prizmDefaultProp()
   active = true;
+
+  @HostBinding('class.prizm-skeleton_text') get prizmSkeletonText() {
+    return this.active && this.isText;
+  }
+  @HostBinding('class.prizm-skeleton_rounded') get prizmSkeletonRounded() {
+    return this.active && this.isRounded;
+  }
+  @HostBinding('class.prizm-skeleton_short') get prizmSkeletonShort() {
+    return this.active && this.isShort;
+  }
 }

--- a/libs/components/src/lib/directives/zone-event/zone-event.service.ts
+++ b/libs/components/src/lib/directives/zone-event/zone-event.service.ts
@@ -54,6 +54,7 @@ export class PrizmZoneEventService {
     }
   }
 
+  // TODO need refactoring (think about detect as in overlay-control)
   public getInsideListenedEvents(eventName: string): Observable<UIEvent> {
     return (
       this.insideListenedEvents$ ??

--- a/libs/components/src/lib/modules/mask/mask.module.ts
+++ b/libs/components/src/lib/modules/mask/mask.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-
 import { NgxMaskModule, IConfig } from 'ngx-mask';
 
 const maskConfig: Partial<IConfig> = {

--- a/libs/components/src/lib/modules/overlay/models.ts
+++ b/libs/components/src/lib/modules/overlay/models.ts
@@ -78,6 +78,7 @@ export interface PrizmOverlayContainerSize {
 
 export interface PrizmOverlayConfig {
   backdrop: boolean;
+  styleVars?: Record<string, unknown>;
   containerClass: string;
   wrapperClass: string;
   backdropClass: string;

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "description": "The main library for creating Angular components and elements using Prizm.",
   "private": false,

--- a/libs/helpers/package.json
+++ b/libs/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/helpers",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "description": "Library to make it easy to create Angular applications. Contains Injectables Service, RxJS utilities, directives, and standard pipes.",
   "private": false,

--- a/libs/helpers/src/lib/util/index.ts
+++ b/libs/helpers/src/lib/util/index.ts
@@ -4,3 +4,4 @@ export * from './rxjs';
 export * from './form';
 export * from './decorators';
 export * from './uuid';
+export * from './style';

--- a/libs/helpers/src/lib/util/rxjs/index.ts
+++ b/libs/helpers/src/lib/util/rxjs/index.ts
@@ -1,1 +1,2 @@
 export * from './rxjs';
+export * from './mutation-observer';

--- a/libs/helpers/src/lib/util/rxjs/mutation-observer.ts
+++ b/libs/helpers/src/lib/util/rxjs/mutation-observer.ts
@@ -1,0 +1,17 @@
+import { Observable } from 'rxjs';
+
+export function prizmFromMutationObserver$(
+  target: HTMLElement,
+  config?: MutationObserverInit
+): Observable<MutationRecord[]> {
+  return new Observable(observer => {
+    const mutation = new MutationObserver((mutations, instance) => {
+      observer.next(mutations);
+    });
+    mutation.observe(target, config);
+
+    return () => {
+      mutation.disconnect();
+    };
+  });
+}

--- a/libs/helpers/src/lib/util/rxjs/rxjs.ts
+++ b/libs/helpers/src/lib/util/rxjs/rxjs.ts
@@ -1,9 +1,16 @@
 import { Compare } from '../compare/compare';
-import { filter, map } from 'rxjs/operators';
-import { MonoTypeOperatorFunction, Observable, OperatorFunction, Subscriber } from 'rxjs';
+import { filter, map, throttleTime } from 'rxjs/operators';
+import { merge, MonoTypeOperatorFunction, Observable, OperatorFunction, Subscriber } from 'rxjs';
 
 export function filterFalsy<T>(): MonoTypeOperatorFunction<T> {
   return filter(Compare.isFalsy);
+}
+
+/**
+ * The observable that will be emitted first in the transmitted time interval is used
+ * */
+export function raceEmit<R = any>(time: number, ...sources: Observable<any>[]): Observable<R> {
+  return merge(...sources).pipe(throttleTime(time));
 }
 
 export function prizmElementResized$(...elements: Element[]): Observable<ResizeObserverEntry[]> {

--- a/libs/helpers/src/lib/util/style/index.ts
+++ b/libs/helpers/src/lib/util/style/index.ts
@@ -1,0 +1,1 @@
+export * from './style';

--- a/libs/helpers/src/lib/util/style/style.ts
+++ b/libs/helpers/src/lib/util/style/style.ts
@@ -1,0 +1,16 @@
+import { Compare } from '../compare';
+
+export function prizmStyleGetVars(obj: Record<string, unknown>): Record<string, string> {
+  return Object.entries(obj).reduce((base, [key, value]) => {
+    key = prizmStyleToSnake(key);
+    if (key.startsWith('--')) key = key.replace(/^--/, '');
+    if (key.startsWith('prizm')) key = key.replace(/^prizm-/, '');
+    key = `--prizm-${key}`;
+    base[key] = Compare.isNullish(value) ? '' : value?.toString() ?? '';
+    return base;
+  }, {} as Record<string, string>);
+}
+
+export function prizmStyleToSnake(str: string): string {
+  return str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
+}

--- a/libs/i18n/package.json
+++ b/libs/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/i18n",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "peerDependencies": {
     "@angular/core": "^14.2.12"
   },

--- a/libs/icons/base/package.json
+++ b/libs/icons/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Prizm UI base icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^14.2.12",
     "@angular/core": "^14.2.12",
-    "@prizm-ui/core": "^1.4.0"
+    "@prizm-ui/core": "^1.4.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json
+++ b/libs/icons/flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/flag-icons",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Prizm UI flags icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^14.2.12",
     "@angular/core": "^14.2.12",
-    "@prizm-ui/core": "^1.4.0"
+    "@prizm-ui/core": "^1.4.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/plugin/generators.json
+++ b/libs/plugin/generators.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "name": "plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "generators": {
     "migrate-from-cb3": {
       "factory": "./src/generators/migrate-from-cb3/index",

--- a/libs/plugin/package.json
+++ b/libs/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {
@@ -10,6 +10,6 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@prizm-ui/ast": "^1.4.0"
+    "@prizm-ui/ast": "^1.4.1"
   }
 }

--- a/libs/plugin/src/generators/update-version/generator.spec.ts
+++ b/libs/plugin/src/generators/update-version/generator.spec.ts
@@ -26,7 +26,7 @@ describe('nx-plugin:generator update-version', () => {
         projectType: 'library',
       })
     );
-    tree.write('/projects/project2/package.json', JSON.stringify({ version: '1.4.0' }));
+    tree.write('/projects/project2/package.json', JSON.stringify({ version: '1.4.1' }));
     tree.write(
       '/projects/project2/project.json',
       JSON.stringify({

--- a/libs/schematics/package.json
+++ b/libs/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/install",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Package installer @prizm-ui/* , Angular schematic ng-add",
   "schematics": "./src/collection.json",
   "private": false,

--- a/libs/schematics/src/ng-add/consts.ts
+++ b/libs/schematics/src/ng-add/consts.ts
@@ -11,21 +11,21 @@ interface ImportingModule {
 export const MAIN_PACKAGES: ReadonlyArray<Package> = [
   {
     name: '@prizm-ui/core',
-    version: '2.1.2',
+    version: '1.4.1',
   },
   {
     name: '@prizm-ui/components',
-    version: '2.1.2',
+    version: '1.4.1',
   },
   {
     name: '@prizm-ui/helpers',
-    version: '2.1.2',
+    version: '1.4.1',
   },
 ];
 
 export const INSTALL_PACKAGE: Readonly<Package> = {
   name: '@prizm-ui/install',
-  version: '2.1.2',
+  version: '1.4.1',
 };
 
 export const MAIN_MODULES: ReadonlyArray<ImportingModule> = [

--- a/libs/theme/package.json
+++ b/libs/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/theme",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "peerDependencies": {
     "@angular/common": "^14.2.12",
     "@angular/core": "^14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "husky": {
     "hooks": {


### PR DESCRIPTION
## [1.4.1](https://github.com/zyfra/Prizm) (31-07-2023)

### Features

- feat(components/autoresize): added directive and example how to use in textarea #544
- feat(components/sidebar): ability was added to control styles of wrapper elements #541
- feat(components/table): ability was added to control tree rows #366
- feat(components/dropdown-host): ability was added to control classes for dropdown #536
- feat(components/input-select): ability was added to control classes and styles for dropdown #536
- feat(components/input-multi-select): ability was added to control classes and styles for dropdown #536
- feat(components/breadcrumbs): added ability to work with projections #464
- feat(components/overlay): added new logic for detecting events from dynamic elements #411
- feat(helpers/rxjs): 'raceEmit' operator was added to detect first emit in the transmitted time interval between source streams
- feat(components/tabs): add full width underline #539

### Bug fixes

- fix(components/input-layout): problems with layout in outer #537
- fix(components/table): prizmThGroup throws an error together with structure directives #510
- fix(components/table): prizmThGroup throws an error together with structure directives #510
- fix(components/tabs): after build the color changes #543
- fix(components/overlay): the initial positioning of the window does not take right place #387
- fix(components/dropdown-host): wrong position of dropdown #394
- fix(components/dropdown-host): flickering on scroll #495
- fix(components/tabs): automatically close after select from menu #482
- fix(components/input-number): block not number symbols #486
- fix(components/widget): fixed the height in component prizm-widget-base-example #484
- fix(components/skeleton): styles are not removed when the skeleton is disabled #304
- fix(doc): font fixes #280 #302 #303 #460
