### PR TITLE
feat(components/dialog): added outer-header with example #854

### DIFF
--- a/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.html
@@ -6,6 +6,9 @@
     <prizm-doc-example id="base" [content]="exampleBasic" heading="Base">
       <prizm-dialog-service-example></prizm-dialog-service-example>
     </prizm-doc-example>
+    <prizm-doc-example id="outer-header" [content]="exampleBasic" heading="Outer Header With Context">
+      <prizm-dialog-outer-header-example></prizm-dialog-outer-header-example>
+    </prizm-doc-example>
     <prizm-doc-example id="with-buttons" [content]="exampleWithButtons" heading="With Footer">
       <prizm-dialog-service-with-buttons-example></prizm-dialog-service-with-buttons-example>
     </prizm-doc-example>

--- a/apps/doc/src/app/components/dialogs/dialog/dialog-example.module.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog-example.module.ts
@@ -17,6 +17,7 @@ import { PrizmDialogServiceExampleComponent } from './examples/base/dialog-base-
 import { PrizmDialogServiceWithButtonsExampleComponent } from './examples/with-buttons/dialog-with-buttons-example.component';
 import { PrizmDialogServiceWithParentExampleComponent } from './examples/with-parent/dialog-with-parent-example.component';
 import { PrizmDialogServiceResultHandlingExampleComponent } from './examples/result/dialog-result-handling-example.component';
+import { PrizmDialogOuterHeaderExampleComponent } from './examples/outher-header/dialog-outher-header-example.component';
 
 @NgModule({
   imports: [
@@ -34,6 +35,7 @@ import { PrizmDialogServiceResultHandlingExampleComponent } from './examples/res
     PrizmInputSelectModule,
   ],
   declarations: [
+    PrizmDialogOuterHeaderExampleComponent,
     PrizmDialogServiceExampleComponent,
     PrizmDialogServiceWithButtonsExampleComponent,
     PrizmDialogServiceWithParentExampleComponent,

--- a/apps/doc/src/app/components/dialogs/dialog/examples/outher-header/dialog-outher-header-example.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/outher-header/dialog-outher-header-example.component.html
@@ -1,0 +1,42 @@
+<button (click)="show()" type="button" prizmButton>Show Dialog</button>
+
+<div style="margin-top: 16px">
+  <prizm-doc-documentation [hasTestId]="false">
+    <ng-template
+      [(documentationPropertyValue)]="position"
+      [documentationPropertyValues]="positionVariants"
+      documentationPropertyName="position"
+      documentationPropertyType="PrizmOverlayInsidePlacement"
+    >
+      Position
+    </ng-template>
+    <ng-template
+      [(documentationPropertyValue)]="dismissible"
+      documentationPropertyName="dismissible"
+      documentationPropertyType="boolean"
+    >
+      Dismissible
+    </ng-template>
+
+    <ng-template
+      [(documentationPropertyValue)]="backdrop"
+      documentationPropertyName="backdrop"
+      documentationPropertyType="boolean"
+    >
+      Backdrop
+    </ng-template>
+  </prizm-doc-documentation>
+</div>
+
+<ng-template
+  #outerHeaderTemp
+  let-context="context"
+  let-completeWith="completeWith"
+  let-closeWord="closeWord"
+  let-header="header"
+>
+  <div class="header">
+    <div>{{ header }} #{{ context.customNumber }}</div>
+    <button (click)="completeWith(true)" prizmButton appearance="primary" size="s">{{ closeWord }}</button>
+  </div>
+</ng-template>

--- a/apps/doc/src/app/components/dialogs/dialog/examples/outher-header/dialog-outher-header-example.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/outher-header/dialog-outher-header-example.component.ts
@@ -1,0 +1,57 @@
+import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
+import { PrizmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
+
+@Component({
+  selector: 'prizm-dialog-outer-header-example',
+  templateUrl: './dialog-outher-header-example.component.html',
+  styles: [
+    `
+      .box {
+        display: flex;
+        gap: 1rem;
+      }
+
+      .header {
+        border-bottom: 1px solid var(--prizm-border-widget);
+        padding: var(--prizm-dialog-header-padding, 14px 16px);
+        display: flex;
+        justify-content: space-between;
+        font-style: var(--prizm-dialog-header-font-style, normal);
+        font-weight: var(--prizm-dialog-header-font-weight, 600);
+        font-size: var(--prizm-dialog-header-font-size, var(--prizm-dialog-font-size, 14px));
+        color: var(--prizm-dialog-header-text, var(--prizm-text-contrast));
+      }
+    `,
+  ],
+})
+export class PrizmDialogOuterHeaderExampleComponent {
+  @ViewChild('outerHeaderTemp', { read: TemplateRef }) outerHeaderTemp!: TemplateRef<any>;
+  public positionVariants: PrizmOverlayInsidePlacement[] = Object.values(PrizmOverlayInsidePlacement);
+  public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
+  public backdrop = false;
+  public dismissible = true;
+
+  constructor(@Inject(PrizmDialogService) private readonly dialogService: PrizmDialogService) {}
+
+  public show(): void {
+    this.dialogService
+      .open(
+        `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
+        {
+          closeable: true,
+          outerHeader: this.outerHeaderTemp,
+          width: 500,
+          header: 'Окно',
+          closeWord: 'Закрыть',
+          context: {
+            customNumber: 1,
+          },
+          position: this.position,
+          dismissible: this.dismissible,
+          backdrop: this.backdrop,
+          size: 'm',
+        }
+      )
+      .subscribe();
+  }
+}

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.html
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.html
@@ -1,16 +1,18 @@
 <div class="host" prizmFocusTrap prizmTheme>
-  <div class="header prizm-font-title-h4" *ngIf="context.header">
-    <div class="title" *polymorphOutlet="context.header as data; context: context">
-      {{ data }}
+  <ng-container *polymorphOutlet="context.outerHeader as data; context: context">
+    <div class="header prizm-font-title-h4" *ngIf="context.header || context.outerHeader">
+      <div class="title" *polymorphOutlet="context.header as data; context: context">
+        {{ data }}
+      </div>
+      <button
+        *ngIf="context.closeable"
+        [size]="16"
+        [interactive]="true"
+        (click)="close()"
+        prizmInputIconButton="cancel-close"
+      ></button>
     </div>
-    <button
-      *ngIf="context.closeable"
-      [size]="16"
-      [interactive]="true"
-      (click)="close()"
-      prizmInputIconButton="cancel-close"
-    ></button>
-  </div>
+  </ng-container>
 
   <div class="content prizm-font-main-body-14">
     <prizm-scrollbar class="scrollbar">

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
@@ -42,6 +42,8 @@ export interface PrizmDialogOptions<O = unknown, DATA = unknown> extends PrizmDi
   readonly closeWord?: string;
   readonly closeable: boolean;
   readonly header: PolymorphContent<PrizmBaseDialogContext<O, PrizmDialogOptions<O, DATA>>>;
+  readonly context?: Record<string, unknown>;
+  readonly outerHeader: PolymorphContent<PrizmBaseDialogContext<O, PrizmDialogOptions<O, DATA>>>;
   readonly footer?: PolymorphContent<PrizmBaseDialogContext<O, PrizmDialogOptions<O, DATA>>> | null;
   readonly footerStyle?: string;
   readonly content?: PolymorphContent<PrizmBaseDialogContext<O, PrizmDialogOptions<O, DATA>>>;

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.service.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.service.ts
@@ -13,6 +13,7 @@ const DEFAULT_OPTIONS: PrizmDialogOptions = {
   position: PrizmOverlayInsidePlacement.CENTER,
   dismissible: true,
   header: '',
+  outerHeader: '',
 } as const;
 
 @Injectable({


### PR DESCRIPTION
feat(components/dialog): added outer-header with example (resolved #854)
