### PR TITLE
fix: moved required deps to dependencies group

### DIFF
--- a/libs/charts/base/package.json
+++ b/libs/charts/base/package.json
@@ -8,14 +8,14 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^16.1.8",
     "@angular/core": "^16.1.8",
     "@prizm-ui/theme": "^3.4.0",
-    "@prizm-ui/helpers": "^3.4.0",
-    "@antv/g2plot": "^2.4.22"
+    "@prizm-ui/helpers": "^3.4.0"
   },
   "dependencies": {
+    "@antv/g2plot": "^2.4.22",
+    "lodash-es": "^4.17.21",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/charts/base/package.json.ng14
+++ b/libs/charts/base/package.json.ng14
@@ -8,14 +8,14 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^14.2.12",
     "@angular/core": "^14.2.12",
     "@prizm-ui/theme": "^1.8.0",
-    "@prizm-ui/helpers": "^1.8.0",
-    "@antv/g2plot": "^2.4.22"
+    "@prizm-ui/helpers": "^1.8.0"
   },
   "dependencies": {
+    "@antv/g2plot": "^2.4.22",
+    "lodash-es": "^4.17.21",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/charts/base/package.json.ng15
+++ b/libs/charts/base/package.json.ng15
@@ -8,14 +8,14 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
     "@prizm-ui/theme": "^2.3.0",
-    "@prizm-ui/helpers": "^2.2.0",
-    "@antv/g2plot": "^2.4.22"
+    "@prizm-ui/helpers": "^2.2.0"
   },
   "dependencies": {
+    "@antv/g2plot": "^2.4.22",
+    "lodash-es": "^4.17.21",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/charts/base/package.json.ng16
+++ b/libs/charts/base/package.json.ng16
@@ -8,14 +8,14 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^16.1.8",
     "@angular/core": "^16.1.8",
     "@prizm-ui/theme": "^3.4.0",
-    "@prizm-ui/helpers": "^3.4.0",
-    "@antv/g2plot": "^2.4.22"
+    "@prizm-ui/helpers": "^3.4.0"
   },
   "dependencies": {
+    "@antv/g2plot": "^2.4.22",
+    "lodash-es": "^4.17.21",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -9,21 +9,21 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^16.1.8",
     "@angular/core": "^16.1.8",
-    "@angular/cdk": "^16.1.7",
-    "ngx-mask": "16.2.6",
-    "@ng-web-apis/common": "^3.0.0",
-    "@ng-web-apis/resize-observer": "^3.0.1",
-    "@ng-web-apis/intersection-observer": "^3.0.0",
-    "@ng-web-apis/mutation-observer": "3.0.1",
     "@prizm-ui/helpers": "^3.4.0",
     "@prizm-ui/core": "^3.4.0",
     "@prizm-ui/i18n": "^3.4.0",
     "@prizm-ui/theme": "^3.4.0"
   },
   "dependencies": {
+    "@angular/cdk": "^16.1.7",
+    "@ng-web-apis/common": "^3.0.0",
+    "@ng-web-apis/resize-observer": "^3.0.1",
+    "@ng-web-apis/intersection-observer": "^3.0.0",
+    "@ng-web-apis/mutation-observer": "3.0.1",
+    "lodash-es": "^4.17.21",
+    "ngx-mask": "16.2.6",
     "tslib": "^2.4.0"
   }
 }

--- a/libs/components/package.json.ng14
+++ b/libs/components/package.json.ng14
@@ -9,20 +9,20 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^14.2.12",
     "@angular/core": "^14.2.12",
-    "ngx-mask": "14.2.4",
-    "@ng-web-apis/common": "2.0.0",
-    "@ng-web-apis/resize-observer": "2.0.0",
-    "@ng-web-apis/intersection-observer": "2.0.0",
-    "@ng-web-apis/mutation-observer": "2.0.0",
     "@prizm-ui/helpers": "^1.8.0",
     "@prizm-ui/core": "^1.8.0",
     "@prizm-ui/i18n": "^1.8.0",
     "@prizm-ui/theme": "^1.8.0"
   },
   "dependencies": {
+    "@ng-web-apis/common": "2.0.0",
+    "@ng-web-apis/resize-observer": "2.0.0",
+    "@ng-web-apis/intersection-observer": "2.0.0",
+    "@ng-web-apis/mutation-observer": "2.0.0",
+    "lodash-es": "^4.17.21",
+    "ngx-mask": "14.2.4",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/components/package.json.ng15
+++ b/libs/components/package.json.ng15
@@ -9,21 +9,21 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@angular/cdk": "^15.2.0",
-    "ngx-mask": "15.1.5",
-    "@ng-web-apis/common": "^2.0.0",
-    "@ng-web-apis/resize-observer": "2.0.0",
-    "@ng-web-apis/intersection-observer": "2.0.0",
-    "@ng-web-apis/mutation-observer": "2.0.0",
     "@prizm-ui/helpers": "^2.5.0",
     "@prizm-ui/core": "^2.5.0",
     "@prizm-ui/i18n": "^2.5.0",
     "@prizm-ui/theme": "^2.5.0"
   },
   "dependencies": {
+    "@angular/cdk": "^15.2.0",
+    "@ng-web-apis/common": "^2.0.0",
+    "@ng-web-apis/resize-observer": "2.0.0",
+    "@ng-web-apis/intersection-observer": "2.0.0",
+    "@ng-web-apis/mutation-observer": "2.0.0",
+    "lodash-es": "^4.17.21",
+    "ngx-mask": "15.1.5",
     "tslib": "^2.3.0"
   }
 }

--- a/libs/components/package.json.ng16
+++ b/libs/components/package.json.ng16
@@ -9,21 +9,21 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "lodash-es": "^4.17.21",
     "@angular/common": "^16.1.8",
     "@angular/core": "^16.1.8",
-    "@angular/cdk": "^16.1.7",
-    "ngx-mask": "16.2.6",
-    "@ng-web-apis/common": "^3.0.0",
-    "@ng-web-apis/resize-observer": "^3.0.0",
-    "@ng-web-apis/intersection-observer": "^3.0.0",
-    "@ng-web-apis/mutation-observer": "^3.0.0",
     "@prizm-ui/helpers": "^3.4.0",
     "@prizm-ui/core": "^3.4.0",
     "@prizm-ui/i18n": "^3.4.0",
     "@prizm-ui/theme": "^3.4.0"
   },
   "dependencies": {
-    "tslib": "^2.3.0"
+    "@angular/cdk": "^16.1.7",
+    "@ng-web-apis/common": "^3.0.0",
+    "@ng-web-apis/resize-observer": "^3.0.1",
+    "@ng-web-apis/intersection-observer": "^3.0.0",
+    "@ng-web-apis/mutation-observer": "3.0.1",
+    "lodash-es": "^4.17.21",
+    "ngx-mask": "16.2.6",
+    "tslib": "^2.4.0"
   }
 }


### PR DESCRIPTION
Перемещены зависимости, которые не требуются документацией и, скорее всего, не используются отдельно в проекте из peerDependencies в dependencies.