### PR TITLE
fix: progress status translations for file upload #931

### DIFF
--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
@@ -1,3 +1,14 @@
-<prizm-file-upload [multiple]="false" [accept]="'image/*'" [maxFilesCount]="3" [maxFileSize]="1000000">
-  Maximum image size 1MB
+<prizm-file-upload
+  [multiple]="true"
+  [accept]="'image/*'"
+  [progress]="$any(progress$$ | async)"
+  [maxFilesCount]="3"
+  [maxFileSize]="1000000"
+  [disabled]="disabled"
+  (filesChange)="onFilesChange($event)"
+  (filesValidationErrors)="onfilesValidationErrors($any($event))"
+  (filesCountError)="onFilesCountError($event)"
+  (retry)="retry($event)"
+>
+  Максимум три изображения размером не более 1МБ
 </prizm-file-upload>

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
@@ -10,5 +10,5 @@
   (filesCountError)="onFilesCountError($event)"
   (retry)="retry($event)"
 >
-  Максимум три изображения размером не более 1МБ
+  Maximum of three images up to 1MB in size
 </prizm-file-upload>

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { PRIZM_LANGUAGE, PRIZM_RUSSIAN_LANGUAGE, PrizmLanguageFileUpload } from '@prizm-ui/i18n';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
+import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
+import { PrizmFileValidationErrors, PrizmFilesProgress, PrizmToastService } from '@prizm-ui/components';
 
 export const PRIZM_ENGLISH_FILE_UPLOAD: PrizmLanguageFileUpload = {
   fileUpload: {
@@ -27,4 +29,150 @@ export const PRIZM_ENGLISH_FILE_UPLOAD: PrizmLanguageFileUpload = {
     },
   ],
 })
-export class PrizmFileUploadI18nExampleComponent {}
+export class PrizmFileUploadI18nExampleComponent {
+  progress$$ = new BehaviorSubject<PrizmFilesProgress>({});
+  files: Array<File> = [];
+  disabled = false;
+
+  public onFilesChange(files: Array<File>): void {
+    this.files = files;
+    if (this.files.length > 0) {
+      this.send();
+    }
+  }
+
+  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+    for (const filename of Object.keys(errors)) {
+      this.toastService.create(JSON.stringify(errors[filename]), {
+        title: `Файл ${filename} не прошел валидацию`,
+        appearance: 'warning',
+        timer: 5000,
+      });
+    }
+  }
+
+  public onFilesCountError(fileNames: Array<string>): void {
+    this.toastService.create(`Файлы ${fileNames.join(' ,')} не были добавлены`, {
+      title: `Максимальное количество файлов превышено`,
+      appearance: 'warning',
+      timer: 5000,
+    });
+  }
+
+  public send(): void {
+    this.disabled = true;
+    const formData = new FormData();
+    for (const file of this.files) {
+      formData.append(file.name, file);
+    }
+
+    this.http
+      .post('/fakeFileUpload', formData, {
+        reportProgress: true,
+        observe: 'events',
+      })
+      .subscribe(
+        (event: HttpEvent<any>) => {
+          switch (event.type) {
+            case HttpEventType.Sent:
+              break;
+            case HttpEventType.Response: {
+              this.disabled = false;
+
+              if (event.status >= 200 && event.status < 300) {
+                for (const file of this.files) {
+                  this.progress$$.next({
+                    ...this.progress$$.value,
+                    [file.name]: { progress: 100, error: false },
+                  });
+                }
+              } else {
+                for (const file of this.files) {
+                  this.progress$$.next({
+                    ...this.progress$$.value,
+                    [file.name]: { error: true },
+                  });
+                }
+              }
+
+              break;
+            }
+            case HttpEventType.UploadProgress: {
+              for (const file of this.files) {
+                this.progress$$.next({
+                  ...this.progress$$.value,
+                  [file.name]: {
+                    progress: Math.round((event.loaded / (event?.total ?? 0)) * 100),
+                    error: false,
+                  },
+                });
+              }
+
+              break;
+            }
+          }
+        },
+        error => {
+          console.log(error);
+        }
+      );
+  }
+
+  public retry(file: File): void {
+    this.disabled = true;
+    const formData = new FormData();
+
+    formData.append(file.name, file);
+
+    this.http
+      .post('/fakeFileUpload', formData, {
+        reportProgress: true,
+        observe: 'events',
+      })
+      .subscribe(
+        (event: HttpEvent<any>) => {
+          switch (event.type) {
+            case HttpEventType.Sent:
+              break;
+            case HttpEventType.Response: {
+              this.disabled = false;
+
+              if (event.status >= 200 && event.status < 300) {
+                this.progress$$.next({
+                  ...this.progress$$.value,
+                  [file.name]: { progress: 100, error: false },
+                });
+              } else {
+                this.progress$$.next({
+                  ...this.progress$$.value,
+                  [file.name]: { error: true },
+                });
+              }
+
+              break;
+            }
+            case HttpEventType.UploadProgress: {
+              this.progress$$.next({
+                ...this.progress$$.value,
+                [file.name]: {
+                  progress: Math.round((event.loaded / (event.total ?? 0)) * 100),
+                  error: false,
+                },
+              });
+
+              break;
+            }
+          }
+        },
+        error => {
+          console.log(error);
+        }
+      );
+  }
+
+  constructor(private readonly toastService: PrizmToastService, private http: HttpClient) {}
+
+  public ngOnDestroy(): void {
+    this.progress$$.complete();
+  }
+}

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -7,10 +7,10 @@ export const PRIZM_ENGLISH_FILE_UPLOAD: PrizmLanguageFileUpload = {
     dropzone__description: 'Select a file or drag it to this area',
     dropzone__title: 'File upload',
     btn__select: 'Browse',
-    status__idle: 'Waiting to upload',
-    status__progress: 'Uploading',
-    status__warning: 'Error',
-    status__success: 'Uploaded',
+    idle: 'Waiting to upload',
+    progress: 'Uploading',
+    warning: 'Error',
+    success: 'Uploaded',
   },
 };
 

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -7,6 +7,10 @@ export const PRIZM_ENGLISH_FILE_UPLOAD: PrizmLanguageFileUpload = {
     dropzone__description: 'Select a file or drag it to this area',
     dropzone__title: 'File upload',
     btn__select: 'Browse',
+    status__idle: 'Waiting to upload',
+    status__progress: 'Uploading',
+    status__warning: 'Error',
+    status__success: 'Uploaded',
   },
 };
 

--- a/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.html
+++ b/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.html
@@ -10,7 +10,6 @@
   [progress]="$any(progress$$ | async)"
   [maxFilesCount]="3"
   [maxFileSize]="1000000"
-  [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
   (filesValidationErrors)="onfilesValidationErrors($any($event))"
   (filesCountError)="onFilesCountError($event)"

--- a/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.html
+++ b/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.html
@@ -4,5 +4,16 @@
 <br />
 <br />
 
-<prizm-file-upload [multiple]="false" [accept]="'image/*'" [maxFilesCount]="3" [maxFileSize]="1000000">
+<prizm-file-upload
+  [multiple]="true"
+  [accept]="'image/*'"
+  [progress]="$any(progress$$ | async)"
+  [maxFilesCount]="3"
+  [maxFileSize]="1000000"
+  [disabled]="disabled"
+  (filesChange)="onFilesChange($event)"
+  (filesValidationErrors)="onfilesValidationErrors($any($event))"
+  (filesCountError)="onFilesCountError($event)"
+  (retry)="retry($event)"
+>
 </prizm-file-upload>

--- a/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.ts
+++ b/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.ts
@@ -45,7 +45,6 @@ export class PrizmLanguageSwitcherExampleComponent {
 
   progress$$ = new BehaviorSubject<PrizmFilesProgress>({});
   files: Array<File> = [];
-  disabled = false;
 
   public onFilesChange(files: Array<File>): void {
     this.files = files;
@@ -73,7 +72,6 @@ export class PrizmLanguageSwitcherExampleComponent {
   }
 
   public send(): void {
-    this.disabled = true;
     const formData = new FormData();
     for (const file of this.files) {
       formData.append(file.name, file);
@@ -90,8 +88,6 @@ export class PrizmLanguageSwitcherExampleComponent {
             case HttpEventType.Sent:
               break;
             case HttpEventType.Response: {
-              this.disabled = false;
-
               if (event.status >= 200 && event.status < 300) {
                 for (const file of this.files) {
                   this.progress$$.next({
@@ -132,7 +128,6 @@ export class PrizmLanguageSwitcherExampleComponent {
   }
 
   public retry(file: File): void {
-    this.disabled = true;
     const formData = new FormData();
 
     formData.append(file.name, file);
@@ -148,8 +143,6 @@ export class PrizmLanguageSwitcherExampleComponent {
             case HttpEventType.Sent:
               break;
             case HttpEventType.Response: {
-              this.disabled = false;
-
               if (event.status >= 200 && event.status < 300) {
                 this.progress$$.next({
                   ...this.progress$$.value,

--- a/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.ts
+++ b/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.ts
@@ -1,13 +1,14 @@
 import { Component, Self } from '@angular/core';
 import {
-  PRIZM_LANGUAGE,
   PRIZM_RUSSIAN_LANGUAGE,
   PrizmLanguageName,
   prizmLanguageSwitcher,
   PrizmLanguageSwitcher,
 } from '@prizm-ui/i18n';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { PRIZM_ENGLISH_FILE_UPLOAD } from '../../../../components/file-upload/examples/i18n/file-upload-i18n-example.component';
+import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
+import { PrizmFileValidationErrors, PrizmFilesProgress } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-language-switcher-example',
@@ -31,12 +32,158 @@ import { PRIZM_ENGLISH_FILE_UPLOAD } from '../../../../components/file-upload/ex
   ],
 })
 export class PrizmLanguageSwitcherExampleComponent {
+  toastService: any;
   constructor(
     @Self()
-    private readonly prizmLanguageSwitcher: PrizmLanguageSwitcher
+    private readonly prizmLanguageSwitcher: PrizmLanguageSwitcher,
+    private http: HttpClient
   ) {}
 
   public changeLanguage(lang: string) {
     this.prizmLanguageSwitcher.setLanguage(lang as PrizmLanguageName);
+  }
+
+  progress$$ = new BehaviorSubject<PrizmFilesProgress>({});
+  files: Array<File> = [];
+  disabled = false;
+
+  public onFilesChange(files: Array<File>): void {
+    this.files = files;
+    if (this.files.length > 0) {
+      this.send();
+    }
+  }
+
+  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+    for (const filename of Object.keys(errors)) {
+      this.toastService.create(JSON.stringify(errors[filename]), {
+        title: `Файл ${filename} не прошел валидацию`,
+        appearance: 'warning',
+        timer: 5000,
+      });
+    }
+  }
+
+  public onFilesCountError(fileNames: Array<string>): void {
+    this.toastService.create(`Файлы ${fileNames.join(' ,')} не были добавлены`, {
+      title: `Максимальное количество файлов превышено`,
+      appearance: 'warning',
+      timer: 5000,
+    });
+  }
+
+  public send(): void {
+    this.disabled = true;
+    const formData = new FormData();
+    for (const file of this.files) {
+      formData.append(file.name, file);
+    }
+
+    this.http
+      .post('/fakeFileUpload', formData, {
+        reportProgress: true,
+        observe: 'events',
+      })
+      .subscribe(
+        (event: HttpEvent<any>) => {
+          switch (event.type) {
+            case HttpEventType.Sent:
+              break;
+            case HttpEventType.Response: {
+              this.disabled = false;
+
+              if (event.status >= 200 && event.status < 300) {
+                for (const file of this.files) {
+                  this.progress$$.next({
+                    ...this.progress$$.value,
+                    [file.name]: { progress: 100, error: false },
+                  });
+                }
+              } else {
+                for (const file of this.files) {
+                  this.progress$$.next({
+                    ...this.progress$$.value,
+                    [file.name]: { error: true },
+                  });
+                }
+              }
+
+              break;
+            }
+            case HttpEventType.UploadProgress: {
+              for (const file of this.files) {
+                this.progress$$.next({
+                  ...this.progress$$.value,
+                  [file.name]: {
+                    progress: Math.round((event.loaded / (event?.total ?? 0)) * 100),
+                    error: false,
+                  },
+                });
+              }
+
+              break;
+            }
+          }
+        },
+        error => {
+          console.log(error);
+        }
+      );
+  }
+
+  public retry(file: File): void {
+    this.disabled = true;
+    const formData = new FormData();
+
+    formData.append(file.name, file);
+
+    this.http
+      .post('/fakeFileUpload', formData, {
+        reportProgress: true,
+        observe: 'events',
+      })
+      .subscribe(
+        (event: HttpEvent<any>) => {
+          switch (event.type) {
+            case HttpEventType.Sent:
+              break;
+            case HttpEventType.Response: {
+              this.disabled = false;
+
+              if (event.status >= 200 && event.status < 300) {
+                this.progress$$.next({
+                  ...this.progress$$.value,
+                  [file.name]: { progress: 100, error: false },
+                });
+              } else {
+                this.progress$$.next({
+                  ...this.progress$$.value,
+                  [file.name]: { error: true },
+                });
+              }
+
+              break;
+            }
+            case HttpEventType.UploadProgress: {
+              this.progress$$.next({
+                ...this.progress$$.value,
+                [file.name]: {
+                  progress: Math.round((event.loaded / (event.total ?? 0)) * 100),
+                  error: false,
+                },
+              });
+
+              break;
+            }
+          }
+        },
+        error => {
+          console.log(error);
+        }
+      );
+  }
+
+  public ngOnDestroy(): void {
+    this.progress$$.complete();
   }
 }

--- a/apps/doc/src/app/how-to-work/internationalization/internationalization.module.ts
+++ b/apps/doc/src/app/how-to-work/internationalization/internationalization.module.ts
@@ -1,20 +1,21 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { PrizmAccordionModule, PrizmFileUploadModule, PrizmButtonModule } from '@prizm-ui/components';
+import { PrizmButtonComponent, PrizmFileUploadComponent } from '@prizm-ui/components';
 import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 import { InternationalizationComponent } from './internationalization.component';
 import { PrizmLanguageSwitcherExampleComponent } from './examples/language-switcher/language-switcher-example.component';
 import { PrizmLanguageName, PrizmLanguageSwitcher } from '@prizm-ui/i18n';
+import { AsyncPipe } from '@angular/common';
 
 @NgModule({
   exports: [InternationalizationComponent],
   declarations: [InternationalizationComponent, PrizmLanguageSwitcherExampleComponent],
   imports: [
     PrizmAddonDocModule,
-    PrizmAccordionModule,
     RouterModule.forChild(prizmDocGenerateRoutes(InternationalizationComponent)),
-    PrizmFileUploadModule,
-    PrizmButtonModule,
+    PrizmFileUploadComponent,
+    PrizmButtonComponent,
+    AsyncPipe,
   ],
 })
 export class InternationalizationModule {

--- a/libs/components/src/lib/components/file-upload/file-upload-options.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload-options.ts
@@ -1,23 +1,8 @@
 import { InjectionToken } from '@angular/core';
-
-export type PrizmFileUploadOptions = {
-  showRetryButtons: boolean;
-  statusNames: {
-    idle: string;
-    progress: string;
-    warning: string;
-    success: string;
-  };
-};
+import { PrizmFileUploadOptions } from './types';
 
 export const prizmFileUploadDefaultOptions: PrizmFileUploadOptions = {
   showRetryButtons: true,
-  statusNames: {
-    idle: 'status__idle',
-    progress: 'status__progress',
-    warning: 'status__warning',
-    success: 'status__success',
-  },
 };
 
 export const PRIZM_FILEUPLOAD_OPTIONS = new InjectionToken<Partial<PrizmFileUploadOptions>>(

--- a/libs/components/src/lib/components/file-upload/file-upload-options.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload-options.ts
@@ -13,10 +13,10 @@ export type PrizmFileUploadOptions = {
 export const prizmFileUploadDefaultOptions: PrizmFileUploadOptions = {
   showRetryButtons: true,
   statusNames: {
-    idle: 'Ожидание загрузки',
-    progress: 'Загрузка',
-    warning: 'Ошибка',
-    success: 'Загружено',
+    idle: 'status__idle',
+    progress: 'status__progress',
+    warning: 'status__warning',
+    success: 'status__success',
   },
 };
 

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -56,7 +56,7 @@
         class="file__stage"
         *prizmLet="item.value.progress | prizmUploadStatus : item.value.error as status"
       >
-        {{ translations | prizmPluck : [status] }}
+        {{ options.statusNames ? options.statusNames[status] : (translations | prizmPluck : [status]) }}
       </div>
 
       <button

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -1,90 +1,94 @@
-<input
-  class="hidden"
-  #inputFile
-  [multiple]="multiple"
-  [accept]="accept"
-  (change)="onFileInputChange($event)"
-  type="file"
-/>
+<ng-container *prizmLet="fileUpload$ | async as translations">
+  <input
+    class="hidden"
+    #inputFile
+    [multiple]="multiple"
+    [accept]="accept"
+    (change)="onFileInputChange($event)"
+    type="file"
+  />
 
-<div class="dropzone" #dropzone *prizmLet="fileUpload$ | async as translations" (drop)="onDrop($event)">
-  <div class="dropzone__title">
-    {{ translations | prizmPluck : ['dropzone__title'] }}
-  </div>
-  <div class="dropzone__description">
-    {{ translations | prizmPluck : ['dropzone__description'] }}
-  </div>
-  <div class="dropzone__user-content">
-    <ng-content></ng-content>
-  </div>
-
-  <button
-    class="dropzone__file-select"
-    [disabled]="disabled"
-    (click)="inputFile.click()"
-    type="button"
-    prizmButton
-    appearanceType="outline"
-    appearance="secondary"
-    size="m"
-  >
-    {{ translations | prizmPluck : ['btn__select'] }}
-  </button>
-</div>
-
-<div class="files" *ngIf="filesMap.size > 0">
-  <div class="file files__item" *ngFor="let item of filesMap | keyvalue; trackBy: filesTrackBy">
-    <div class="file__preview">
-      <img
-        class="file__image"
-        *ngIf="item.value.url; else iconTpl"
-        [src]="item.value.url | prizmSanitizer : 'bypassSecurityTrustResourceUrl'"
-      />
-
-      <ng-template #iconTpl>
-        <prizm-icon class="file__icon" [size]="24" iconClass="files-file"></prizm-icon>
-      </ng-template>
+  <div class="dropzone" #dropzone (drop)="onDrop($event)">
+    <div class="dropzone__title">
+      {{ translations | prizmPluck : ['dropzone__title'] }}
+    </div>
+    <div class="dropzone__description">
+      {{ translations | prizmPluck : ['dropzone__description'] }}
+    </div>
+    <div class="dropzone__user-content">
+      <ng-content></ng-content>
     </div>
 
-    <div class="file__info">
-      <span class="file__name">{{ item.key }}</span>
-      <span class="file__size">{{ getFileSize(item.value.file.size) }}</span>
-    </div>
-
-    <div class="file__stage">{{ getStage(item.key).name }}</div>
-
     <button
-      class="file__retry-btn"
-      *ngIf="item.value.error && options.showRetryButtons"
+      class="dropzone__file-select"
       [disabled]="disabled"
-      [icon]="'arrows-refresh'"
-      (click)="retryUpload(item.key)"
-      prizmIconButton
-      appearanceType="ghost"
+      (click)="inputFile.click()"
+      type="button"
+      prizmButton
+      appearanceType="outline"
       appearance="secondary"
-      size="s"
-    ></button>
+      size="m"
+    >
+      {{ translations | prizmPluck : ['btn__select'] }}
+    </button>
+  </div>
 
-    <button
-      class="file__delete-btn"
-      [disabled]="disabled"
-      [icon]="'delete'"
-      (click)="removeFile(item.key)"
-      prizmIconButton
-      appearanceType="ghost"
-      appearance="secondary"
-      size="s"
-    ></button>
+  <div class="files" *ngIf="filesMap.size > 0">
+    <div class="file files__item" *ngFor="let item of filesMap | keyvalue; trackBy: filesTrackBy">
+      <div class="file__preview">
+        <img
+          class="file__image"
+          *ngIf="item.value.url; else iconTpl"
+          [src]="item.value.url | prizmSanitizer : 'bypassSecurityTrustResourceUrl'"
+        />
 
-    <div class="file__progress progress">
-      <progress
-        class="progress__bar {{ getStage(item.key).cssClass }}"
-        [value]="item.value.progress"
-        prizmProgressBar
-        max="100"
+        <ng-template #iconTpl>
+          <prizm-icon class="file__icon" [size]="24" iconClass="files-file"></prizm-icon>
+        </ng-template>
+      </div>
+
+      <div class="file__info">
+        <span class="file__name">{{ item.key }}</span>
+        <span class="file__size">{{ getFileSize(item.value.file.size) }}</span>
+      </div>
+
+      <div class="file__stage">
+        {{ translations | prizmPluck : [getStage(item.key).name] }}
+      </div>
+
+      <button
+        class="file__retry-btn"
+        *ngIf="item.value.error && options.showRetryButtons"
+        [disabled]="disabled"
+        [icon]="'arrows-refresh'"
+        (click)="retryUpload(item.key)"
+        prizmIconButton
+        appearanceType="ghost"
+        appearance="secondary"
         size="s"
-      ></progress>
-      <span class="progress__value">{{ item.value.progress }}%</span>
+      ></button>
+
+      <button
+        class="file__delete-btn"
+        [disabled]="disabled"
+        [icon]="'delete'"
+        (click)="removeFile(item.key)"
+        prizmIconButton
+        appearanceType="ghost"
+        appearance="secondary"
+        size="s"
+      ></button>
+
+      <div class="file__progress progress">
+        <progress
+          class="progress__bar {{ getStage(item.key).cssClass }}"
+          [value]="item.value.progress"
+          prizmProgressBar
+          max="100"
+          size="s"
+        ></progress>
+        <span class="progress__value">{{ item.value.progress }}%</span>
+      </div>
     </div>
   </div>
-</div>
+</ng-container>

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -49,11 +49,14 @@
 
       <div class="file__info">
         <span class="file__name">{{ item.key }}</span>
-        <span class="file__size">{{ getFileSize(item.value.file.size) }}</span>
+        <span class="file__size">{{ item.value.file.size | prizmFileSize }}</span>
       </div>
 
-      <div class="file__stage">
-        {{ translations | prizmPluck : [getStage(item.key).name] }}
+      <div
+        class="file__stage"
+        *prizmLet="item.value.progress | prizmUploadStatus : item.value.error as status"
+      >
+        {{ translations | prizmPluck : [status] }}
       </div>
 
       <button
@@ -81,7 +84,7 @@
 
       <div class="file__progress progress">
         <progress
-          class="progress__bar {{ getStage(item.key).cssClass }}"
+          class="progress__bar {{ item.value.progress | prizmUploadStatus : item.value.error }}"
           [value]="item.value.progress"
           prizmProgressBar
           max="100"

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -56,7 +56,7 @@
         class="file__stage"
         *prizmLet="item.value.progress | prizmUploadStatus : item.value.error as status"
       >
-        {{  options.statusNames?.[status] ?? (translations | prizmPluck : [status]) }}
+        {{  $any(options.statusNames?.[status]) ?? (translations | prizmPluck : [status]) }}
       </div>
 
       <button

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -56,7 +56,7 @@
         class="file__stage"
         *prizmLet="item.value.progress | prizmUploadStatus : item.value.error as status"
       >
-        {{ options.statusNames ? options.statusNames[status] : (translations | prizmPluck : [status]) }}
+        {{  options.statusNames?.[status] ?? (translations | prizmPluck : [status]) }}
       </div>
 
       <button

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -52,11 +52,8 @@
         <span class="file__size">{{ item.value.file.size | prizmFileSize }}</span>
       </div>
 
-      <div
-        class="file__stage"
-        *prizmLet="item.value.progress | prizmUploadStatus : item.value.error as status"
-      >
-        {{  $any(options.statusNames?.[status]) ?? (translations | prizmPluck : [status]) }}
+      <div class="file__stage">
+        {{  options.statusNames?.[item.value.progress | prizmUploadStatus : item.value.error] ?? (translations | prizmPluck : [item.value.progress | prizmUploadStatus : item.value.error]) }}
       </div>
 
       <button

--- a/libs/components/src/lib/components/file-upload/file-upload.enums.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.enums.ts
@@ -1,0 +1,6 @@
+export enum UploadingStatusEnum {
+  idle = 'idle',
+  progress = 'progress',
+  warning = 'warning',
+  success = 'success',
+}

--- a/libs/components/src/lib/components/file-upload/pipes/file-size.pipe.ts
+++ b/libs/components/src/lib/components/file-upload/pipes/file-size.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'prizmFileSize', standalone: true })
+export class PrizmFileSizePipe implements PipeTransform {
+  public transform(size: number): string {
+    if (size < 1024) {
+      return size + 'bytes';
+    } else if (size > 1024 && size < 1048576) {
+      return (size / 1024).toFixed(1) + 'KB';
+    } else if (size > 1048576) {
+      return (size / 1048576).toFixed(1) + 'MB';
+    }
+
+    return '';
+  }
+}

--- a/libs/components/src/lib/components/file-upload/pipes/upload-status.pipe.ts
+++ b/libs/components/src/lib/components/file-upload/pipes/upload-status.pipe.ts
@@ -1,0 +1,21 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { UploadingStatusEnum } from '../file-upload.enums';
+
+@Pipe({ name: 'prizmUploadStatus', standalone: true })
+export class PrizmUploadStatusPipe implements PipeTransform {
+  public transform(progress: number, error: boolean): UploadingStatusEnum {
+    if (error) {
+      return UploadingStatusEnum.warning;
+    }
+
+    if (progress === 0) {
+      return UploadingStatusEnum.idle;
+    }
+
+    if (progress === 100) {
+      return UploadingStatusEnum.success;
+    }
+
+    return UploadingStatusEnum.progress;
+  }
+}

--- a/libs/components/src/lib/components/file-upload/types.ts
+++ b/libs/components/src/lib/components/file-upload/types.ts
@@ -9,3 +9,9 @@ export type PrizmFilesProgress = {
     error?: boolean;
   };
 };
+
+export type PrizmFileUploadOptions = {
+  showRetryButtons: boolean;
+};
+
+export type PrizmFilesMap = Map<string, { file: File; progress: number; error: boolean; url?: string }>;

--- a/libs/components/src/lib/components/file-upload/types.ts
+++ b/libs/components/src/lib/components/file-upload/types.ts
@@ -12,6 +12,12 @@ export type PrizmFilesProgress = {
 
 export type PrizmFileUploadOptions = {
   showRetryButtons: boolean;
+  statusNames?: {
+    idle: string;
+    progress: string;
+    warning: string;
+    success: string;
+  };
 };
 
 export type PrizmFilesMap = Map<string, { file: File; progress: number; error: boolean; url?: string }>;

--- a/libs/components/src/lib/components/file-upload/types.ts
+++ b/libs/components/src/lib/components/file-upload/types.ts
@@ -1,3 +1,5 @@
+import { UploadingStatusEnum } from './file-upload.enums';
+
 export type PrizmFileValidationErrors = {
   accept?: { expect: string; current: string };
   size?: { max: number; current: number };
@@ -13,10 +15,7 @@ export type PrizmFilesProgress = {
 export type PrizmFileUploadOptions = {
   showRetryButtons: boolean;
   statusNames?: {
-    idle: string;
-    progress: string;
-    warning: string;
-    success: string;
+    [key in UploadingStatusEnum]: string;
   };
 };
 

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -9,10 +9,10 @@ export interface PrizmLanguageFileUpload {
     dropzone__title: string;
     dropzone__description: string;
     btn__select: string;
-    status__idle: string;
-    status__progress: string;
-    status__warning: string;
-    status__success: string;
+    idle: string;
+    progress: string;
+    warning: string;
+    success: string;
   };
 }
 export interface PrizmLanguageInputLayoutDateRelative {

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -4,15 +4,16 @@ import { PrizmLanguageName, PrizmLanguageShortName } from './language-names';
 // prettier-ignore
 type MONTHS_ARRAY = [string, string, string, string, string, string, string, string, string, string, string, string];
 
+// idle, proggres, warning and success are options for backward compatibility
 export interface PrizmLanguageFileUpload {
   fileUpload: {
     dropzone__title: string;
     dropzone__description: string;
     btn__select: string;
-    idle: string;
-    progress: string;
-    warning: string;
-    success: string;
+    idle?: string;
+    progress?: string;
+    warning?: string;
+    success?: string;
   };
 }
 export interface PrizmLanguageInputLayoutDateRelative {

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -9,6 +9,10 @@ export interface PrizmLanguageFileUpload {
     dropzone__title: string;
     dropzone__description: string;
     btn__select: string;
+    status__idle: string;
+    status__progress: string;
+    status__warning: string;
+    status__success: string;
   };
 }
 export interface PrizmLanguageInputLayoutDateRelative {

--- a/libs/i18n/src/lib/languages/russian/file-upload.ts
+++ b/libs/i18n/src/lib/languages/russian/file-upload.ts
@@ -5,10 +5,10 @@ export const PRIZM_RUSSIAN_FILE_UPLOAD: PrizmLanguageFileUpload = {
     dropzone__description: 'Выберите файл или перетащите его в эту область',
     dropzone__title: 'Загрузка файлов',
     btn__select: 'Выбрать',
-    status__idle: 'Ожидание загрузки',
-    status__progress: 'Загрузка',
-    status__warning: 'Ошибка',
-    status__success: 'Загружено',
+    idle: 'Ожидание загрузки',
+    progress: 'Загрузка',
+    warning: 'Ошибка',
+    success: 'Загружено',
   },
 };
 
@@ -17,9 +17,9 @@ export const PRIZM_ENGLISH_FILE_UPLOAD: PrizmLanguageFileUpload = {
     dropzone__description: 'Select a file or drag it to this area',
     dropzone__title: 'File upload',
     btn__select: 'Browse',
-    status__idle: 'Waiting to upload',
-    status__progress: 'Uploading',
-    status__warning: 'Error',
-    status__success: 'Uploaded',
+    idle: 'Waiting to upload',
+    progress: 'Uploading',
+    warning: 'Error',
+    success: 'Uploaded',
   },
 };

--- a/libs/i18n/src/lib/languages/russian/file-upload.ts
+++ b/libs/i18n/src/lib/languages/russian/file-upload.ts
@@ -5,6 +5,10 @@ export const PRIZM_RUSSIAN_FILE_UPLOAD: PrizmLanguageFileUpload = {
     dropzone__description: 'Выберите файл или перетащите его в эту область',
     dropzone__title: 'Загрузка файлов',
     btn__select: 'Выбрать',
+    status__idle: 'Ожидание загрузки',
+    status__progress: 'Загрузка',
+    status__warning: 'Ошибка',
+    status__success: 'Загружено',
   },
 };
 
@@ -13,5 +17,9 @@ export const PRIZM_ENGLISH_FILE_UPLOAD: PrizmLanguageFileUpload = {
     dropzone__description: 'Select a file or drag it to this area',
     dropzone__title: 'File upload',
     btn__select: 'Browse',
+    status__idle: 'Waiting to upload',
+    status__progress: 'Uploading',
+    status__warning: 'Error',
+    status__success: 'Uploaded',
   },
 };


### PR DESCRIPTION
fix(components/file-upload): progress status translations for file upload #931
refactor(components/file-upload): funtions for file size and uploading status are moved to pipes #931
refactor(components/file-upload): deprecated modules replaced by standalones i File Upload Component #931
refactor(components/file-upload): translations for uploading status are moved from fileUploadOptions to translations  #931

Resolved #931
