### PR TITLE
fix: table row group column borders disappear when filtering #230

### DIFF
--- a/apps/doc/src/app/components/table/examples/table-row-group-example/table-row-group-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-row-group-example/table-row-group-example.component.html
@@ -26,5 +26,14 @@
         <td class="format__number" *prizmCell="'count'" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>
       </tr>
     </tbody>
+
+    <tbody [data]="products3" prizmTbody heading="Группа 3">
+      <tr class="row" *prizmRow="let item of products2; let i = index" [status]="$any(item.status)" prizmTr>
+        <td class="format__number" *prizmCell="'code'" prizmTd>{{ item.code | spaceNumber : '0.0-0' }}</td>
+        <td *prizmCell="'name'" prizmTd>{{ item.name }}</td>
+        <td *prizmCell="'category'" prizmTd>{{ item.category }}</td>
+        <td class="format__number" *prizmCell="'count'" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>
+      </tr>
+    </tbody>
   </table>
 </prizm-scrollbar>

--- a/apps/doc/src/app/components/table/examples/table-row-group-example/table-row-group-example.component.ts
+++ b/apps/doc/src/app/components/table/examples/table-row-group-example/table-row-group-example.component.ts
@@ -23,4 +23,6 @@ export class TableRowGroupExampleComponent {
   public products1: ITableProduct[] = TABLE_EXAMPLE_DATA_1;
 
   public products2: ITableProduct[] = TABLE_EXAMPLE_DATA_2;
+
+  public products3: ITableProduct[] = [];
 }

--- a/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.html
@@ -4,7 +4,7 @@
 </div>
 <br />
 <prizm-scrollbar class="scrollable" visibility="hidden">
-  <table class="table" [columns]="columns" prizmTable>
+  <table class="table" #table="prizmTable" [columns]="columns" prizmTable>
     <thead>
       <tr prizmThGroup>
         <th *prizmHead="'code'" [resizable]="true" rowspan="2" prizmTh>Код</th>
@@ -26,7 +26,11 @@
 
     <tbody [data]="searchAllowedProducts" prizmTbody>
       <tr class="row" *prizmRow="let item of searchAllowedProducts; let i = index" prizmTr>
-        <td class="format__number" *prizmCell="'code'" prizmTd>{{ item.code | spaceNumber : '0.0-0' }}</td>
+        <td class="format__number" *prizmCell="'code'" prizmTd>
+          maxColspan:[{{ table.tableService.tableMaxColspan$ | async }}]
+
+          {{ item.code | spaceNumber : '0.0-0' }}
+        </td>
         <td *prizmCell="'name'" prizmTd>{{ item.name }}</td>
         <td *prizmCell="'category'" prizmTd>{{ item.category }}</td>
         <td class="format__number" *prizmCell="'count'" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>

--- a/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-search-example/table-search-example.component.html
@@ -4,7 +4,7 @@
 </div>
 <br />
 <prizm-scrollbar class="scrollable" visibility="hidden">
-  <table class="table" #table="prizmTable" [columns]="columns" prizmTable>
+  <table class="table" [columns]="columns" prizmTable>
     <thead>
       <tr prizmThGroup>
         <th *prizmHead="'code'" [resizable]="true" rowspan="2" prizmTh>Код</th>
@@ -27,8 +27,6 @@
     <tbody [data]="searchAllowedProducts" prizmTbody>
       <tr class="row" *prizmRow="let item of searchAllowedProducts; let i = index" prizmTr>
         <td class="format__number" *prizmCell="'code'" prizmTd>
-          maxColspan:[{{ table.tableService.tableMaxColspan$ | async }}]
-
           {{ item.code | spaceNumber : '0.0-0' }}
         </td>
         <td *prizmCell="'name'" prizmTd>{{ item.name }}</td>

--- a/libs/components/src/lib/components/table/directives/table.directive.ts
+++ b/libs/components/src/lib/components/table/directives/table.directive.ts
@@ -20,11 +20,11 @@ import { PrizmTableCellSorter, PrizmTableSorterService } from '../service';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmTableRowService } from '../service/row.service';
 import { prizmTableDefaultColumnSort } from '../table.const';
-import { TableService } from '../table.service';
+import { PrizmTableService } from '../table.service';
 
 @Directive({
   selector: `table[prizmTable]`,
-  providers: [TableService, ...PRIZM_TABLE_PROVIDERS, PrizmTableTreeService, PrizmTableRowService],
+  providers: [PrizmTableService, ...PRIZM_TABLE_PROVIDERS, PrizmTableTreeService, PrizmTableRowService],
   // eslint-disable-next-line @angular-eslint/no-host-metadata-property
   host: {
     style: `border-collapse: separate; border-spacing: 0`,
@@ -85,7 +85,7 @@ export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
   constructor(
     public readonly tree: PrizmTableTreeService,
     public readonly sorterService: PrizmTableSorterService<T>,
-    public readonly tableService: TableService,
+    public readonly tableService: PrizmTableService,
     @Inject(IntersectionObserverService)
     readonly entries$: Observable<IntersectionObserverEntry[]>,
     @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef

--- a/libs/components/src/lib/components/table/directives/table.directive.ts
+++ b/libs/components/src/lib/components/table/directives/table.directive.ts
@@ -20,10 +20,11 @@ import { PrizmTableCellSorter, PrizmTableSorterService } from '../service';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmTableRowService } from '../service/row.service';
 import { prizmTableDefaultColumnSort } from '../table.const';
+import { TableService } from '../table.service';
 
 @Directive({
   selector: `table[prizmTable]`,
-  providers: [...PRIZM_TABLE_PROVIDERS, PrizmTableTreeService, PrizmTableRowService],
+  providers: [TableService, ...PRIZM_TABLE_PROVIDERS, PrizmTableTreeService, PrizmTableRowService],
   // eslint-disable-next-line @angular-eslint/no-host-metadata-property
   host: {
     style: `border-collapse: separate; border-spacing: 0`,
@@ -84,6 +85,7 @@ export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
   constructor(
     public readonly tree: PrizmTableTreeService,
     public readonly sorterService: PrizmTableSorterService<T>,
+    public readonly tableService: TableService,
     @Inject(IntersectionObserverService)
     readonly entries$: Observable<IntersectionObserverEntry[]>,
     @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef

--- a/libs/components/src/lib/components/table/table.service.ts
+++ b/libs/components/src/lib/components/table/table.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { combineLatest, concat, Observable, of, Subject, switchMap } from 'rxjs';
+import { map, shareReplay } from 'rxjs/operators';
+
+type PrizmThGroup = any;
+@Injectable()
+export class TableService {
+  private readonly set = new Set<PrizmThGroup>();
+  private readonly changes$ = new Subject<void>();
+
+  constructor() {}
+
+  readonly tableMaxColspan$: Observable<number> = concat(of(void null), this.changes$).pipe(
+    switchMap(() => {
+      const thGroups = [...this.set];
+      return combineLatest(thGroups.map((i: PrizmThGroup) => i.structure$)).pipe(
+        map(i => {
+          return Math.max(...i.map(i => i.colspan)) as number;
+        })
+      );
+    }),
+    shareReplay(1)
+  );
+
+  public add(thGroup: PrizmThGroup) {
+    this.set.add(thGroup);
+
+    this.changes$.next();
+  }
+
+  public remove(thGroup: PrizmThGroup) {
+    this.set.delete(thGroup);
+
+    this.changes$.next();
+  }
+}

--- a/libs/components/src/lib/components/table/table.service.ts
+++ b/libs/components/src/lib/components/table/table.service.ts
@@ -4,16 +4,14 @@ import { map, shareReplay } from 'rxjs/operators';
 
 type PrizmThGroup = any;
 @Injectable()
-export class TableService {
+export class PrizmTableService {
   private readonly set = new Set<PrizmThGroup>();
   private readonly changes$ = new Subject<void>();
-
-  constructor() {}
 
   readonly tableMaxColspan$: Observable<number> = concat(of(void null), this.changes$).pipe(
     switchMap(() => {
       const thGroups = [...this.set];
-      return combineLatest(thGroups.map((i: PrizmThGroup) => i.structure$)).pipe(
+      return combineLatest(thGroups.map((i: PrizmThGroup) => i.groupStructure$)).pipe(
         map(i => {
           return Math.max(...i.map(i => i.colspan)) as number;
         })
@@ -22,13 +20,13 @@ export class TableService {
     shareReplay(1)
   );
 
-  public add(thGroup: PrizmThGroup) {
+  public addThGroup(thGroup: PrizmThGroup) {
     this.set.add(thGroup);
 
     this.changes$.next();
   }
 
-  public remove(thGroup: PrizmThGroup) {
+  public removeThGroup(thGroup: PrizmThGroup) {
     this.set.delete(thGroup);
 
     this.changes$.next();

--- a/libs/components/src/lib/components/table/tbody/tbody.component.html
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.html
@@ -54,8 +54,8 @@
   <ng-container *ngTemplateOutlet="loadingTemplate?.template || loadingWrapperTemplate"></ng-container>
 
   <ng-template #loadingWrapperTemplate>
-    <tr prizmTr>
-      <td [colSpan]="columnsCount" prizmTd>Loading...</td>
+    <tr>
+      <td [colSpan]="columnsCount">Loading...</td>
     </tr>
   </ng-template>
 </ng-template>
@@ -64,8 +64,8 @@
   <ng-container *ngTemplateOutlet="emptyTemplate?.template || emptyInnerTemplate"></ng-container>
 
   <ng-template #emptyInnerTemplate>
-    <tr prizmTr>
-      <td [colSpan]="columnsCount" prizmTd>—</td>
+    <tr class="empty-row">
+      <td [colSpan]="columnsCount">—</td>
     </tr>
   </ng-template>
 </ng-template>

--- a/libs/components/src/lib/components/table/tbody/tbody.component.html
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.html
@@ -54,8 +54,8 @@
   <ng-container *ngTemplateOutlet="loadingTemplate?.template || loadingWrapperTemplate"></ng-container>
 
   <ng-template #loadingWrapperTemplate>
-    <tr>
-      <td>Loading...</td>
+    <tr prizmTr>
+      <td [colSpan]="columnsCount" prizmTd>Loading...</td>
     </tr>
   </ng-template>
 </ng-template>
@@ -64,8 +64,8 @@
   <ng-container *ngTemplateOutlet="emptyTemplate?.template || emptyInnerTemplate"></ng-container>
 
   <ng-template #emptyInnerTemplate>
-    <tr>
-      <td>—</td>
+    <tr prizmTr>
+      <td [colSpan]="columnsCount" prizmTd>—</td>
     </tr>
   </ng-template>
 </ng-template>

--- a/libs/components/src/lib/components/table/tbody/tbody.component.less
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.less
@@ -56,29 +56,40 @@
   }
 }
 
+.empty-row {
+  td {
+    border: 1px solid var(--prizm-border-widget);
+    border-top: transparent;
+  }
+}
+
 :host-context([data-size='xs']) {
   font-size: 12px;
   line-height: 12px;
 
-  .heading {
+  .heading,
+  .empty-row {
     height: @height-xs;
   }
 }
 
 :host-context([data-size='s']) {
-  .heading {
+  .heading,
+  .empty-row {
     height: @height-s;
   }
 }
 
 :host-context([data-size='m']) {
-  .heading {
+  .heading,
+  .empty-row {
     height: @height-m;
   }
 }
 
 :host-context([data-size='l']) {
-  .heading {
+  .heading,
+  .empty-row {
     height: @height-l;
   }
 }

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -19,7 +19,7 @@ import { CollectionViewer, isDataSource, ListRange } from '@angular/cdk/collecti
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { BehaviorSubject, isObservable, Observable } from 'rxjs';
-import { filter, map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PolymorphContent } from '../../../directives';
 import { PrizmTableEmptyDirective } from '../directives/empty.directive';
 import { PrizmTableLoadingDirective } from '../directives/loading.directive';
@@ -157,14 +157,8 @@ export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   ) {}
 
   ngAfterViewInit(): void {
-    this.rows.changes
-      .pipe(
-        startWith(this.rows),
-        map(({ first }: QueryList<PrizmTrComponent<T>>) => first),
-        filter((first: PrizmTrComponent<T>) => !!first),
-        map(({ colCount }) => colCount),
-        takeUntil(this.destroy$)
-      )
+    this.table.tableService.tableMaxColspan$
+      .pipe(takeUntil(this.destroy$))
       .subscribe((columnsCount: number) => {
         this.columnsCount = columnsCount;
         this.changeDetectorRef.detectChanges();

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -21,7 +21,6 @@ import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { BehaviorSubject, isObservable, Observable } from 'rxjs';
 import { filter, map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PolymorphContent } from '../../../directives';
-import { PrizmCellDirective } from '../directives/cell.directive';
 import { PrizmTableEmptyDirective } from '../directives/empty.directive';
 import { PrizmTableLoadingDirective } from '../directives/loading.directive';
 import { PrizmRowDirective } from '../directives/row.directive';
@@ -32,7 +31,6 @@ import { PrizmTableSorterService } from '../service';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmTableDataSourceInput } from '../table.types';
 import { PrizmTrComponent } from '../tr/tr.component';
-import { PrizmTableRowService } from '../service/row.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector

--- a/libs/components/src/lib/components/table/th-group/th-group.component.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.component.ts
@@ -60,6 +60,7 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
   heads$: Observable<PrizmHeadDirective<T>[]> | null = null;
 
   readonly structure$ = concat(
+    // TODO remove (move to lifecycle hook)
     timer(0).pipe(mapTo([])),
     defer(() => of(this.th.toArray())),
     defer(() => this.th.changes.pipe(map(() => this.th.toArray())))

--- a/libs/components/src/lib/components/table/th-group/th-group.component.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.component.ts
@@ -2,31 +2,36 @@ import {
   AfterContentInit,
   ChangeDetectionStrategy,
   Component,
-  ContentChild,
   ContentChildren,
   forwardRef,
   Inject,
   Input,
+  OnDestroy,
   QueryList,
+  Self,
 } from '@angular/core';
 import { prizmAutoEmit } from '@prizm-ui/core';
-import { BehaviorSubject, concat, Observable, of } from 'rxjs';
-import { startWith, switchMap } from 'rxjs/operators';
+import { BehaviorSubject, concat, defer, Observable, of, timer } from 'rxjs';
+import { map, mapTo, shareReplay, startWith, switchMap } from 'rxjs/operators';
 
 import { PrizmHeadDirective } from '../directives/head.directive';
 import { PrizmTableDirective } from '../directives/table.directive';
 import { PRIZM_TABLE_PROVIDER } from '../providers/table.provider';
 import { PrizmThComponent } from '../th/th.component';
 import { moveInEventLoopIteration } from '@prizm-ui/helpers';
+import { TableService } from '../table.service';
+import { PrizmThGroupService } from './th-group.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: `tr[prizmThGroup]`,
   templateUrl: `./th-group.template.html`,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [PRIZM_TABLE_PROVIDER],
+  providers: [PRIZM_TABLE_PROVIDER, PrizmThGroupService],
 })
-export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>> implements AfterContentInit {
+export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
+  implements AfterContentInit, OnDestroy
+{
   private readonly columns$$ = new BehaviorSubject<ReadonlyArray<keyof T | string> | null>(null);
   @Input()
   @prizmAutoEmit({
@@ -43,18 +48,40 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>> impl
     );
   }
 
-  @ContentChild(forwardRef(() => PrizmThComponent))
-  readonly th!: PrizmThComponent<T>;
+  // @ContentChild(forwardRef(() => PrizmThComponent))
+  // readonly th!: PrizmThComponent<T>;
+
+  @ContentChildren(forwardRef(() => PrizmThComponent), { descendants: true })
+  readonly th!: QueryList<PrizmThComponent<T>>;
 
   @ContentChildren(forwardRef(() => PrizmHeadDirective))
   readonly heads: QueryList<PrizmHeadDirective<T>> = new QueryList<PrizmHeadDirective<T>>();
 
   heads$: Observable<PrizmHeadDirective<T>[]> | null = null;
 
+  readonly structure$ = concat(
+    timer(0).pipe(mapTo([])),
+    defer(() => of(this.th.toArray())),
+    defer(() => this.th.changes.pipe(map(() => this.th.toArray())))
+  ).pipe(
+    map((cols: PrizmThComponent<T>[]) => {
+      const colspan = cols.reduce((acc, element) => acc + element.el.nativeElement.colSpan, 0);
+      return {
+        cols,
+        colspan,
+      };
+    }),
+    shareReplay(1)
+  );
+
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))
-    public readonly table: PrizmTableDirective<T>
-  ) {}
+    public readonly table: PrizmTableDirective<T>,
+    public readonly tableService: TableService,
+    @Self() public readonly thGroupService: PrizmThGroupService
+  ) {
+    this.tableService.add(this);
+  }
 
   ngAfterContentInit(): void {
     this.heads$ = this.heads.changes.pipe(
@@ -75,5 +102,9 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>> impl
         );
       })
     ) as any;
+  }
+
+  ngOnDestroy(): void {
+    this.tableService.remove(this);
   }
 }

--- a/libs/components/src/lib/components/table/th-group/th-group.service.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Задача что prizmTh
+ * */
+@Injectable()
+export class PrizmThGroupService {}

--- a/libs/components/src/lib/components/table/th/th.component.ts
+++ b/libs/components/src/lib/components/table/th/th.component.ts
@@ -17,6 +17,7 @@ import { PrizmTableSortKeyException } from '../../../exceptions';
 import { PrizmTableCellSorter, PrizmTableCellSorterHandler, PrizmTableSorterService } from '../service';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
+import { TableService } from '../table.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -55,6 +56,8 @@ export class PrizmThComponent<T extends Partial<Record<keyof T, any>>> {
     @Optional()
     @Inject(PrizmHeadDirective)
     private readonly head: PrizmHeadDirective<T> | null,
+    private readonly tableService: TableService,
+    public readonly el: ElementRef<HTMLTableCellElement>,
     private readonly sorterService: PrizmTableSorterService<T>,
     @Optional()
     @Inject(forwardRef(() => PrizmTableDirective))

--- a/libs/components/src/lib/components/table/th/th.component.ts
+++ b/libs/components/src/lib/components/table/th/th.component.ts
@@ -17,7 +17,6 @@ import { PrizmTableSortKeyException } from '../../../exceptions';
 import { PrizmTableCellSorter, PrizmTableCellSorterHandler, PrizmTableSorterService } from '../service';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { TableService } from '../table.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -56,7 +55,6 @@ export class PrizmThComponent<T extends Partial<Record<keyof T, any>>> {
     @Optional()
     @Inject(PrizmHeadDirective)
     private readonly head: PrizmHeadDirective<T> | null,
-    private readonly tableService: TableService,
     public readonly el: ElementRef<HTMLTableCellElement>,
     private readonly sorterService: PrizmTableSorterService<T>,
     @Optional()


### PR DESCRIPTION
fix(components/table): table row group column borders disappear when filtering #230
feat(components/table):  PrizmTableService added  #230