### PR TITLE
feat: white-space pre-line for hints and dialogs

### DIFF
--- a/apps/doc/src/app/components/hint/examples/with-template/hint-with-template-example.component.html
+++ b/apps/doc/src/app/components/hint/examples/with-template/hint-with-template-example.component.html
@@ -2,5 +2,5 @@
 
 <ng-template #dropdown>
   <div>Hello</div>
-  <div>Good Byu</div>
+  <div>Good bye</div>
 </ng-template>

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -7,6 +7,7 @@
   line-height: var(--prizm-confirm-dialog-title-line-height, 20px);
   text-align: var(--prizm-confirm-dialog-title-align, center);
   color: var(--prizm-confirm-dialog-title, var(--prizm-text-main));
+  white-space: pre-line;
 }
 
 .description {
@@ -16,6 +17,7 @@
   line-height: var(--prizm-confirm-dialog-description-line-height, 20px);
   text-align: var(--prizm-confirm-dialog-description-align, center);
   color: var(--prizm-confirm-dialog-description, var(--prizm-text-subscript));
+  white-space: pre-line;
 }
 
 :host {

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.less
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.less
@@ -158,6 +158,11 @@ prizm-scrollbar {
   }
 }
 
+.title,
+.description {
+  white-space: pre-line;
+}
+
 .title {
   margin-bottom: 8px;
 }

--- a/libs/components/src/lib/directives/hint/hint-container.component.less
+++ b/libs/components/src/lib/directives/hint/hint-container.component.less
@@ -7,6 +7,7 @@
   font-size: var(--prizm-hint-container-font-size, 14px);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: pre-line;
 
   &,
   prizm-scrollbar {

--- a/libs/components/src/lib/directives/tooltip/tooltip-container.component.less
+++ b/libs/components/src/lib/directives/tooltip/tooltip-container.component.less
@@ -3,6 +3,7 @@
   padding: var(--prizm-tooltip-margin, 8px);
   color: var(--prizm-tooltip-container-text, var(--prizm-grey-g2-g12));
   font-size: var(--prizm-tooltip-container-font-size, 12px);
+  white-space: pre-line;
 
   prizm-scrollbar,
   .box {


### PR DESCRIPTION
feat(components/hint): white-space: pre-line added  #781
feat(components/tooltip): white-space: pre-line added  #781
feat(components/confirm-popup): white-space: pre-line added for title and description  #781
feat(components/confirm-dialog): white-space: pre-line added for title and description #768