### PR TITLE
fix: disabled sync between layout in in put #771

### DIFF
--- a/apps/doc/src/app/components/input/textarea/examples/textarea-basic-example/textarea-basic-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-basic-example/textarea-basic-example.component.html
@@ -1,3 +1,3 @@
-<prizm-input-layout label="Заголовок">
-  <textarea [height]="70" prizmInput></textarea>
+<prizm-input-layout [forceClear]="true" label="Заголовок">
+  <textarea [height]="70" [formControl]="value" prizmInput></textarea>
 </prizm-input-layout>

--- a/apps/doc/src/app/components/input/textarea/examples/textarea-basic-example/textarea-basic-example.component.ts
+++ b/apps/doc/src/app/components/input/textarea/examples/textarea-basic-example/textarea-basic-example.component.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 
 @Component({
   selector: 'prizm-textarea-basic-example',
@@ -6,4 +7,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   styleUrls: ['./textarea-basic-example.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TextareaBasicExampleComponent {}
+export class TextareaBasicExampleComponent {
+  public value = new FormControl('222', [Validators.required, Validators.maxLength(10)]);
+}

--- a/apps/doc/src/app/components/side-menu/examples/side-menu-example-basic/side-menu-example-basic.component.html
+++ b/apps/doc/src/app/components/side-menu/examples/side-menu-example-basic/side-menu-example-basic.component.html
@@ -37,7 +37,7 @@
               <prizm-icon
                 class="instruments__icon"
                 [size]="16"
-                iconClass="cansel-delete-content"
+                iconClass="cancel-delete-content"
               ></prizm-icon>
               <prizm-icon class="instruments__icon" [size]="16" iconClass="tools-content-save"></prizm-icon>
             </div>

--- a/libs/components/assets/icon-codepoints.json
+++ b/libs/components/assets/icon-codepoints.json
@@ -701,7 +701,7 @@
   "cancel-delete-line": {
     "content": ""
   },
-  "cansel-delete-content": {
+  "cancel-delete-content": {
     "content": ""
   },
   "cansel-delete-file": {

--- a/libs/components/src/lib/components/icon/icon-16-definitions.ts
+++ b/libs/components/src/lib/components/icon/icon-16-definitions.ts
@@ -283,7 +283,7 @@ export const Icon16Defs = [
       'cancel-close-circle',
       'cancel-close',
       'cancel-delete-line',
-      'cansel-delete-content',
+      'cancel-delete-content',
       'cansel-delete-file',
     ],
   },

--- a/libs/components/src/lib/components/icon/icon-definitions.ts
+++ b/libs/components/src/lib/components/icon/icon-definitions.ts
@@ -281,7 +281,7 @@ export const IconDefs = [
       'cancel-close-small',
       'cancel-close',
       'cancel-delete-line',
-      'cansel-delete-content',
+      'cancel-delete-content',
       'cansel-delete-file',
     ],
   },

--- a/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
+++ b/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
@@ -121,6 +121,7 @@ export abstract class PrizmInputNgControl<T>
   }
 
   public setDisabledState(isDisabled: boolean) {
+    this.stateChanges.next();
     this.checkControlUpdate();
   }
 
@@ -141,6 +142,7 @@ export abstract class PrizmInputNgControl<T>
         : value;
 
     this.refreshLocalValue(this.fromControlValue(controlValue));
+    this.stateChanges.next();
   }
 
   private refreshLocalValue(value: T | null): void {

--- a/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
+++ b/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
@@ -18,9 +18,12 @@ export abstract class PrizmInputNgControl<T>
   readonly changeDetectorRef!: ChangeDetectorRef;
   readonly layoutComponent!: PrizmInputLayoutComponent;
   private previousInternalValue$$ = new BehaviorSubject<T | null>(null);
-  private lastState = {
-    touched: false,
-    pristine: true,
+  private readonly lastSyncedState: {
+    touched: boolean | null;
+    pristine: boolean | null;
+  } = {
+    touched: null,
+    pristine: null,
   };
   onChange: (val: T) => void = PRIZM_EMPTY_FUNCTION;
   onTouch: (val: T) => void = PRIZM_EMPTY_FUNCTION;
@@ -214,12 +217,12 @@ export abstract class PrizmInputNgControl<T>
   }
 
   private updateLayoutOnTouched(): void {
-    if (this.ngControl.pristine !== this.lastState.pristine) {
-      this.lastState.pristine = !!this.ngControl.pristine;
-      this.stateChanges.next();
-    }
-    if (this.ngControl.touched !== this.lastState.touched) {
-      this.lastState.touched = !!this.ngControl.touched;
+    if (
+      this.ngControl.pristine !== this.lastSyncedState.pristine ||
+      this.ngControl.touched !== this.lastSyncedState.touched
+    ) {
+      this.lastSyncedState.touched = this.ngControl.touched;
+      this.lastSyncedState.pristine = this.ngControl.pristine;
       this.stateChanges.next();
     }
   }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.html
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.html
@@ -36,11 +36,11 @@
         <span class="prizm-input-label-required" *ngIf="$.required">*</span>
       </label>
       <button
-        class="prizm-input-label-clear-btn"
+        class="prizm-input-label-clear-btn clear-icon"
         [interactive]="true"
         [disabled]="$.disabled"
         (click)="onClearClick($event)"
-        prizmInputIconButton="cansel-delete-content"
+        prizmInputIconButton="cancel-delete-content"
       ></button>
     </div>
   </ng-template>
@@ -85,12 +85,12 @@
         </div>
 
         <button
-          class="prizm-input-button-default {{ showStatusButton ? '' : 'alone' }}"
+          class="prizm-input-button-default clear-icon {{ showStatusButton ? '' : 'alone' }}"
           *ngIf="showClearButton"
           [interactive]="true"
           [disabled]="$.disabled"
           (click)="onClearClick($event)"
-          prizmInputIconButton="cansel-delete-content"
+          prizmInputIconButton="cancel-delete-content"
         ></button>
 
         <button

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -280,3 +280,11 @@
   text-overflow: ellipsis;
   gap: 4px;
 }
+
+.clear-icon {
+  z-index: 2;
+}
+
+.prizm-input-form-status-button {
+  z-index: 1;
+}

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
@@ -133,7 +133,7 @@ export class PrizmInputLayoutComponent
         debounceTime(10),
         tap(() => {
           this.actualizeStatusIcon();
-          this.cdr.markForCheck();
+          this.cdr.detectChanges();
         }),
         takeUntil(this.destroy$)
       )

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -261,7 +261,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   public clear(event: MouseEvent): void {
     if (this.disabled) return;
 
-    this.updateValue('' as VALUE);
+    this.updateValue(null as VALUE);
 
     this.ngControl?.control?.markAsDirty();
 

--- a/libs/components/src/styles/icons-16/icons-16.less
+++ b/libs/components/src/styles/icons-16/icons-16.less
@@ -720,7 +720,7 @@
   &.cancel-delete-line:before {
     content: '';
   }
-  &.cansel-delete-content:before {
+  &.cancel-delete-content:before {
     content: '';
   }
   &.cansel-delete-file:before {

--- a/libs/components/src/styles/icons/icons.less
+++ b/libs/components/src/styles/icons/icons.less
@@ -712,7 +712,7 @@
   &.cancel-delete-line:before {
     content: '';
   }
-  &.cansel-delete-content:before {
+  &.cancel-delete-content:before {
     content: '';
   }
   &.cansel-delete-file:before {


### PR DESCRIPTION
- fix: disabled sync between layout in in put #771 
- feat: sync on touched change with parent layout #353
- fix(components/input-control): update layout flow #691
- fix(components/input-layout): clear button with status message #766
- fix(icons): fix name cansel to cancel
- fix(components/input): update empty state #723