### PR TITLE
fix(components): added empty initializer for all query list

### DIFF
--- a/libs/components/src/lib/components/accordion/accordion.component.ts
+++ b/libs/components/src/lib/components/accordion/accordion.component.ts
@@ -9,9 +9,8 @@ import {
 import { PrizmAccordionItemComponent } from './components/accordion-item/accordion-item.component';
 import { merge } from 'rxjs';
 import { mapTo, takeUntil } from 'rxjs/operators';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-accordion',
@@ -24,7 +23,7 @@ import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 export class PrizmAccordionComponent extends PrizmAbstractTestId implements AfterContentInit {
   @Input() public onlyOneExpanded = false;
   @ContentChildren(PrizmAccordionItemComponent, { descendants: false })
-  accordionItems: QueryList<PrizmAccordionItemComponent> = EMPTY_QUERY;
+  accordionItems: QueryList<PrizmAccordionItemComponent> = prizmEmptyQueryList();
 
   override readonly testId_ = 'ui_accordion';
 

--- a/libs/components/src/lib/components/accordion/accordion.component.ts
+++ b/libs/components/src/lib/components/accordion/accordion.component.ts
@@ -11,6 +11,7 @@ import { merge } from 'rxjs';
 import { mapTo, takeUntil } from 'rxjs/operators';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-accordion',
@@ -23,7 +24,7 @@ import { PrizmAbstractTestId } from '../../abstract/interactive';
 export class PrizmAccordionComponent extends PrizmAbstractTestId implements AfterContentInit {
   @Input() public onlyOneExpanded = false;
   @ContentChildren(PrizmAccordionItemComponent, { descendants: false })
-  accordionItems!: QueryList<PrizmAccordionItemComponent>;
+  accordionItems: QueryList<PrizmAccordionItemComponent> = EMPTY_QUERY;
 
   override readonly testId_ = 'ui_accordion';
 

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
@@ -16,14 +16,13 @@ import {
 } from '@angular/core';
 import { IBreadcrumb } from './breadcrumb.interface';
 import { animationFrameScheduler, BehaviorSubject, merge, Subject } from 'rxjs';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 import { debounceTime, observeOn, takeUntil, tap } from 'rxjs/operators';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { PrizmBreadcrumbDirective } from './breadcrumbs.directive';
 import { CommonModule } from '@angular/common';
 import { PrizmIconModule } from '../icon';
 import { PrizmDropdownHostModule } from '../dropdowns/dropdown-host';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-breadcrumbs',
@@ -57,9 +56,9 @@ export class PrizmBreadcrumbsComponent<Breadcrumb extends IBreadcrumb>
   @ViewChild('container', { static: true }) public containerRef!: ElementRef;
   @ViewChild('breadcrumbsFake', { static: true }) public fakeBreadcrumbContainer!: ElementRef;
   @ViewChildren('breadcrumb', { read: ElementRef }) public breadcrumbsList: QueryList<ElementRef> =
-    EMPTY_QUERY;
+    prizmEmptyQueryList();
   @ContentChildren(PrizmBreadcrumbDirective) public breadcrumbsItem: QueryList<PrizmBreadcrumbDirective> =
-    EMPTY_QUERY;
+    prizmEmptyQueryList();
 
   public breadcrumbs$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);
   public breadcrumbsToShow$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);

--- a/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/components/src/lib/components/breadcrumbs/breadcrumbs.component.ts
@@ -23,6 +23,7 @@ import { PrizmBreadcrumbDirective } from './breadcrumbs.directive';
 import { CommonModule } from '@angular/common';
 import { PrizmIconModule } from '../icon';
 import { PrizmDropdownHostModule } from '../dropdowns/dropdown-host';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-breadcrumbs',
@@ -55,8 +56,10 @@ export class PrizmBreadcrumbsComponent<Breadcrumb extends IBreadcrumb>
   @Output() public breadcrumbChange: EventEmitter<Breadcrumb> = new EventEmitter();
   @ViewChild('container', { static: true }) public containerRef!: ElementRef;
   @ViewChild('breadcrumbsFake', { static: true }) public fakeBreadcrumbContainer!: ElementRef;
-  @ViewChildren('breadcrumb', { read: ElementRef }) public breadcrumbsList!: QueryList<ElementRef>;
-  @ContentChildren(PrizmBreadcrumbDirective) public breadcrumbsItem!: QueryList<PrizmBreadcrumbDirective>;
+  @ViewChildren('breadcrumb', { read: ElementRef }) public breadcrumbsList: QueryList<ElementRef> =
+    EMPTY_QUERY;
+  @ContentChildren(PrizmBreadcrumbDirective) public breadcrumbsItem: QueryList<PrizmBreadcrumbDirective> =
+    EMPTY_QUERY;
 
   public breadcrumbs$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);
   public breadcrumbsToShow$: BehaviorSubject<Breadcrumb[]> = new BehaviorSubject<Breadcrumb[]>([]);

--- a/libs/components/src/lib/components/grid/grid.component.ts
+++ b/libs/components/src/lib/components/grid/grid.component.ts
@@ -12,6 +12,7 @@ import {
 import { PrizmGridItemComponent } from './components/grid-item/grid-item.component';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { CommonModule } from '@angular/common';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-grid',
@@ -26,8 +27,12 @@ export class PrizmGridComponent extends PrizmAbstractTestId implements AfterCont
   @Input() public rows = '10';
 
   @ViewChild('container', { static: true }) container!: ElementRef;
-  @ContentChildren(PrizmGridItemComponent, { read: ElementRef }) public gridItems!: QueryList<ElementRef>;
-  @ContentChildren(PrizmGridItemComponent) public gridItemsData!: QueryList<PrizmGridItemComponent>;
+
+  @ContentChildren(PrizmGridItemComponent, { read: ElementRef })
+  public gridItems: QueryList<ElementRef> = EMPTY_QUERY;
+
+  @ContentChildren(PrizmGridItemComponent)
+  public gridItemsData: QueryList<PrizmGridItemComponent> = EMPTY_QUERY;
 
   override readonly testId_ = 'ui-area--grid';
 

--- a/libs/components/src/lib/components/grid/grid.component.ts
+++ b/libs/components/src/lib/components/grid/grid.component.ts
@@ -1,18 +1,18 @@
 import {
-  Component,
-  ChangeDetectionStrategy,
-  Input,
   AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
   ContentChildren,
   ElementRef,
+  HostBinding,
+  Input,
   QueryList,
   ViewChild,
-  HostBinding,
 } from '@angular/core';
 import { PrizmGridItemComponent } from './components/grid-item/grid-item.component';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { CommonModule } from '@angular/common';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
+import { prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 @Component({
   selector: 'prizm-grid',
@@ -29,10 +29,10 @@ export class PrizmGridComponent extends PrizmAbstractTestId implements AfterCont
   @ViewChild('container', { static: true }) container!: ElementRef;
 
   @ContentChildren(PrizmGridItemComponent, { read: ElementRef })
-  public gridItems: QueryList<ElementRef> = EMPTY_QUERY;
+  public gridItems: QueryList<ElementRef> = prizmEmptyQueryList();
 
   @ContentChildren(PrizmGridItemComponent)
-  public gridItemsData: QueryList<PrizmGridItemComponent> = EMPTY_QUERY;
+  public gridItemsData: QueryList<PrizmGridItemComponent> = prizmEmptyQueryList();
 
   override readonly testId_ = 'ui-area--grid';
 

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.ts
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.ts
@@ -17,6 +17,7 @@ import { PRIZM_NAVIGATION_MENU_CHILDREN_HANDLER, PrizmNavigationMenuChildrenHand
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { PrizmTreeControllerDirective, PrizmTreeModule } from '../../../tree';
 import { NgFor } from '@angular/common';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-navigation-menu-items',
@@ -29,9 +30,9 @@ import { NgFor } from '@angular/common';
 export class PrizmNavigationMenuItemsComponent<
   T extends { children?: unknown[] }
 > extends PrizmAbstractTestId {
-  @ViewChildren(PrizmNavigationMenuItemComponent) private menuItemsList!: QueryList<
+  @ViewChildren(PrizmNavigationMenuItemComponent) private menuItemsList: QueryList<
     PrizmNavigationMenuItemComponent<T>
-  >;
+  > = EMPTY_QUERY;
 
   @Output() itemExpandedChanged = new EventEmitter<{
     item: InternalPrizmNavigationMenuItem<T>;

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.ts
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-items/prizm-navigation-menu-items.component.ts
@@ -17,7 +17,7 @@ import { PRIZM_NAVIGATION_MENU_CHILDREN_HANDLER, PrizmNavigationMenuChildrenHand
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { PrizmTreeControllerDirective, PrizmTreeModule } from '../../../tree';
 import { NgFor } from '@angular/common';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
+import { prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 @Component({
   selector: 'prizm-navigation-menu-items',
@@ -32,7 +32,7 @@ export class PrizmNavigationMenuItemsComponent<
 > extends PrizmAbstractTestId {
   @ViewChildren(PrizmNavigationMenuItemComponent) private menuItemsList: QueryList<
     PrizmNavigationMenuItemComponent<T>
-  > = EMPTY_QUERY;
+  > = prizmEmptyQueryList();
 
   @Output() itemExpandedChanged = new EventEmitter<{
     item: InternalPrizmNavigationMenuItem<T>;

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.ts
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.ts
@@ -35,6 +35,7 @@ import { PrizmButtonModule } from '../../../button';
 import { PolymorphOutletDirective, PrizmHoveredModule } from '../../../../directives';
 import { PrizmAccordionComponent } from '../../../accordion';
 import { PrizmNavigationMenuToolbarComponent } from '../prizm-navigation-menu-toolbar/prizm-navigation-menu-toolbar.component';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-navigation-menu',
@@ -60,7 +61,7 @@ export class PrizmNavigationMenuComponent<
   UserItem extends Omit<PrizmNavigationMenuItem, 'children'> & { children?: UserItem[] }
 > extends PrizmAbstractTestId {
   @ContentChildren(PrizmNavigationMenuGroupComponent)
-  menuGroups!: QueryList<PrizmNavigationMenuGroupComponent<UserItem>>;
+  menuGroups: QueryList<PrizmNavigationMenuGroupComponent<UserItem>> = EMPTY_QUERY;
 
   @Output() homeClicked = new EventEmitter<void>();
   @Output() activeItemChanged = new EventEmitter<UserItem>();

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.ts
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.ts
@@ -15,7 +15,7 @@ import { PrizmNavigationMenuToolbarService } from '../../services/prizm-navigati
 import { PrizmNavigationMenuService } from '../../services/prizm-navigation-menu.service';
 import { Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 import {
   GroupExpandedChangedEvent,
   ItemExpandedChangedEvent,
@@ -35,7 +35,6 @@ import { PrizmButtonModule } from '../../../button';
 import { PolymorphOutletDirective, PrizmHoveredModule } from '../../../../directives';
 import { PrizmAccordionComponent } from '../../../accordion';
 import { PrizmNavigationMenuToolbarComponent } from '../prizm-navigation-menu-toolbar/prizm-navigation-menu-toolbar.component';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-navigation-menu',
@@ -61,7 +60,7 @@ export class PrizmNavigationMenuComponent<
   UserItem extends Omit<PrizmNavigationMenuItem, 'children'> & { children?: UserItem[] }
 > extends PrizmAbstractTestId {
   @ContentChildren(PrizmNavigationMenuGroupComponent)
-  menuGroups: QueryList<PrizmNavigationMenuGroupComponent<UserItem>> = EMPTY_QUERY;
+  menuGroups: QueryList<PrizmNavigationMenuGroupComponent<UserItem>> = prizmEmptyQueryList();
 
   @Output() homeClicked = new EventEmitter<void>();
   @Output() activeItemChanged = new EventEmitter<UserItem>();

--- a/libs/components/src/lib/components/slider/slider.component.ts
+++ b/libs/components/src/lib/components/slider/slider.component.ts
@@ -15,14 +15,13 @@ import {
   ViewChildren,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 import { fromEvent, merge, Observable } from 'rxjs';
 import { distinctUntilChanged, map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PrizmSliderCnobComponent } from './slider-cnob.component';
 import { PrizmSliderCnobValuePosition, PrizmSliderOrientation, PrizmSliderValue } from './types';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-slider',
@@ -58,7 +57,8 @@ export class PrizmSliderComponent
 
   @ViewChild('track') scrollbar!: ElementRef<HTMLDivElement>;
 
-  @ViewChildren(PrizmSliderCnobComponent) private _cnobs: QueryList<PrizmSliderCnobComponent> = EMPTY_QUERY;
+  @ViewChildren(PrizmSliderCnobComponent) private _cnobs: QueryList<PrizmSliderCnobComponent> =
+    prizmEmptyQueryList();
 
   private get cnobs(): Observable<QueryList<PrizmSliderCnobComponent>> {
     return this._cnobs.changes.pipe(startWith(this._cnobs));

--- a/libs/components/src/lib/components/slider/slider.component.ts
+++ b/libs/components/src/lib/components/slider/slider.component.ts
@@ -22,6 +22,7 @@ import { distinctUntilChanged, map, startWith, switchMap, takeUntil, tap } from 
 import { PrizmSliderCnobComponent } from './slider-cnob.component';
 import { PrizmSliderCnobValuePosition, PrizmSliderOrientation, PrizmSliderValue } from './types';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-slider',
@@ -57,7 +58,7 @@ export class PrizmSliderComponent
 
   @ViewChild('track') scrollbar!: ElementRef<HTMLDivElement>;
 
-  @ViewChildren(PrizmSliderCnobComponent) private _cnobs!: QueryList<PrizmSliderCnobComponent>;
+  @ViewChildren(PrizmSliderCnobComponent) private _cnobs: QueryList<PrizmSliderCnobComponent> = EMPTY_QUERY;
 
   private get cnobs(): Observable<QueryList<PrizmSliderCnobComponent>> {
     return this._cnobs.changes.pipe(startWith(this._cnobs));

--- a/libs/components/src/lib/components/splitter/splitter.component.ts
+++ b/libs/components/src/lib/components/splitter/splitter.component.ts
@@ -29,6 +29,7 @@ import { PrizmSplitterCustomGutterDirective } from './custom-gutter.directive';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { CommonModule } from '@angular/common';
 import { ResizeObserverModule } from '@ng-web-apis/resize-observer';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 type AreaRealSize = { area: PrizmSplitterAreaComponent; realSize: number; realMinSize: number };
 type GutterData = { areaBefore: number; areaAfter: number; order: number };
@@ -55,10 +56,11 @@ export class PrizmSplitterComponent extends PrizmAbstractTestId implements After
   @ViewChild('container', { static: true }) private containerElement!: ElementRef<HTMLElement>;
   @ContentChild(PrizmSplitterCustomGutterDirective) customGutter!: PrizmSplitterCustomGutterDirective;
 
-  @ContentChildren(PrizmSplitterAreaComponent) splitterAreaQueryList!: QueryList<PrizmSplitterAreaComponent>;
+  @ContentChildren(PrizmSplitterAreaComponent) splitterAreaQueryList: QueryList<PrizmSplitterAreaComponent> =
+    EMPTY_QUERY;
 
   @ViewChildren(PrizmSplitterGutterComponent)
-  splitterGutterQueryList!: QueryList<PrizmSplitterGutterComponent>;
+  splitterGutterQueryList: QueryList<PrizmSplitterGutterComponent> = EMPTY_QUERY;
 
   override readonly testId_ = 'ui_splitter';
   get gutterElementSize(): number {

--- a/libs/components/src/lib/components/splitter/splitter.component.ts
+++ b/libs/components/src/lib/components/splitter/splitter.component.ts
@@ -19,7 +19,7 @@ import { PrizmSplitterOrientation } from './types';
 import { asyncScheduler, BehaviorSubject, fromEvent, merge, Observable } from 'rxjs';
 import { map, observeOn, startWith, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 import { PrizmSplitterGutterComponent } from './gutter/gutter.component';
 import { PrizmSplitterAreaComponent } from './area/area.component';
@@ -29,7 +29,6 @@ import { PrizmSplitterCustomGutterDirective } from './custom-gutter.directive';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { CommonModule } from '@angular/common';
 import { ResizeObserverModule } from '@ng-web-apis/resize-observer';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 type AreaRealSize = { area: PrizmSplitterAreaComponent; realSize: number; realMinSize: number };
 type GutterData = { areaBefore: number; areaAfter: number; order: number };
@@ -57,10 +56,10 @@ export class PrizmSplitterComponent extends PrizmAbstractTestId implements After
   @ContentChild(PrizmSplitterCustomGutterDirective) customGutter!: PrizmSplitterCustomGutterDirective;
 
   @ContentChildren(PrizmSplitterAreaComponent) splitterAreaQueryList: QueryList<PrizmSplitterAreaComponent> =
-    EMPTY_QUERY;
+    prizmEmptyQueryList();
 
   @ViewChildren(PrizmSplitterGutterComponent)
-  splitterGutterQueryList: QueryList<PrizmSplitterGutterComponent> = EMPTY_QUERY;
+  splitterGutterQueryList: QueryList<PrizmSplitterGutterComponent> = prizmEmptyQueryList();
 
   override readonly testId_ = 'ui_splitter';
   get gutterElementSize(): number {

--- a/libs/components/src/lib/components/stepper/stepper-selector.component.ts
+++ b/libs/components/src/lib/components/stepper/stepper-selector.component.ts
@@ -5,6 +5,7 @@ import { PrizmStepperStepDirective } from './stepper-step.directive';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { CommonModule } from '@angular/common';
 import { PrizmIconComponent } from '../icon/icon.component';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-stepper-selector',
@@ -28,7 +29,7 @@ export class PrizmStepperSelectorComponent extends PrizmAbstractTestId {
   @Output() selectStep = new EventEmitter<number>();
 
   @ViewChildren(PrizmStepperSelectorItemDirective)
-  selectorItems!: QueryList<PrizmStepperSelectorItemDirective>;
+  selectorItems: QueryList<PrizmStepperSelectorItemDirective> = EMPTY_QUERY;
   override readonly testId_ = 'ui_stepper--selector';
 
   public clickOnStep(index: number): void {

--- a/libs/components/src/lib/components/stepper/stepper-selector.component.ts
+++ b/libs/components/src/lib/components/stepper/stepper-selector.component.ts
@@ -5,7 +5,7 @@ import { PrizmStepperStepDirective } from './stepper-step.directive';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { CommonModule } from '@angular/common';
 import { PrizmIconComponent } from '../icon/icon.component';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
+import { prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 @Component({
   selector: 'prizm-stepper-selector',
@@ -29,7 +29,7 @@ export class PrizmStepperSelectorComponent extends PrizmAbstractTestId {
   @Output() selectStep = new EventEmitter<number>();
 
   @ViewChildren(PrizmStepperSelectorItemDirective)
-  selectorItems: QueryList<PrizmStepperSelectorItemDirective> = EMPTY_QUERY;
+  selectorItems: QueryList<PrizmStepperSelectorItemDirective> = prizmEmptyQueryList();
   override readonly testId_ = 'ui_stepper--selector';
 
   public clickOnStep(index: number): void {

--- a/libs/components/src/lib/components/stepper/stepper.component.ts
+++ b/libs/components/src/lib/components/stepper/stepper.component.ts
@@ -15,7 +15,7 @@ import { PrizmStepperStepDirective } from './stepper-step.directive';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { CommonModule } from '@angular/common';
 import { PrizmStepperSelectorComponent } from './stepper-selector.component';
-import { EMPTY_QUERY } from '@taiga-ui/cdk';
+import { prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 @Component({
   selector: 'prizm-stepper',
@@ -41,7 +41,7 @@ export class PrizmStepperComponent extends PrizmAbstractTestId implements AfterC
   @Output() selectStep = new EventEmitter<number>();
 
   @ContentChildren(PrizmStepperStepDirective)
-  prizmStepperStepDirectiveQL: QueryList<PrizmStepperStepDirective> = EMPTY_QUERY;
+  prizmStepperStepDirectiveQL: QueryList<PrizmStepperStepDirective> = prizmEmptyQueryList();
 
   steps$!: Observable<PrizmStepperStepDirective[]>;
   override readonly testId_ = 'ui_stepper';

--- a/libs/components/src/lib/components/stepper/stepper.component.ts
+++ b/libs/components/src/lib/components/stepper/stepper.component.ts
@@ -15,6 +15,7 @@ import { PrizmStepperStepDirective } from './stepper-step.directive';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { CommonModule } from '@angular/common';
 import { PrizmStepperSelectorComponent } from './stepper-selector.component';
+import { EMPTY_QUERY } from '@taiga-ui/cdk';
 
 @Component({
   selector: 'prizm-stepper',
@@ -40,7 +41,7 @@ export class PrizmStepperComponent extends PrizmAbstractTestId implements AfterC
   @Output() selectStep = new EventEmitter<number>();
 
   @ContentChildren(PrizmStepperStepDirective)
-  prizmStepperStepDirectiveQL!: QueryList<PrizmStepperStepDirective>;
+  prizmStepperStepDirectiveQL: QueryList<PrizmStepperStepDirective> = EMPTY_QUERY;
 
   steps$!: Observable<PrizmStepperStepDirective[]>;
   override readonly testId_ = 'ui_stepper';

--- a/libs/components/src/lib/components/table/directives/sort-by.directive.ts
+++ b/libs/components/src/lib/components/table/directives/sort-by.directive.ts
@@ -5,14 +5,14 @@ import { PrizmSortableDirective } from './sortable.directive';
 import { PrizmTableDirective } from './table.directive';
 import { PrizmComparator } from '../table.types';
 import { prizmDefaultProp } from '@prizm-ui/core';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
+import { prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 @Directive({
   selector: `table[prizmTable][prizmSortBy]`,
 })
 export class PrizmSortByDirective<T extends Partial<Record<keyof T, any>>> {
   @ContentChildren(PrizmSortableDirective, { descendants: true })
-  private readonly sortables: QueryList<PrizmSortableDirective<T>> = EMPTY_QUERY;
+  private readonly sortables: QueryList<PrizmSortableDirective<T>> = prizmEmptyQueryList();
 
   @Input()
   @prizmDefaultProp()

--- a/libs/components/src/lib/components/table/directives/sort-by.directive.ts
+++ b/libs/components/src/lib/components/table/directives/sort-by.directive.ts
@@ -5,15 +5,14 @@ import { PrizmSortableDirective } from './sortable.directive';
 import { PrizmTableDirective } from './table.directive';
 import { PrizmComparator } from '../table.types';
 import { prizmDefaultProp } from '@prizm-ui/core';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Directive({
   selector: `table[prizmTable][prizmSortBy]`,
 })
 export class PrizmSortByDirective<T extends Partial<Record<keyof T, any>>> {
   @ContentChildren(PrizmSortableDirective, { descendants: true })
-  private readonly sortables: QueryList<PrizmSortableDirective<T>> = new QueryList<
-    PrizmSortableDirective<T>
-  >();
+  private readonly sortables: QueryList<PrizmSortableDirective<T>> = EMPTY_QUERY;
 
   @Input()
   @prizmDefaultProp()

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -31,6 +31,7 @@ import { PrizmTableSorterService } from '../service';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmTableDataSourceInput } from '../table.types';
 import { PrizmTrComponent } from '../tr/tr.component';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -134,7 +135,7 @@ export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   readonly row?: PrizmRowDirective<T>;
 
   @ContentChildren(forwardRef(() => PrizmTrComponent))
-  readonly rows: QueryList<PrizmTrComponent<T>> = new QueryList<PrizmTrComponent<T>>();
+  readonly rows: QueryList<PrizmTrComponent<T>> = EMPTY_QUERY;
 
   columnsCount = 0;
   /**

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -17,7 +17,7 @@ import {
 import { CollectionViewer, isDataSource, ListRange } from '@angular/cdk/collections';
 
 import { prizmDefaultProp } from '@prizm-ui/core';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 import { BehaviorSubject, isObservable, Observable } from 'rxjs';
 import { switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PolymorphContent } from '../../../directives';
@@ -31,7 +31,6 @@ import { PrizmTableSorterService } from '../service';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmTableDataSourceInput } from '../table.types';
 import { PrizmTrComponent } from '../tr/tr.component';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -135,7 +134,7 @@ export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   readonly row?: PrizmRowDirective<T>;
 
   @ContentChildren(forwardRef(() => PrizmTrComponent))
-  readonly rows: QueryList<PrizmTrComponent<T>> = EMPTY_QUERY;
+  readonly rows: QueryList<PrizmTrComponent<T>> = prizmEmptyQueryList();
 
   columnsCount = 0;
   /**

--- a/libs/components/src/lib/components/table/th-group/th-group.component.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.component.ts
@@ -19,10 +19,9 @@ import { PrizmHeadDirective } from '../directives/head.directive';
 import { PrizmTableDirective } from '../directives/table.directive';
 import { PRIZM_TABLE_PROVIDER } from '../providers/table.provider';
 import { PrizmThComponent } from '../th/th.component';
-import { moveInEventLoopIteration } from '@prizm-ui/helpers';
+import { moveInEventLoopIteration, prizmEmptyQueryList } from '@prizm-ui/helpers';
 import { PrizmTableService } from '../table.service';
 import { PrizmThGroupService } from './th-group.service';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -51,10 +50,10 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
   }
 
   @ContentChildren(forwardRef(() => PrizmThComponent), { descendants: true })
-  readonly th: QueryList<PrizmThComponent<T>> = EMPTY_QUERY;
+  readonly th: QueryList<PrizmThComponent<T>> = prizmEmptyQueryList();
 
   @ContentChildren(forwardRef(() => PrizmHeadDirective))
-  readonly heads: QueryList<PrizmHeadDirective<T>> = EMPTY_QUERY;
+  readonly heads: QueryList<PrizmHeadDirective<T>> = prizmEmptyQueryList();
 
   heads$: Observable<PrizmHeadDirective<T>[]> | null = null;
 

--- a/libs/components/src/lib/components/table/th-group/th-group.component.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.component.ts
@@ -22,6 +22,7 @@ import { PrizmThComponent } from '../th/th.component';
 import { moveInEventLoopIteration } from '@prizm-ui/helpers';
 import { PrizmTableService } from '../table.service';
 import { PrizmThGroupService } from './th-group.service';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -49,14 +50,11 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
     );
   }
 
-  // @ContentChild(forwardRef(() => PrizmThComponent))
-  // readonly th!: PrizmThComponent<T>;
-
   @ContentChildren(forwardRef(() => PrizmThComponent), { descendants: true })
-  readonly th!: QueryList<PrizmThComponent<T>>;
+  readonly th: QueryList<PrizmThComponent<T>> = EMPTY_QUERY;
 
   @ContentChildren(forwardRef(() => PrizmHeadDirective))
-  readonly heads: QueryList<PrizmHeadDirective<T>> = new QueryList<PrizmHeadDirective<T>>();
+  readonly heads: QueryList<PrizmHeadDirective<T>> = EMPTY_QUERY;
 
   heads$: Observable<PrizmHeadDirective<T>[]> | null = null;
 

--- a/libs/components/src/lib/components/table/tr/tr.component.ts
+++ b/libs/components/src/lib/components/table/tr/tr.component.ts
@@ -22,6 +22,7 @@ import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmCellService } from '../directives/cell.service';
 import { PrizmTdService } from '../td/td.service';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -52,7 +53,7 @@ export class PrizmTrComponent<T extends Partial<Record<keyof T, unknown>>> {
   }
 
   @ContentChildren(forwardRef(() => PrizmCellDirective))
-  readonly cells: QueryList<PrizmCellDirective> = new QueryList<PrizmCellDirective>();
+  readonly cells: QueryList<PrizmCellDirective> = EMPTY_QUERY;
 
   readonly cells$ = merge(
     this.cells.changes,

--- a/libs/components/src/lib/components/table/tr/tr.component.ts
+++ b/libs/components/src/lib/components/table/tr/tr.component.ts
@@ -18,11 +18,10 @@ import { PrizmTableDirective } from '../directives/table.directive';
 import { PRIZM_TABLE_PROVIDER } from '../providers/table.provider';
 import { PrizmTbodyComponent } from '../tbody/tbody.component';
 import { PrizmTableCellStatus } from '../table.types';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmCellService } from '../directives/cell.service';
 import { PrizmTdService } from '../td/td.service';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -53,7 +52,7 @@ export class PrizmTrComponent<T extends Partial<Record<keyof T, unknown>>> {
   }
 
   @ContentChildren(forwardRef(() => PrizmCellDirective))
-  readonly cells: QueryList<PrizmCellDirective> = EMPTY_QUERY;
+  readonly cells: QueryList<PrizmCellDirective> = prizmEmptyQueryList();
 
   readonly cells$ = merge(
     this.cells.changes,

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -21,7 +21,12 @@ import { PrizmTabsService } from './tabs.service';
 import { PrizmTabComponent } from './components/tab.component';
 import { PrizmTabMenuItemDirective } from './tab-menu-item.directive';
 import { PrizmDropdownHostComponent } from '../dropdowns/dropdown-host';
-import { PrizmCallFuncPipe, PrizmDestroyService, PrizmLetDirective } from '@prizm-ui/helpers';
+import {
+  PrizmCallFuncPipe,
+  PrizmDestroyService,
+  prizmEmptyQueryList,
+  PrizmLetDirective,
+} from '@prizm-ui/helpers';
 import { PrizmTabCanOpen } from './tabs.model';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { CommonModule } from '@angular/common';
@@ -38,7 +43,6 @@ import { PrizmCounterComponent } from '../counter';
 import { PrizmIconModule } from '../icon';
 import { PrizmIconTabsPipe } from './pipes/icon-tabs.pipe';
 import { prizmIsTextOverflow$ } from '../../util';
-import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-tabs',
@@ -87,10 +91,10 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
   public tabsMoreDropdown!: PrizmDropdownHostComponent;
 
   @ContentChildren(PrizmTabComponent, { descendants: true })
-  public tabElements: QueryList<PrizmTabComponent> = EMPTY_QUERY;
+  public tabElements: QueryList<PrizmTabComponent> = prizmEmptyQueryList();
 
   @ContentChildren(PrizmTabMenuItemDirective, { read: TemplateRef, descendants: true })
-  public menuElements: QueryList<TemplateRef<PrizmTabComponent>> = EMPTY_QUERY;
+  public menuElements: QueryList<TemplateRef<PrizmTabComponent>> = prizmEmptyQueryList();
 
   override readonly testId_ = 'ui_tabs';
 

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -38,6 +38,7 @@ import { PrizmCounterComponent } from '../counter';
 import { PrizmIconModule } from '../icon';
 import { PrizmIconTabsPipe } from './pipes/icon-tabs.pipe';
 import { prizmIsTextOverflow$ } from '../../util';
+import { EMPTY_QUERY } from '@taiga-ui/cdk/constants/empty';
 
 @Component({
   selector: 'prizm-tabs',
@@ -84,10 +85,12 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
   @ViewChild('tabsContainer', { static: true }) public tabsContainer!: ElementRef;
   @ViewChild('tabsDropdown', { static: true }) public tabsDropdown!: PrizmDropdownHostComponent;
   public tabsMoreDropdown!: PrizmDropdownHostComponent;
+
   @ContentChildren(PrizmTabComponent, { descendants: true })
-  public tabElements!: QueryList<PrizmTabComponent>;
+  public tabElements: QueryList<PrizmTabComponent> = EMPTY_QUERY;
+
   @ContentChildren(PrizmTabMenuItemDirective, { read: TemplateRef, descendants: true })
-  public menuElements!: QueryList<TemplateRef<PrizmTabComponent>>;
+  public menuElements: QueryList<TemplateRef<PrizmTabComponent>> = EMPTY_QUERY;
 
   override readonly testId_ = 'ui_tabs';
 

--- a/libs/doc/base/src/lib/components/documentation/documentation.component.ts
+++ b/libs/doc/base/src/lib/components/documentation/documentation.component.ts
@@ -12,7 +12,6 @@ import {
   ViewChildren,
 } from '@angular/core';
 import {
-  EMPTY_QUERY,
   tuiHexToRgb,
   tuiIsNumber,
   tuiIsString,
@@ -89,10 +88,12 @@ export class PrizmDocDocumentationComponent implements AfterContentInit {
   isAPI = false;
 
   @ContentChildren(PrizmDocDocumentationPropertyConnectorDirective)
-  propertiesConnectors: QueryList<PrizmDocDocumentationPropertyConnectorDirective<any>> = EMPTY_QUERY;
+  propertiesConnectors: QueryList<PrizmDocDocumentationPropertyConnectorDirective<any>> =
+    prizmEmptyQueryList();
 
   @ViewChildren(PrizmDocDocumentationPropertyConnectorDirective)
-  propertiesInnerConnectors: QueryList<PrizmDocDocumentationPropertyConnectorDirective<any>> = EMPTY_QUERY;
+  propertiesInnerConnectors: QueryList<PrizmDocDocumentationPropertyConnectorDirective<any>> =
+    prizmEmptyQueryList();
 
   activeItemIndex = 0;
   testIdPostfix = '';

--- a/libs/doc/base/src/lib/components/documentation/documentation.component.ts
+++ b/libs/doc/base/src/lib/components/documentation/documentation.component.ts
@@ -30,7 +30,7 @@ import { PrizmDocHostElementListenerService } from '../host';
 import orderBy from 'lodash-es/orderBy';
 import { PrizmDocumentationPropertyType } from '../../types/pages';
 import { UntypedFormControl, Validators } from '@angular/forms';
-import { PrizmFormControlHelpers } from '@prizm-ui/helpers';
+import { prizmEmptyQueryList, PrizmFormControlHelpers } from '@prizm-ui/helpers';
 // @bad TODO subscribe propertiesConnectors changes
 // @bad TODO refactor to make more flexible
 @Component({

--- a/libs/doc/base/src/lib/components/page/page.component.ts
+++ b/libs/doc/base/src/lib/components/page/page.component.ts
@@ -9,12 +9,12 @@ import {
   QueryList,
   SimpleChanges,
 } from '@angular/core';
-import { EMPTY_QUERY } from '@taiga-ui/cdk';
 
 import { PRIZM_DOC_DEFAULT_TABS } from '../../tokens/default-tabs';
 import { PAGE_PROVIDERS, PAGE_SEE_ALSO } from './page.providers';
 import { PrizmDocPageTabConnectorDirective } from './page-tab.directive';
 import { PrizmPageService } from './page.service';
+import { prizmEmptyQueryList } from '@prizm-ui/helpers';
 
 @Component({
   selector: `prizm-doc-page`,
@@ -37,7 +37,7 @@ export class PrizmDocPageComponent implements OnChanges {
   path = ``;
 
   @ContentChildren(PrizmDocPageTabConnectorDirective)
-  readonly tabConnectors: QueryList<PrizmDocPageTabConnectorDirective> = EMPTY_QUERY;
+  readonly tabConnectors: QueryList<PrizmDocPageTabConnectorDirective> = prizmEmptyQueryList();
 
   activeItemIndex = NaN;
 

--- a/libs/helpers/src/lib/util/common.ts
+++ b/libs/helpers/src/lib/util/common.ts
@@ -1,3 +1,5 @@
+import { QueryList } from '@angular/core';
+
 /**
  * sort number, string, date by asc or desc
  * */
@@ -22,4 +24,8 @@ export function prizmSort<T>(x: T, y: T, asc = true): number {
   }
 
   return result;
+}
+
+export function prizmEmptyQueryList<T = any>() {
+  return new QueryList<T>();
 }


### PR DESCRIPTION
fix(components): added empty initializer for all query list #1188

Resolved #1188

Affected components: Accordion, Breadcrumbs, Grid, Navigation-Menu, Slider, Splitter, Stepper, Table, Tabs