### PR TITLE
fix: add more space for chips in multiselect  #892

### DIFF
--- a/libs/components/src/lib/components/chips/chips.component.less
+++ b/libs/components/src/lib/components/chips/chips.component.less
@@ -15,7 +15,7 @@
       max-width: 100%;
 
       &.single-line {
-        max-width: calc(100% - 20px);
+        max-width: 100%;
       }
 
       &.hidden {
@@ -31,7 +31,7 @@
       height: 20px;
       padding-top: 1px;
       overflow: hidden;
-      max-width: calc(100% - 20px);
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
fix(components/multiselect): add more space for chips in multiselect  #892