### PR TITLE
#566 fix(components/input-layout-date-relative): relative date input validation

### DIFF
--- a/libs/components/src/lib/components/input/input-date-relative/input-date-relative.utils.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-date-relative.utils.ts
@@ -50,7 +50,7 @@ export function RenderText(model: RelativeDateModel): string {
 
   result += renderTimeMap.get(model.time) || '';
   result += direction || '';
-  result += model.number || '1';
+  result += model.number || '';
   result += period || '';
 
   return result;

--- a/libs/components/src/lib/components/input/input-date-relative/input-date-relative.utils.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-date-relative.utils.ts
@@ -22,11 +22,13 @@ export function UpdateActiveItem<T>(items: RelativeDateMenuItem<T>[], id: T): Re
   });
 }
 
+type ExtendedRelativeDateModel = RelativeDateModel & { wrongFormat?: boolean };
+
 /**
  * Parse input text to model
  */
-export function ParseTextInput(text: string): RelativeDateModel {
-  const result: RelativeDateModel = {} as RelativeDateModel;
+export function ParseTextInput(text: string): ExtendedRelativeDateModel {
+  const result: ExtendedRelativeDateModel = {} as ExtendedRelativeDateModel;
 
   const regexMatch = new RegExp(MatchPattern);
   const match = regexMatch.exec(text) ?? [];
@@ -35,6 +37,7 @@ export function ParseTextInput(text: string): RelativeDateModel {
   result.direction = directionMap.get(match[2]) as any;
   result.period = periodMap.get(match[4]) as any;
   result.number = (match[3] as any) || '';
+  result.wrongFormat = text !== match[0];
 
   return result;
 }

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   ElementRef,
   forwardRef,
-  HostBinding,
   Inject,
   Injector,
   Input,
@@ -12,9 +11,11 @@ import {
   ViewChild,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { prizmDefaultProp } from '@prizm-ui/core';
-import { prizmIsNativeFocusedIn } from '../../../util/is-native-focused-in';
+import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmLanguageInputLayoutDateRelative } from '@prizm-ui/i18n';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+
 import {
   getDefaultRelativeDateMenuItems,
   IdByGroup,
@@ -25,15 +26,11 @@ import {
   RelativeDateTimeId,
 } from './input-date-relative.models';
 import { ParseTextInput, RenderText, UpdateActiveItem } from './input-date-relative.utils';
-import { PRIZM_DATE_RIGHT_BUTTONS } from '../../../tokens/date-extra-buttons';
-import { PrizmDateButton } from '../../../types/date-button';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
-import { PrizmInputControl } from '../common/base/input-control.class';
-import { PrizmInputNgControl } from '../common/base/input-ng-control.class';
-import { PrizmInputStatusTextDirective } from '../common';
-import { PRIZM_CRON, PRIZM_INPUT_LAYOUT_DATE_RELATIVE } from '../../../tokens';
-import { PrizmLanguageInputLayoutDateRelative } from '@prizm-ui/i18n';
+import { PrizmInputStatusTextDirective, PrizmInputNgControl, PrizmInputControl } from '../common';
+import { PRIZM_DATE_RIGHT_BUTTONS, PRIZM_INPUT_LAYOUT_DATE_RELATIVE } from '../../../tokens';
+import { PrizmDateButton } from '../../../types';
 import { prizmI18nInitWithKey } from '../../../services';
+import { prizmIsNativeFocusedIn } from '../../../util';
 
 const MenuItems: RelativeDateMenuItems = getDefaultRelativeDateMenuItems();
 
@@ -115,7 +112,7 @@ export class PrizmInputLayoutDateRelativeComponent
   public valueChange(value: string) {
     this.parseInputValue(value);
     this.actualizeMenu();
-    this.actualizeInput();
+    this.updateTouchedAndValue(value);
   }
 
   public ngOnDestroy(): void {
@@ -135,6 +132,9 @@ export class PrizmInputLayoutDateRelativeComponent
 
       case 'period':
         this.activePeriodId = <IdByGroup<'period'>>item.id;
+        if (!this.activeNumber) {
+          this.activeNumber = '1';
+        }
         break;
     }
 
@@ -147,9 +147,7 @@ export class PrizmInputLayoutDateRelativeComponent
    * Parses control input value
    */
   private parseInputValue(value: string): void {
-    const textInput = value;
-
-    const model = ParseTextInput(textInput);
+    const model = ParseTextInput(value);
 
     this.activeTimeId = model.time;
     this.activeDirectionId = model.direction;
@@ -165,7 +163,7 @@ export class PrizmInputLayoutDateRelativeComponent
 
   public get focused(): boolean {
     return !!(
-      this.focusableElement?.nativeElement && prizmIsNativeFocusedIn(this.focusableElement?.nativeElement)
+      this.focusableElement?.nativeElement && prizmIsNativeFocusedIn(this.focusableElement!.nativeElement)
     );
   }
 
@@ -179,9 +177,7 @@ export class PrizmInputLayoutDateRelativeComponent
       direction: this.activeDirectionId,
       period: this.activePeriodId,
     });
-
-    this.markAsTouched();
-    this.updateValue(stringValue);
+    this.updateTouchedAndValue(stringValue);
   }
 
   public override clear(ev: MouseEvent): void {
@@ -211,5 +207,10 @@ export class PrizmInputLayoutDateRelativeComponent
     } else {
       this.isOpen = false;
     }
+  }
+
+  private updateTouchedAndValue(value: string | null): void {
+    this.markAsTouched();
+    this.updateValue(value);
   }
 }

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -172,7 +172,7 @@ export class PrizmInputLayoutDateRelativeComponent
 
   public get focused(): boolean {
     return !!(
-      this.focusableElement?.nativeElement && prizmIsNativeFocusedIn(this.focusableElement!.nativeElement)
+      this.focusableElement?.nativeElement && prizmIsNativeFocusedIn(this.focusableElement.nativeElement)
     );
   }
 

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -88,6 +88,7 @@ export class PrizmInputLayoutDateRelativeComponent
   private activeDirectionId!: RelativeDateDirectionId;
   private activePeriodId!: RelativeDatePeriodId;
   private activeNumber = '';
+  private activeWrongFormat = false;
 
   private readonly subscriptions = new Subscription();
 
@@ -112,6 +113,13 @@ export class PrizmInputLayoutDateRelativeComponent
   public valueChange(value: string) {
     this.parseInputValue(value);
     this.actualizeMenu();
+    if (!this.activeWrongFormat) {
+      if (this.activePeriodId && !this.activeNumber) {
+        this.activeNumber = '1';
+        this.actualizeInput();
+        return;
+      }
+    }
     this.updateTouchedAndValue(value);
   }
 
@@ -153,6 +161,7 @@ export class PrizmInputLayoutDateRelativeComponent
     this.activeDirectionId = model.direction;
     this.activeNumber = model.number;
     this.activePeriodId = model.period;
+    this.activeWrongFormat = !!model.wrongFormat;
   }
 
   public get nativeFocusableElement(): HTMLInputElement | null {

--- a/libs/i18n/src/lib/languages/russian/input-date-layout-relative.ts
+++ b/libs/i18n/src/lib/languages/russian/input-date-layout-relative.ts
@@ -2,6 +2,6 @@ import { PrizmLanguageInputLayoutDateRelative } from '../../interfaces';
 
 export const PRIZM_RUSSIAN_INPUT_LAYOUT_DATE_RELATIVE: PrizmLanguageInputLayoutDateRelative = {
   inputLayoutDateRelative: {
-    wrongFormat: 'Не правильный формат данных',
+    wrongFormat: 'Неправильный формат данных',
   },
 };


### PR DESCRIPTION
[#566](https://github.com/zyfra/Prizm/issues/566)
- Исправлена проблема с валидацией относительной даты в компоненте InputLayoutDateRelative.