### PR TITLE
fix: table documentation open property #654

### DIFF
--- a/apps/doc/src/app/components/table/table-example.component.html
+++ b/apps/doc/src/app/components/table/table-example.component.html
@@ -126,7 +126,7 @@
             </tr>
           </thead>
 
-          <tbody [data]="products" prizmTbody>
+          <tbody [data]="products" [open]="open" prizmTbody>
             <ng-container *prizmRow="let item of products; let i = index">
               <tr prizmTr>
                 <td class="format__number" *prizmCell="'code'" prizmTd>
@@ -201,6 +201,7 @@
         Heading
       </ng-template>
       <ng-template
+        [(documentationPropertyValue)]="open"
         documentationPropertyName="open"
         documentationPropertyType="boolean"
         documentationPropertyMode="input-output"

--- a/apps/doc/src/app/components/table/table-example.component.ts
+++ b/apps/doc/src/app/components/table/table-example.component.ts
@@ -22,6 +22,7 @@ export class TableExampleComponent {
     ['name', 'category'],
     ['code', 'name', 'category', 'count'],
   ];
+  public open = true;
 
   borderStyle: PrizmTableBorderStyle = 'grid';
   borderStyleVariants: Array<PrizmTableBorderStyle> = ['grid', 'horizontal', 'vertical'];


### PR DESCRIPTION
fix(docs/table): description for 'open' property for table body added to docs https://github.com/zyfra/Prizm/issues/654

Closed #654