### PR TITLE
fix(components/tabs): opening a dropdown with tabs

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.3-next.2, 2.1.5-next.2, 3.0.0-next.2](https://github.com/zyfra/Prizm) (17-08-2023)
+
+### Bug fixes
+
+- fix(components/tabs): opening a dropdown with tabs, it switches back to a tab that was not selected through the dropdown.
+
 ## [1.4.3-next.1, 2.1.5-next.1, 3.0.0-next.1](https://github.com/zyfra/Prizm) (17-08-2023)
 
 ### Features

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - fix(components/tabs): opening a dropdown with tabs, it switches back to a tab that was not selected through the dropdown.
+- fix(components/icon): icon name doesn't show in test id #589
 
 ## [1.4.3-next.1, 2.1.5-next.1, 3.0.0-next.1](https://github.com/zyfra/Prizm) (17-08-2023)
 

--- a/libs/components/src/lib/components/tabs/tabs.component.html
+++ b/libs/components/src/lib/components/tabs/tabs.component.html
@@ -62,7 +62,7 @@
               [closable]="tab.closable"
               [disabled]="tab.disabled"
               [attr.dropdown-tab]="true"
-              (click)="clickTab(i)"
+              (click)="clickTab()"
               (closeTab)="closeTab(tabElement.idx)"
             >
             </prizm-tab>

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -194,7 +194,7 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
     this.reCalculatePositions();
   }
 
-  public clickTab(idx: number): void {
+  public clickTab(): void {
     this.openLeft = this.openRight = false;
   }
 }

--- a/libs/icons/base/src/lib/prizm-icons.component.ts
+++ b/libs/icons/base/src/lib/prizm-icons.component.ts
@@ -31,9 +31,11 @@ import { PrizmAbstractTestId, prizmPx } from '@prizm-ui/core';
 })
 export class PrizmIconsSvgComponent extends PrizmAbstractTestId {
   private svgIcon: SVGElement;
-
+  private iconName: string;
   @Input()
   set name(iconName: string) {
+    this.iconName = iconName;
+
     if (this.svgIcon) {
       this.element.nativeElement.removeChild(this.svgIcon);
     }
@@ -48,7 +50,7 @@ export class PrizmIconsSvgComponent extends PrizmAbstractTestId {
   color: string;
 
   override get generateManeTestId(): string {
-    return 'ui_icon' + (this.name ? `--${this.name}` : '');
+    return 'ui_icon' + (this.iconName ? `--${this.iconName}` : '');
   }
 
   @HostBinding('style.width')


### PR DESCRIPTION
## [1.4.3-next.2, 2.1.5-next.2, 3.0.0-next.2](https://github.com/zyfra/Prizm) (17-08-2023)

### Bug fixes

- fix(components/tabs): opening a dropdown with tabs, it switches back to a tab that was not selected through the dropdown.
- fix(components/icon): icon name doesn't show in test id #589

