### PR TITLE
[draft] docs: example input tree select

### DIFF
--- a/apps/doc/src/app/components/input/input-multi-select/examples/with-object/multi-select-with-object-example.component.html
+++ b/apps/doc/src/app/components/input/input-multi-select/examples/with-object/multi-select-with-object-example.component.html
@@ -19,3 +19,18 @@
   </div>
   <ng-template #allTemplate> Выбрать все </ng-template>
 </ng-template>
+
+
+<prizm-input-layout label="Выберите из списка">
+  <prizm-input-tree-multi-select
+    [items]="items"
+    [selectAllItem]="selectAllItem"
+    [valueTemplate]="valueTemplate"
+    [formControl]="valueTreeControl"
+    [searchMatcher]="searchMatcher"
+    [identityMatcher]="identityMatcher"
+    [stringify]="stringify"
+    [searchable]="false"
+  >
+  </prizm-input-tree-multi-select>
+</prizm-input-layout>

--- a/apps/doc/src/app/components/input/input-multi-select/examples/with-object/multi-select-with-object-example.component.ts
+++ b/apps/doc/src/app/components/input/input-multi-select/examples/with-object/multi-select-with-object-example.component.ts
@@ -24,13 +24,16 @@ type PrizmItem = {
   ],
 })
 export class PrizmInputMultiSelectWithObjectExampleComponent {
-  readonly items: PrizmItem[] = [
-    { id: 1, name: 'Россия' },
-    { id: 2, name: 'США' },
-    { id: 3, name: 'ОАЭ' },
+  readonly items: (PrizmItem & any)[] = [
+    { id: 1, name: 'Россия', parentId: '0' },
+    { id: 2, name: 'США', parentId: '0' },
+    { id: 3, name: 'ОАЭ', parentId: '0' },
+    { id: 4, name: 'Москва', parentId: 1 },
   ];
+
   readonly selectAllItem = { id: -1, name: 'Выбрать все' };
   readonly valueControl = new UntypedFormControl([{ id: 3 }]);
+  readonly valueTreeControl = new UntypedFormControl([{ id: 3 }]);
   readonly searchMatcher: PrizmMultiSelectSearchMatcher<PrizmItem> = (search: string, item: PrizmItem) => {
     return item.name?.toLowerCase().includes(search.toLowerCase());
   };

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.module.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.module.ts
@@ -14,6 +14,9 @@ import { PrizmHintModule } from '../../../directives/hint';
 import { PrizmCheckboxModule } from '../../checkbox';
 import { PrizmIconModule } from '../../icon';
 import { PrizmInputMultiSelectComponent } from './input-multi-select.component';
+import {PrizmInputTreeMultiselectComponent} from "./input-tree-multiselect/input-tree-multiselect.component";
+import {PrizmTreeModule} from "../../tree";
+import {PrizmMapperPipeModule} from "../../../pipes";
 
 @NgModule({
   imports: [
@@ -35,8 +38,10 @@ import { PrizmInputMultiSelectComponent } from './input-multi-select.component';
     PrizmCheckboxModule,
     PrizmLifecycleModule,
     PrizmDropdownHostModule,
+    PrizmTreeModule,
+    PrizmMapperPipeModule,
   ],
-  declarations: [PrizmInputMultiSelectComponent],
-  exports: [PrizmInputMultiSelectComponent, PrizmInputTextModule],
+  declarations: [PrizmInputMultiSelectComponent, PrizmInputTreeMultiselectComponent],
+  exports: [PrizmInputMultiSelectComponent, PrizmInputTreeMultiselectComponent, PrizmInputTextModule],
 })
 export class PrizmInputMultiSelectModule {}

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-tree-multiselect/input-tree-multiselect.component.html
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-tree-multiselect/input-tree-multiselect.component.html
@@ -1,0 +1,81 @@
+<prizm-dropdown-host
+  #dropdownHostRef
+  [content]="dropdown"
+  [isOpen]="opened$ | async"
+  [prizmDropdownHost]="layoutComponent.el.nativeElement"
+  [prizmDropdownHostWidth]="dropdownWidth"
+  [prizmDropdownMinHeight]="minDropdownHeight"
+  [prizmDropdownMaxHeight]="maxDropdownHeight"
+  [dropdownStyles]="dropdownStyles"
+  [dropdownClasses]="dropdownClasses"
+  [ngSwitch]="layoutComponent.outer"
+  (isOpenChange)="$event && searchInputControl.setValue(''); opened$$.next($event)"
+>
+  <input
+    #focusableElementRef
+    [style.display]="layoutComponent.outer && value?.length ? 'none' : ''"
+    [style.visibility]="!layoutComponent.outer && value?.length ? 'hidden' : ''"
+    [disabled]="disabled"
+    [readonly]="true"
+    [placeholder]="placeholder"
+    [ngModelOptions]="{ standalone: true }"
+    [ngModel]="($any(value) | prizmCallFunc : stringify) ?? ''"
+    prizmInput
+  />
+
+  <ng-template #dropdown>
+    <prizm-tree
+      *ngFor="let item of data.children"
+      [prizmTreeController]="true"
+      [value]="item"
+      [content]="content"
+      [childrenHandler]="handler"
+    ></prizm-tree>
+
+    <ng-template #content let-item>
+      <prizm-checkbox [ngModel]="item | prizmMapper : getValue : map" (ngModelChange)="onChecked(item, $event)">
+        <span>{{ item.name }}</span>
+      </prizm-checkbox>
+    </ng-template>
+  </ng-template>
+</prizm-dropdown-host>
+
+<ng-container *prizmInputLayoutRight>
+  <ng-container
+    *polymorphOutlet="
+      icon || defaultIcon as iconName;
+      context: { opened: opened$ | async, disabled: disabled }
+    "
+  >
+    <prizm-icon
+      [class.opened]="opened$ | async"
+      [class.active]="(focused$ | async) || (opened$ | async)"
+      [class.icon-dropdown]="iconName === defaultIcon"
+      [iconClass]="$any(iconName)"
+      [class.disabled]="disabled"
+      (click)="safeOpenModal()"
+    >
+    </prizm-icon>
+  </ng-container>
+</ng-container>
+
+<ng-container *prizmInputLayoutInBody>
+  <div class="in-body-chips-box" *ngIf="value?.length">
+    <ng-container [ngTemplateOutlet]="chipsTemplate"> </ng-container>
+  </div>
+</ng-container>
+
+<ng-template #chipsTemplate>
+  <ng-container *prizmLet="selectedItemsChips$ | async as chips">
+    <prizm-chips
+      [style.max-width.px]="layoutComponent.el.nativeElement.clientWidth - button_layout_width"
+      [class.empty]="!chips.length"
+      [size]="$any(size)"
+      [class.inner]="inner"
+      [singleLine]="true"
+      [deletable]="!disabled && isChipsDeletable"
+      [chips]="chips"
+      (removeChipEvent)="removeChip($event)"
+    ></prizm-chips>
+  </ng-container>
+</ng-template>

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-tree-multiselect/input-tree-multiselect.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-tree-multiselect/input-tree-multiselect.component.ts
@@ -1,0 +1,85 @@
+import { AfterViewInit, ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PRIZM_EMPTY_ARRAY } from 'libs/core/src/lib/const';
+import { PrizmInputControl, PrizmInputNgControl } from '../../../input';
+import { PrizmInputMultiSelectComponent } from '../input-multi-select.component';
+import { TreeNode } from 'primeng/api';
+import { PrizmHandler } from 'libs/components/src/lib/types';
+import {take, takeUntil} from 'rxjs/operators';
+import { PrizmMultiSelectItemWithChecked } from '@prizm-ui/components';
+@Component({
+  selector: 'prizm-input-tree-multi-select',
+  templateUrl: './input-tree-multiselect.component.html',
+  styleUrls: ['../input-multi-select.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PrizmInputTreeMultiselectComponent),
+      multi: true,
+    },
+    PrizmDestroyService,
+    { provide: PrizmInputControl, useExisting: PrizmInputTreeMultiselectComponent },
+  ],
+})
+export class PrizmInputTreeMultiselectComponent<T> extends PrizmInputMultiSelectComponent<any> {
+  map = new Map<TreeNode, boolean>();
+
+  data: any = {};
+
+  override ngOnInit() {
+    super.ngOnInit();
+    this.items$.pipe(takeUntil(this.destroy$)).subscribe(items => {
+      this.data = { children: list_to_tree(items) };
+    });
+  }
+
+  readonly handler: PrizmHandler<TreeNode, readonly TreeNode[]> = item => item.children || PRIZM_EMPTY_ARRAY;
+
+  readonly getValue = (item: TreeNode, map: Map<TreeNode, boolean>): boolean | null => {
+    const flat = flatten(item);
+    const result = !!map.get(flat[0]);
+
+    for (let i = 0; i < flat.length; i++) {
+      if (result !== !!map.get(flat[i])) {
+        return null;
+      }
+    }
+
+    return result;
+  };
+
+  public onChecked(node: any, value: boolean): void {
+    // Just example
+    this.filteredItems$.pipe(take(1)).subscribe(items => this.select(items.find(n => n.obj.id === node.id)));
+  }
+}
+
+function flatten(item: TreeNode): readonly TreeNode[] {
+  return item.children ? item.children.map(flatten).reduce((arr, item) => [...arr, ...item], []) : [item];
+}
+
+function list_to_tree(list: any[]) {
+  const map = {};
+  let node = [];
+  const roots = [];
+
+  for (let i = 0; i < list.length; i += 1) {
+    // @ts-ignore
+    map[list[i].id] = i; // initialize the map
+    list[i].children = []; // initialize the children
+  }
+
+  for (let i = 0; i < list.length; i += 1) {
+    node = list[i];
+    // @ts-ignore
+    if (node.parentId !== '0') {
+      // @ts-ignore
+      list[map[node.parentId]].children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "1.2.1",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prizm-ui/sdk",
-      "version": "1.2.1",
+      "version": "2.1.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Не мержить! Сделан как пример.

![telegram-cloud-photo-size-2-5377708550115151411-x](https://github.com/zyfra/Prizm/assets/131881448/e70c7c99-78aa-4ca0-953c-c898d1a7ac10)

для примера был взят часть кода из tree и multiselect,
не prodaction ready, нужно доводить до ума, 

сделано через наследование,
еще можно собрать такой компонент из
` prizm chip item + input layout + tree + dropdown host`

----
### команде Prizm: 

что не ок ->
template у типов dropdown host нельзя менять на свой кастомный,
selectItem должен быть публичным и поддерживать прием оригинального контента, item
кажется для любых компонентов использующих dropdown host нужно иметь возможность подменять всецело его контент, легкая доработка.