### PR TITLE
feat(components/input-layout-date-time-range): example with formgroup…

### DIFF
--- a/apps/doc/src/app/components/input/input-layout-date-time-range/examples/form-group/input-layout-date-time-range-form-group-example.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/examples/form-group/input-layout-date-time-range-form-group-example.component.html
@@ -1,0 +1,13 @@
+<div [formGroup]="formGroup">
+  <prizm-input-layout label="Период действия расписания">
+    <prizm-input-layout-date-time-range
+      size="l"
+      formControlName="period"
+    ></prizm-input-layout-date-time-range>
+  </prizm-input-layout>
+</div>
+
+<h3>
+  Value:
+  <b>{{ formGroup.get('period')?.value }}</b>
+</h3>

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/examples/form-group/input-layout-date-time-range-form-group-example.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/examples/form-group/input-layout-date-time-range-form-group-example.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { PrizmDateTimeRange, PrizmDay, PrizmDayRange, PrizmTime, PrizmTimeRange } from '@prizm-ui/components';
+
+@Component({
+  selector: 'prizm-input-layout-date-time-range-form-group-example',
+  templateUrl: './input-layout-date-time-range-form-group-example.component.html',
+  styles: [
+    `
+      :host {
+        --prizm-input-layout-width: 23rem;
+      }
+
+      .box {
+        display: flex;
+        gap: 1rem;
+      }
+    `,
+  ],
+})
+export class PrizmInputLayoutDateTimeRangeFormGroupExampleComponent {
+  formGroup = new FormGroup({
+    period: new FormControl(
+      this.toPrizmPeriod({
+        from: null,
+        to: null,
+      })
+    ),
+  });
+
+  private toPrizmPeriod(value: any): PrizmDateTimeRange {
+    const now = new Date();
+    const start = value.from ?? new Date(now.getFullYear() - 5, now.getMonth(), now.getDate());
+    const end =
+      value.to ??
+      (value.from
+        ? new Date(value.from.getFullYear() + 5, value.from.getMonth(), value.from.getDate())
+        : new Date(now.getFullYear() + 5, now.getMonth(), now.getDate()));
+    const fromDay = new PrizmDay(start.getFullYear(), start.getMonth(), start.getDate());
+    const toDay = new PrizmDay(end.getFullYear(), end.getMonth(), end.getDate());
+    const dayRange = new PrizmDayRange(fromDay, toDay);
+    const fromTime = new PrizmTime(start.getHours(), start.getMinutes());
+    const toTime = new PrizmTime(end.getHours(), end.getMinutes());
+    const timeRange = new PrizmTimeRange(fromTime, toTime);
+    return new PrizmDateTimeRange(dayRange, timeRange);
+  }
+}

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.html
@@ -3,6 +3,9 @@
     <prizm-doc-example id="base" [content]="exampleBase" heading="Base">
       <prizm-input-layout-date-time-range-base-example></prizm-input-layout-date-time-range-base-example>
     </prizm-doc-example>
+    <prizm-doc-example id="form-group" [content]="exampleFormGroup" heading="Form Group">
+      <prizm-input-layout-date-time-range-form-group-example></prizm-input-layout-date-time-range-form-group-example>
+    </prizm-doc-example>
     <prizm-doc-example id="disabled" [content]="exampleDisabled" heading="Disabled">
       <prizm-input-layout-date-time-range-disabled-example>
       </prizm-input-layout-date-time-range-disabled-example>

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.ts
@@ -56,6 +56,12 @@ export class InputLayoutDateTimeRangeComponent {
     TypeScript: import('./examples/base/input-layout-date-time-range-base-example.component.ts?raw'),
     HTML: import('./examples/base/input-layout-date-time-range-base-example.component.html?raw'),
   };
+  readonly exampleFormGroup: TuiDocExample = {
+    TypeScript: import(
+      './examples/form-group/input-layout-date-time-range-form-group-example.component.ts?raw'
+    ),
+    HTML: import('./examples/form-group/input-layout-date-time-range-form-group-example.component.html?raw'),
+  };
 
   readonly exampleDisabled: TuiDocExample = {
     TypeScript: import('./examples/disabled/input-layout-date-time-range-disabled-example.component.ts?raw'),

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.module.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { InputLayoutDateTimeRangeComponent } from './input-layout-date-time-range.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -8,6 +8,7 @@ import { PrizmInputLayoutDateTimeRangeBaseExampleComponent } from './examples/ba
 import { PolymorphModule, PrizmInputLayoutDateTimeRangeModule } from '@prizm-ui/components';
 import { PrizmInputLayoutDateTimeRangeDisabledExampleComponent } from './examples/disabled/input-layout-date-time-range-disabled-example.component';
 import { PrizmInputNativeDateRangeBaseExampleComponent } from './examples/native-date/input-native-date-time-range-base-example.component';
+import { PrizmInputLayoutDateTimeRangeFormGroupExampleComponent } from './examples/form-group/input-layout-date-time-range-form-group-example.component';
 
 @NgModule({
   imports: [
@@ -20,6 +21,7 @@ import { PrizmInputNativeDateRangeBaseExampleComponent } from './examples/native
     RouterModule.forChild(prizmDocGenerateRoutes(InputLayoutDateTimeRangeComponent)),
   ],
   declarations: [
+    PrizmInputLayoutDateTimeRangeFormGroupExampleComponent,
     PrizmInputLayoutDateTimeRangeBaseExampleComponent,
     PrizmInputLayoutDateTimeRangeDisabledExampleComponent,
     PrizmInputNativeDateRangeBaseExampleComponent,


### PR DESCRIPTION
### Features
- feat(components/input-layout-date-time-range): example with formGroup was added #565'