### PR TITLE
#711 feat(components/navigation-menu): extend PrizmNavigationMenuItem with…

### DIFF
--- a/apps/doc/src/app/components/navigation-menu/examples/navigation-menu-basic-example/navigation-menu.constants.ts
+++ b/apps/doc/src/app/components/navigation-menu/examples/navigation-menu-basic-example/navigation-menu.constants.ts
@@ -107,18 +107,20 @@ export const MOKED_ITEMS: CustomItem[] = [
       },
       {
         id: v4(),
-        text: '2 (text)',
+        text: '2 (text) [a group with nested group items]',
         icon: 'documents_folders_folder',
+        isGroup: true,
         children: [
           {
             id: v4(),
-            text: '2-1 (text)',
+            text: '2-1 (text) [not a group]',
             icon: 'documents_folders_folder',
           },
           {
             id: v4(),
-            text: '2-2 (text)',
+            text: '2-2 (text) [a group]',
             icon: 'documents_folders_folder',
+            isGroup: true,
             children: [
               {
                 id: v4(),

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.html
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.html
@@ -4,9 +4,9 @@
   [class.prizm-navigation-menu-item_hovered]="isHovered"
   [class.prizm-navigation-menu-item_expandable]="isExpandable"
   [tabindex]="0"
-  (keydown.space)="setActive.emit(item)"
-  (keydown.enter)="setActive.emit(item)"
-  (click)="setActive.emit(item)"
+  (keydown.space)="interaction.emit(item)"
+  (keydown.enter)="interaction.emit(item)"
+  (click)="interaction.emit(item)"
   (prizmHoveredChange)="isHovered = $event"
 >
   <prizm-icons-svg

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.ts
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.ts
@@ -16,7 +16,7 @@ import { PrizmAbstractTestId } from '@prizm-ui/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PrizmNavigationMenuItemComponent<T> extends PrizmAbstractTestId {
-  @Output() setActive = new EventEmitter<InternalPrizmNavigationMenuItem<T>>();
+  @Output() interaction = new EventEmitter<InternalPrizmNavigationMenuItem<T>>();
   @Output() toggleExpanded = new EventEmitter<InternalPrizmNavigationMenuItem<T>>();
   @Output() goToParentItem = new EventEmitter<InternalPrizmNavigationMenuItem<T>>();
   @Output() goToRootItem = new EventEmitter<InternalPrizmNavigationMenuItem<T>>();

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.html
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.html
@@ -17,7 +17,7 @@
       [isExpandable]="menuItemsChildrenHandler(item).length > 0"
       [isExpanded]="getItemIsExpanded(item)"
       (toggleExpanded)="treeCtrl.toggleByItemValue($event)"
-      (setActive)="activeItemChanged.emit($event)"
+      (interaction)="handleInteraction($event, treeCtrl)"
       (goToParentItem)="goToParentItem.emit($event)"
       (goToRootItem)="goToRootItem.emit($event)"
     ></prizm-navigation-menu-item>

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.ts
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.ts
@@ -15,6 +15,7 @@ import { PrizmNavigationMenuItemComponent } from '../prizm-navigation-menu-item/
 import { findItem } from '../../helpers/prizm-navigation-menu-items-helpers';
 import { PRIZM_NAVIGATION_MENU_CHILDREN_HANDLER, PrizmNavigationMenuChildrenHandler } from '../../tokens';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
+import { PrizmTreeControllerDirective } from '../../../tree';
 
 @Component({
   selector: 'prizm-navigation-menu-items',
@@ -61,6 +62,17 @@ export class PrizmNavigationMenuItemsComponent<
     public cdr: ChangeDetectorRef
   ) {
     super();
+  }
+
+  public handleInteraction(
+    item: InternalPrizmNavigationMenuItem<T>,
+    treeCtrl: PrizmTreeControllerDirective<InternalPrizmNavigationMenuItem<T>>
+  ): void {
+    if (item.isGroup) {
+      treeCtrl.toggleByItemValue(item);
+    } else {
+      this.activeItemChanged.emit(item);
+    }
   }
 
   public handleExpandedChanged({

--- a/libs/components/src/lib/components/navigation-menu/interfaces/prizm-navigation-menu-items.interfaces.ts
+++ b/libs/components/src/lib/components/navigation-menu/interfaces/prizm-navigation-menu-items.interfaces.ts
@@ -11,6 +11,8 @@ export interface PrizmNavigationMenuItem {
   text: string;
   extraTemplate?: TemplateRef<unknown> | null;
   icon?: string | null;
+  /** If set to true - interaction with item will toggle it's expanded state */
+  isGroup?: boolean;
   children?: PrizmNavigationMenuItem[];
 }
 


### PR DESCRIPTION
https://github.com/zyfra/Prizm/issues/711

Проверить можно будет на сайте документации (базовый пример https://prizm.site/components/navigation-menu#base) - добавил одной из веток меню элементы со флагом isGroup