### PR TITLE
Feat/release 3.2.0.next.1

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.5.0.next.1, 2.2.0.next.1, 3.1.0.next.1](https://github.com/zyfra/Prizm) (06-10-2023)
+## [1.3.0.next.1, 2.3.0.next.1, 3.2.0.next.1](https://github.com/zyfra/Prizm) (06-10-2023)
+
+### Features
+
+- feat(components/input-select): added wrap model for simple content #793 [MR](https://github.com/zyfra/Prizm/pull/810)
+- feat(doc/table): initial table sort example #126 [MR](https://github.com/zyfra/Prizm/pull/805)
+- feat(components/table): initial table sorter added if not set #126 [MR](https://github.com/zyfra/Prizm/pull/805)
+- feat(components/paginator): translations tokens has been added for paginator module [MR](https://github.com/zyfra/Prizm/pull/802)
+- feat: sync on touched change with parent layout #353 [MR](https://github.com/zyfra/Prizm/pull/795)
+- feat(doc): mirror links to showcase added to docs [MR](https://github.com/zyfra/Prizm/pull/794)
+
+### Bug fixes
+
+- fix(components/input-layout): input layout outer label incorrect display #788 [MR](https://github.com/zyfra/Prizm/pull/804)
+- fix(components/paginator): deprecated select component has been changed for new one for paginator #792 [MR](https://github.com/zyfra/Prizm/pull/802)
+- fix: new theme default palette colors fix [MR](https://github.com/zyfra/Prizm/pull/796)
+- fix: disabled sync between layout in in put #771 [MR](https://github.com/zyfra/Prizm/pull/795)
+- fix(components/input-control): update layout flow #691 [MR](https://github.com/zyfra/Prizm/pull/795)
+- fix(components/input-layout): clear button with status message #766 [MR](https://github.com/zyfra/Prizm/pull/795)
+- fix(icons): fix name cansel to cancel [MR](https://github.com/zyfra/Prizm/pull/795)
+- fix(components/input): update empty state #723 [MR](https://github.com/zyfra/Prizm/pull/795)
+
+## [1.5.0, 2.2.0, 3.1.0](https://github.com/zyfra/Prizm) (06-10-2023)
 
 ### Features
 


### PR DESCRIPTION
## [1.3.0.next.1, 2.3.0.next.1, 3.2.0.next.1](https://github.com/zyfra/Prizm) (06-10-2023)

### Features

- feat(components/input-select): added wrap model for simple content #793 [MR](https://github.com/zyfra/Prizm/pull/810)
- feat(doc/table): initial table sort example #126 [MR](https://github.com/zyfra/Prizm/pull/805)
- feat(components/table): initial table sorter added if not set #126 [MR](https://github.com/zyfra/Prizm/pull/805)
- feat(components/paginator): translations tokens has been added for paginator module [MR](https://github.com/zyfra/Prizm/pull/802)
- feat: sync on touched change with parent layout #353 [MR](https://github.com/zyfra/Prizm/pull/795)
- feat(doc): mirror links to showcase added to docs [MR](https://github.com/zyfra/Prizm/pull/794)

### Bug fixes

- fix(components/input-layout): input layout outer label incorrect display #788 [MR](https://github.com/zyfra/Prizm/pull/804)
- fix(components/paginator): deprecated select component has been changed for new one for paginator #792 [MR](https://github.com/zyfra/Prizm/pull/802)
- fix: new theme default palette colors fix [MR](https://github.com/zyfra/Prizm/pull/796)
- fix: disabled sync between layout in in put #771 [MR](https://github.com/zyfra/Prizm/pull/795)
- fix(components/input-control): update layout flow #691 [MR](https://github.com/zyfra/Prizm/pull/795)
- fix(components/input-layout): clear button with status message #766 [MR](https://github.com/zyfra/Prizm/pull/795)
- fix(icons): fix name cansel to cancel [MR](https://github.com/zyfra/Prizm/pull/795)
- fix(components/input): update empty state #723 [MR](https://github.com/zyfra/Prizm/pull/795)
