### PR TITLE
#697 fix(components/overlay): overlay cached inputs

### DIFF
--- a/apps/doc/src/app/components/dialogs/dialog/dialog.module.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog.module.ts
@@ -6,6 +6,8 @@ import {
   PolymorphModule,
   PrizmButtonModule,
   PrizmDialogModule,
+  PrizmInputCommonModule,
+  PrizmInputSelectModule,
   PrizmRadioButtonModule,
 } from '@prizm-ui/components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -25,6 +27,8 @@ import { PrizmDialogServiceWithParentExampleComponent } from './examples/with-pa
     PrizmDialogModule,
     PrizmRadioButtonModule,
     RouterModule.forChild(prizmDocGenerateRoutes(DialogComponent)),
+    PrizmInputCommonModule,
+    PrizmInputSelectModule,
   ],
   declarations: [
     PrizmDialogServiceExampleComponent,

--- a/apps/doc/src/app/components/dialogs/dialog/examples/with-parent/with-parent.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/with-parent/with-parent.component.html
@@ -12,13 +12,11 @@
 ></div>
 
 <ng-template #contentExample>
-  <div style="height: 100%; display: flex; align-items: center">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-    ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-    fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-    mollit anim id est laborum.
-  </div>
+  <h4>Check Dropdown Host Parent Container And Position</h4>
+  <prizm-input-layout label="Validators">
+    <prizm-input-select #input [formControl]="control" [items]="items"> </prizm-input-select>
+    <ng-template [control]="input" prizmInputStatusText>dddd</ng-template>
+  </prizm-input-layout>
 </ng-template>
 
 <div style="margin-top: 16px">

--- a/apps/doc/src/app/components/dialogs/dialog/examples/with-parent/with-parent.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/with-parent/with-parent.component.ts
@@ -1,44 +1,45 @@
 import { Component, ElementRef, Inject, TemplateRef, ViewChild } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 import { PrizmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-dialog-service-with-parent-example',
   templateUrl: './with-parent.component.html',
-  styles: [
-    `
-      .box {
-        display: flex;
-        gap: 1rem;
-      }
-    `,
-  ],
 })
 export class PrizmDialogServiceWithParentExampleComponent {
-  @ViewChild('contentExample') contentExample!: TemplateRef<any>;
-  @ViewChild('parentPanel') parentPanel!: ElementRef<any>;
+  @ViewChild('contentExample') contentExample!: TemplateRef<never>;
+  @ViewChild('parentPanel') parentPanel!: ElementRef<never>;
   public positionVariants: PrizmOverlayInsidePlacement[] = Object.values(PrizmOverlayInsidePlacement);
   public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
   public backdrop = false;
   public dismissible = true;
 
+  readonly items = [
+    'One',
+    'Two',
+    'Three',
+    'Very long text with a lot of characters and spaces and other stuff and things',
+  ];
+  readonly control = new FormControl(this.items[1], [Validators.required]);
+
   constructor(@Inject(PrizmDialogService) private readonly dialogService: PrizmDialogService) {}
 
   public show(): void {
     this.dialogService
-      .open(
-        `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
-        {
-          closeable: true,
-          header: 'Header',
-          width: 500,
-          closeWord: 'Продолжить',
-          position: this.position,
-          dismissible: this.dismissible,
-          parentContainer: this.parentPanel.nativeElement,
-          backdrop: this.backdrop,
-          size: 'm',
-        }
-      )
+      .open(this.contentExample, {
+        closeable: true,
+        header: 'Header',
+        width: 500,
+        closeWord: 'Продолжить',
+        position: this.position,
+        dismissible: this.dismissible,
+        parentContainer: this.parentPanel.nativeElement,
+        backdrop: this.backdrop,
+        size: 'm',
+        styleVars: {
+          dialogContentPadding: '5px 10px 25px 20px',
+        },
+      })
       .subscribe();
   }
 }

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/with-parent/with-parent.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/with-parent/with-parent.component.html
@@ -12,13 +12,8 @@
 ></div>
 
 <ng-template #contentExample>
-  <div style="height: 100%; display: flex; align-items: center">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-    ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-    fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-    mollit anim id est laborum.
-  </div>
+  <h4>Check Dropdown Host Parent Container And Position</h4>
+  <prizm-select [formControl]="control" [items]="items" label="Validators"> </prizm-select>
 </ng-template>
 
 <div style="margin-top: 16px">

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/with-parent/with-parent.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/with-parent/with-parent.component.ts
@@ -1,21 +1,14 @@
 import { Component, ElementRef, Inject, TemplateRef, ViewChild } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 import { PrizmOverlayInsidePlacement, PrizmSidebarService } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-sidebar-with-parent-example',
   templateUrl: './with-parent.component.html',
-  styles: [
-    `
-      .box {
-        display: flex;
-        gap: 1rem;
-      }
-    `,
-  ],
 })
 export class PrizmSidebarWithParentExampleComponent {
-  @ViewChild('contentExample') contentExample!: TemplateRef<any>;
-  @ViewChild('parentPanel') parentPanel!: ElementRef<any>;
+  @ViewChild('contentExample') contentExample!: TemplateRef<never>;
+  @ViewChild('parentPanel') parentPanel!: ElementRef<never>;
   public positionVariants: PrizmOverlayInsidePlacement[] = [
     PrizmOverlayInsidePlacement.LEFT,
     PrizmOverlayInsidePlacement.RIGHT,
@@ -25,6 +18,14 @@ export class PrizmSidebarWithParentExampleComponent {
   public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
   public backdrop = false;
   public dismissible = false;
+
+  readonly items = [
+    'One',
+    'Two',
+    'Three',
+    'Very long text with a lot of characters and spaces and other stuff and things',
+  ];
+  readonly control = new FormControl(this.items[1], [Validators.required]);
 
   constructor(@Inject(PrizmSidebarService) private readonly sidebarService: PrizmSidebarService) {}
 
@@ -42,16 +43,9 @@ export class PrizmSidebarWithParentExampleComponent {
         dismissible: this.dismissible,
         size: 'm',
         parentContainer: this.parentPanel.nativeElement,
-        styleVars: (
-          [
-            PrizmOverlayInsidePlacement.TOP,
-            PrizmOverlayInsidePlacement.BOTTOM,
-          ] as Array<PrizmOverlayInsidePlacement>
-        ).includes(this.position)
-          ? {
-              sidebarContentPadding: '5px 10px',
-            }
-          : undefined,
+        styleVars: {
+          sidebarContentPadding: '5px 10px',
+        },
       })
       .subscribe();
   }

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.module.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.module.ts
@@ -5,10 +5,13 @@ import { RouterModule } from '@angular/router';
 import {
   PolymorphModule,
   PrizmButtonModule,
+  PrizmInputCommonModule,
   PrizmInputIconButtonModule,
+  PrizmInputSelectModule,
   PrizmRadioButtonModule,
   PrizmScrollbarModule,
   PrizmSidebarModule,
+  PrizmSelectModule,
 } from '@prizm-ui/components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SidebarComponent } from './sidebar.component';
@@ -35,6 +38,9 @@ import { PrizmSidebarOnlyConfirmButtonExampleComponent } from './examples/only-c
     PrizmScrollbarModule,
     PrizmRadioButtonModule,
     RouterModule.forChild(prizmDocGenerateRoutes(SidebarComponent)),
+    PrizmInputCommonModule,
+    PrizmInputSelectModule,
+    PrizmSelectModule,
   ],
   declarations: [
     PrizmSidebarOnlyConfirmButtonExampleComponent,


### PR DESCRIPTION
[ISSUE-697](https://github.com/zyfra/Prizm/issues/697)
- Очистка кэшируемых input-параметров при работе с overlay.
- Доработаны примеры в apps с демонстрацией изменений (сайдбар и диалог, блоки WithParent).