### PR TITLE
fix: input layout outer label incorrect display #788

### DIFF
--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -39,7 +39,6 @@
   color: var(--prizm-text-subscript);
   padding-left: 16px;
   line-height: 16px;
-  margin-bottom: 4px;
   transition: top 200ms ease 0s;
   pointer-events: none;
   width: 100%;
@@ -57,9 +56,6 @@
     gap: 4px;
     max-width: 100%;
     width: 100%;
-    //white-space: nowrap;
-    //overflow: hidden;
-    //text-overflow: ellipsis;
 
     &[data-size='l'] {
       top: 5px;


### PR DESCRIPTION
fix(components/input-layout): input layout outer label incorrect display #788