### PR TITLE
fix: invalid icon name can be set in accordion live demo #947

### DIFF
--- a/apps/doc/src/app/components/accordion/accordion-example.component.html
+++ b/apps/doc/src/app/components/accordion/accordion-example.component.html
@@ -132,6 +132,7 @@
       </ng-template>
       <ng-template
         [(documentationPropertyValue)]="icon"
+        [documentationPropertyValues]="iconVariants"
         documentationPropertyName="icon"
         documentationPropertyType="PolymorphContent<PrizmAccordionItemData>"
         documentationPropertyMode="input"

--- a/apps/doc/src/app/components/accordion/accordion-example.component.ts
+++ b/apps/doc/src/app/components/accordion/accordion-example.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
-import { PolymorphContent, PrizmAccordionItemData } from '@prizm-ui/components';
+import { PolymorphContent, PrizmAccordionItemData, IconDefs } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-accordion-example',
@@ -12,7 +12,11 @@ export class AccordionExampleComponent {
   public disabled = false;
   public onlyOneExpanded = false;
   public title: PolymorphContent<PrizmAccordionItemData> = 'Title number 2';
-  public icon: PolymorphContent<PrizmAccordionItemData> = 'Title number 2';
+  public iconVariants: ReadonlyArray<PolymorphContent> = [
+    '',
+    ...IconDefs.reduce((a: any[], c) => a.concat(c?.data), []),
+  ];
+  public icon: PolymorphContent = this.iconVariants[0];
   public isExpanded = false;
 
   public readonly exampleBasicAccordion: TuiDocExample = {

--- a/apps/doc/src/app/components/accordion/accordion-example.module.ts
+++ b/apps/doc/src/app/components/accordion/accordion-example.module.ts
@@ -1,7 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AccordionExampleComponent } from './accordion-example.component';
-import { PrizmAccordionModule, PrizmCheckboxModule } from '@prizm-ui/components';
+import {
+  PrizmAccordionComponent,
+  PrizmAccordionItemComponent,
+  PrizmCheckboxComponent,
+} from '@prizm-ui/components';
 import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { AccordionBasicExampleComponent } from './examples/accordion-basic-example/accordion-basic-example.component';
@@ -21,9 +25,10 @@ import { PrizmAccordionCustomTitleExampleModule } from './examples/custom-title/
   ],
   imports: [
     CommonModule,
-    PrizmAccordionModule,
+    PrizmAccordionComponent,
+    PrizmAccordionItemComponent,
     PrizmAddonDocModule,
-    PrizmCheckboxModule,
+    PrizmCheckboxComponent,
     PrizmAccordionCustomTitleExampleModule,
     RouterModule.forChild(prizmDocGenerateRoutes(AccordionExampleComponent)),
   ],

--- a/apps/doc/src/app/components/accordion/accordion-example.module.ts
+++ b/apps/doc/src/app/components/accordion/accordion-example.module.ts
@@ -1,11 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AccordionExampleComponent } from './accordion-example.component';
-import {
-  PrizmAccordionComponent,
-  PrizmAccordionItemComponent,
-  PrizmCheckboxComponent,
-} from '@prizm-ui/components';
+import { PrizmAccordionModule, PrizmCheckboxComponent } from '@prizm-ui/components';
 import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { AccordionBasicExampleComponent } from './examples/accordion-basic-example/accordion-basic-example.component';
@@ -25,8 +21,7 @@ import { PrizmAccordionCustomTitleExampleModule } from './examples/custom-title/
   ],
   imports: [
     CommonModule,
-    PrizmAccordionComponent,
-    PrizmAccordionItemComponent,
+    PrizmAccordionModule,
     PrizmAddonDocModule,
     PrizmCheckboxComponent,
     PrizmAccordionCustomTitleExampleModule,

--- a/apps/doc/src/app/components/buttons/button/button.component.ts
+++ b/apps/doc/src/app/components/buttons/button/button.component.ts
@@ -5,7 +5,6 @@ import {
   PolymorphContent,
   PrizmAppearance,
   PrizmAppearanceType,
-  PrizmContent,
   PrizmSize,
 } from '@prizm-ui/components';
 

--- a/libs/components/src/lib/components/accordion/components/accordion-item/accordion-item.component.less
+++ b/libs/components/src/lib/components/accordion/components/accordion-item/accordion-item.component.less
@@ -94,7 +94,8 @@
     cursor: not-allowed;
 
     & > .accordion__header .title,
-    & > .accordion__header {
+    & > .accordion__header,
+    & > .accordion__header .header-icon {
       color: var(--prizm-v3-text-icon-disable);
       pointer-events: none;
     }


### PR DESCRIPTION
fix(documentation/accordion): invalid icon name can be set in accordion live demo #947

Resolved #947 