### PR TITLE
chore: release 3.10.0

### DIFF
--- a/.github/workflows/beta-publish-ng14.yml
+++ b/.github/workflows/beta-publish-ng14.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_draft_version=$(
-            (npm view @prizm-ui/components versions --tag ng14beta --json 2>/dev/null || echo '1.13.0-ng14beta.0') | jq '([.[] | select(startswith("1.13.0-ng14beta"))] | last // "1.13.0-ng14beta.0")' 2>/dev/null || echo '1.13.0-ng14beta.0'
+            (npm view @prizm-ui/components versions --tag ng14beta --json 2>/dev/null || echo '1.14.0-ng14beta.0') | jq '([.[] | select(startswith("1.14.0-ng14beta"))] | last // "1.14.0-ng14beta.0")' 2>/dev/null || echo '1.14.0-ng14beta.0'
           )
           echo "LAST_DRAFT_VERSION=${last_draft_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/beta-publish-ng15.yml
+++ b/.github/workflows/beta-publish-ng15.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_draft_version=$(
-            (npm view @prizm-ui/components versions --tag ng15beta --json 2>/dev/null || echo '2.10.0-ng15beta.0') | jq '([.[] | select(startswith("2.10.0-ng15beta"))] | last // "2.10.0-ng15beta.0")' 2>/dev/null || echo '2.10.0-ng15beta.0'
+            (npm view @prizm-ui/components versions --tag ng15beta --json 2>/dev/null || echo '2.11.0-ng15beta.0') | jq '([.[] | select(startswith("2.11.0-ng15beta"))] | last // "2.11.0-ng15beta.0")' 2>/dev/null || echo '2.11.0-ng15beta.0'
           )
           echo "LAST_DRAFT_VERSION=${last_draft_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/beta-publish-ng16.yml
+++ b/.github/workflows/beta-publish-ng16.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_draft_version=$(
-            (npm view @prizm-ui/components versions --tag beta --json 2>/dev/null || echo '3.9.0-beta.0') | jq '([.[] | select(startswith("3.9.0-beta"))] | last // "3.9.0-beta.0")' 2>/dev/null || echo '3.9.0-beta.0'
+            (npm view @prizm-ui/components versions --tag beta --json 2>/dev/null || echo '3.10.0-beta.0') | jq '([.[] | select(startswith("3.10.0-beta"))] | last // "3.10.0-beta.0")' 2>/dev/null || echo '3.10.0-beta.0'
           )
           echo "LAST_DRAFT_VERSION=${last_draft_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/main-publish-ng14.yml
+++ b/.github/workflows/main-publish-ng14.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_v1_version=$(
-            echo '1.13.0'
+            echo '1.14.0'
           )
           echo "LAST_V1_VERSION=${last_v1_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/main-publish-ng15.yml
+++ b/.github/workflows/main-publish-ng15.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_v2_version=$(
-            echo '2.10.0'
+            echo '2.11.0'
           )
           echo "LAST_V2_VERSION=${last_v2_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/main-publish-ng16.yml
+++ b/.github/workflows/main-publish-ng16.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_v3_version=$(
-            echo '3.9.0'
+            echo '3.10.0'
           )
           echo "LAST_V3_VERSION=${last_v3_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/pre-release-publish-ng14.yml
+++ b/.github/workflows/pre-release-publish-ng14.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_next_version=$(
-            (npm view @prizm-ui/components versions --tag ng14next --json 2>/dev/null || echo '1.13.0-ng14next.0') | jq '([.[] | select(startswith("1.13.0-ng14next"))] | last // "1.13.0-ng14next.0")' 2>/dev/null || echo '1.13.0-ng14next.0'
+            (npm view @prizm-ui/components versions --tag ng14next --json 2>/dev/null || echo '1.14.0-ng14next.0') | jq '([.[] | select(startswith("1.14.0-ng14next"))] | last // "1.14.0-ng14next.0")' 2>/dev/null || echo '1.14.0-ng14next.0'
           )
           echo "LAST_NEXT_VERSION=${last_next_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/pre-release-publish-ng15.yml
+++ b/.github/workflows/pre-release-publish-ng15.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_next_version=$(
-            (npm view @prizm-ui/components versions --tag ng15next --json 2>/dev/null || echo '2.10.0-ng15next.0') | jq '([.[] | select(startswith("2.10.0-ng15next"))] | last // "2.10.0-ng15next.0")' 2>/dev/null || echo '2.10.0-ng15next.0'
+            (npm view @prizm-ui/components versions --tag ng15next --json 2>/dev/null || echo '2.11.0-ng15next.0') | jq '([.[] | select(startswith("2.11.0-ng15next"))] | last // "2.11.0-ng15next.0")' 2>/dev/null || echo '2.11.0-ng15next.0'
           )
           echo "LAST_NEXT_VERSION=${last_next_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/pre-release-publish-ng16.yml
+++ b/.github/workflows/pre-release-publish-ng16.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up environment variables
         run: |
           last_next_version=$(
-            (npm view @prizm-ui/components versions --tag next --json 2>/dev/null || echo '3.9.0-next.0') | jq '([.[] | select(startswith("3.9.0-next"))] | last // "3.9.0-next.0")' 2>/dev/null || echo '3.9.0-next.0'
+            (npm view @prizm-ui/components versions --tag next --json 2>/dev/null || echo '3.10.0-next.0') | jq '([.[] | select(startswith("3.10.0-next"))] | last // "3.10.0-next.0")' 2>/dev/null || echo '3.10.0-next.0'
           )
           echo "LAST_NEXT_VERSION=${last_next_version}" >> $GITHUB_ENV
 

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.14.0, 2.11.0, 3.10.0](https://github.com/zyfra/Prizm) (19-01-2023)
+
+## Features
+
+- feat(doc): save current theme in local storage on change
+
+### Bug fixes
+
+- fix(theme/service): recognize current theme #1287 #1292
+- fix(components/tabs): set stacking context to isolate #1291
+- fix(components/input-text): show status on clear required fields #1284
+
 ## [1.13.0, 2.10.0, 3.9.0](https://github.com/zyfra/Prizm) (29-12-2023)
 
 ## Features

--- a/apps/doc/src/app/logo/logo.component.ts
+++ b/apps/doc/src/app/logo/logo.component.ts
@@ -28,6 +28,7 @@ export class LogoComponent {
   }
 
   public onMode(isNight: boolean): void {
+    this.storage.setItem(`night`, isNight ? 'true' : 'false');
     this.themeSwitcher.update(isNight ? 'dark' : 'light');
   }
 }

--- a/apps/doc/src/app/logo/logo.component.ts
+++ b/apps/doc/src/app/logo/logo.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
 import { debounceTime, filter, map } from 'rxjs/operators';
 import { PrizmThemeService } from '@prizm-ui/theme';
 import { LOCAL_STORAGE } from '@ng-web-apis/common';
@@ -10,20 +10,18 @@ import { PrizmIconsSvgRegistry, PrizmIconSvgEnum, prizmIconSvgOtherGitHub } from
   styleUrls: ['./logo.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LogoComponent {
+export class LogoComponent implements OnInit {
+  readonly githubSvgName = PrizmIconSvgEnum.OTHER_GIT_HUB;
+  readonly themeSwitcher = inject(PrizmThemeService);
+  readonly svgRegistry = inject(PrizmIconsSvgRegistry);
+  readonly storage = inject(LOCAL_STORAGE);
   readonly isNight$ = this.themeSwitcher.change$.pipe(
     filter(i => i.el === this.themeSwitcher.rootElement),
     map(i => i.theme === 'dark'),
     debounceTime(0)
   );
 
-  readonly githubSvgName = PrizmIconSvgEnum.OTHER_GIT_HUB;
-
-  constructor(
-    private readonly themeSwitcher: PrizmThemeService,
-    private readonly svgRegistry: PrizmIconsSvgRegistry,
-    @Inject(LOCAL_STORAGE) private readonly storage: Storage
-  ) {
+  ngOnInit(): void {
     this.svgRegistry.registerIcons([prizmIconSvgOtherGitHub]);
   }
 

--- a/apps/doc/src/app/version-manager/current.const.ts
+++ b/apps/doc/src/app/version-manager/current.const.ts
@@ -1,1 +1,1 @@
-export const PRIZM_CURRENT_VERSION = '1.13.0';
+export const PRIZM_CURRENT_VERSION = '1.14.0';

--- a/apps/doc/src/app/version-manager/current.const.ts.ng14
+++ b/apps/doc/src/app/version-manager/current.const.ts.ng14
@@ -1,1 +1,1 @@
-export const PRIZM_CURRENT_VERSION = '1.13.0';
+export const PRIZM_CURRENT_VERSION = '1.14.0';

--- a/apps/doc/src/app/version-manager/current.const.ts.ng15
+++ b/apps/doc/src/app/version-manager/current.const.ts.ng15
@@ -1,1 +1,1 @@
-export const PRIZM_CURRENT_VERSION = '2.10.0';
+export const PRIZM_CURRENT_VERSION = '2.11.0';

--- a/apps/doc/src/app/version-manager/current.const.ts.ng16
+++ b/apps/doc/src/app/version-manager/current.const.ts.ng16
@@ -1,1 +1,1 @@
-export const PRIZM_CURRENT_VERSION = '3.9.0';
+export const PRIZM_CURRENT_VERSION = '3.10.0';

--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -30,8 +30,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     },
   },
   {
-    label: '1.13.0 (ng14)',
-    version: '1.13.0',
+    label: '1.14.0 (ng14)',
+    version: '1.14.0',
     stackblitz: 'https://stackblitz.com/edit/prizm-v1-demo',
     link: new URL('https://prizm-v1.web.app'),
     otherLinks: [],
@@ -54,8 +54,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     otherLinks: [],
   },
   {
-    label: '1.13.0-next (ng14)',
-    version: '1.13.0-next',
+    label: '1.14.0-next (ng14)',
+    version: '1.14.0-next',
     stackblitz: 'https://stackblitz.com/edit/prizm-v1-next-demo',
     link: new URL('https://prizm-v1-next.web.app'),
     otherLinks: [],
@@ -75,8 +75,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     otherLinks: [],
   },
   {
-    label: '1.13.0-beta (ng14)',
-    version: '1.13.0-beta',
+    label: '1.14.0-beta (ng14)',
+    version: '1.14.0-beta',
     stackblitz: 'https://stackblitz.com/edit/prizm-v1-beta-demo',
     link: new URL('https://prizm-v1-beta.web.app'),
     otherLinks: [],

--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -10,8 +10,8 @@ export interface PrizmVersionMeta {
 
 export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
   {
-    label: '3.9.0 (ng16)',
-    version: '3.9.0',
+    label: '3.10.0 (ng16)',
+    version: '3.10.0',
     stackblitz: 'https://stackblitz.com/edit/prizm-v3-demo',
     link: new URL('http://prizm.site'),
     otherLinks: [new URL('https://prizm-v3.web.app')],
@@ -40,8 +40,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     },
   },
   {
-    label: '3.9.0-next (ng16)',
-    version: '3.9.0-next',
+    label: '3.10.0-next (ng16)',
+    version: '3.10.0-next',
     stackblitz: 'https://stackblitz.com/edit/prizm-v3-next-demo',
     link: new URL('https://prizm-v3-next.web.app'),
     otherLinks: [],
@@ -61,8 +61,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     otherLinks: [],
   },
   {
-    label: '3.9.0-beta (ng16)',
-    version: '3.9.0-beta',
+    label: '3.10.0-beta (ng16)',
+    version: '3.10.0-beta',
     stackblitz: 'https://stackblitz.com/edit/prizm-v3-beta-demo',
     link: new URL('https://prizm-v3-beta.web.app'),
     otherLinks: [],

--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -20,8 +20,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     },
   },
   {
-    label: '2.10.0 (ng15)',
-    version: '2.10.0',
+    label: '2.11.0 (ng15)',
+    version: '2.11.0',
     stackblitz: 'https://stackblitz.com/edit/prizm-v2-demo',
     link: new URL('https://prizm-v2.web.app'),
     otherLinks: [],
@@ -47,9 +47,9 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     otherLinks: [],
   },
   {
-    label: '2.10.0-next (ng15)',
+    label: '2.11.0-next (ng15)',
     stackblitz: 'https://stackblitz.com/edit/prizm-v2-next-demo',
-    version: '2.10.0-next',
+    version: '2.11.0-next',
     link: new URL('https://prizm-v2-next.web.app'),
     otherLinks: [],
   },
@@ -68,8 +68,8 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     otherLinks: [],
   },
   {
-    label: '2.10.0-beta (ng15)',
-    version: '2.10.0-beta',
+    label: '2.11.0-beta (ng15)',
+    version: '2.11.0-beta',
     stackblitz: 'https://stackblitz.com/edit/prizm-v2-beta-demo',
     link: new URL('https://prizm-v2-beta.web.app'),
     otherLinks: [],

--- a/libs/ast/package.json
+++ b/libs/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/ast",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/libs/ast/package.json.ng14
+++ b/libs/ast/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/ast",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/libs/ast/package.json.ng15
+++ b/libs/ast/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/ast",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/libs/ast/package.json.ng16
+++ b/libs/ast/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/ast",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/libs/charts/base/package.json
+++ b/libs/charts/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/charts",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -11,8 +11,8 @@
     "lodash-es": "^4.17.21",
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/theme": "^3.9.0",
-    "@prizm-ui/helpers": "^3.9.0",
+    "@prizm-ui/theme": "^3.10.0",
+    "@prizm-ui/helpers": "^3.10.0",
     "@antv/g2plot": "^2.4.22"
   },
   "dependencies": {

--- a/libs/charts/base/package.json.ng14
+++ b/libs/charts/base/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/charts",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -11,8 +11,8 @@
     "lodash-es": "^4.17.21",
     "@angular/common": "^14.2.0",
     "@angular/core": "^14.2.0",
-    "@prizm-ui/theme": "^1.13.0",
-    "@prizm-ui/helpers": "^1.13.0",
+    "@prizm-ui/theme": "^1.14.0",
+    "@prizm-ui/helpers": "^1.14.0",
     "@antv/g2plot": "^2.4.22"
   },
   "dependencies": {

--- a/libs/charts/base/package.json.ng15
+++ b/libs/charts/base/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/charts",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -11,8 +11,8 @@
     "lodash-es": "^4.17.21",
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@prizm-ui/theme": "^2.10.0",
-    "@prizm-ui/helpers": "^2.10.0",
+    "@prizm-ui/theme": "^2.11.0",
+    "@prizm-ui/helpers": "^2.11.0",
     "@antv/g2plot": "^2.4.22"
   },
   "dependencies": {

--- a/libs/charts/base/package.json.ng16
+++ b/libs/charts/base/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/charts",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -11,8 +11,8 @@
     "lodash-es": "^4.17.21",
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/theme": "^3.9.0",
-    "@prizm-ui/helpers": "^3.9.0",
+    "@prizm-ui/theme": "^3.10.0",
+    "@prizm-ui/helpers": "^3.10.0",
     "@antv/g2plot": "^2.4.22"
   },
   "dependencies": {

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/components",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Prizm UI system design components library http://prizm.zyfra.com",
   "license": "MIT",
   "private": false,
@@ -18,10 +18,10 @@
     "@ng-web-apis/resize-observer": "^3.0.0",
     "@ng-web-apis/intersection-observer": "^3.0.0",
     "@ng-web-apis/mutation-observer": "^3.0.0",
-    "@prizm-ui/helpers": "^3.9.0",
-    "@prizm-ui/core": "^3.9.0",
-    "@prizm-ui/i18n": "^3.9.0",
-    "@prizm-ui/theme": "^3.9.0"
+    "@prizm-ui/helpers": "^3.10.0",
+    "@prizm-ui/core": "^3.10.0",
+    "@prizm-ui/i18n": "^3.10.0",
+    "@prizm-ui/theme": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/components/package.json.ng14
+++ b/libs/components/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/components",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Prizm UI system design components library http://prizm.zyfra.com",
   "license": "MIT",
   "private": false,
@@ -17,10 +17,10 @@
     "@ng-web-apis/resize-observer": "2.0.0",
     "@ng-web-apis/intersection-observer": "2.0.0",
     "@ng-web-apis/mutation-observer": "2.0.0",
-    "@prizm-ui/helpers": "^1.13.0",
-    "@prizm-ui/core": "^1.13.0",
-    "@prizm-ui/i18n": "^1.13.0",
-    "@prizm-ui/theme": "^1.13.0"
+    "@prizm-ui/helpers": "^1.14.0",
+    "@prizm-ui/core": "^1.14.0",
+    "@prizm-ui/i18n": "^1.14.0",
+    "@prizm-ui/theme": "^1.14.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/components/package.json.ng15
+++ b/libs/components/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/components",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Prizm UI system design components library http://prizm.zyfra.com",
   "license": "MIT",
   "private": false,
@@ -18,10 +18,10 @@
     "@ng-web-apis/resize-observer": "2.0.0",
     "@ng-web-apis/intersection-observer": "2.0.0",
     "@ng-web-apis/mutation-observer": "2.0.0",
-    "@prizm-ui/helpers": "^2.10.0",
-    "@prizm-ui/core": "^2.10.0",
-    "@prizm-ui/i18n": "^2.10.0",
-    "@prizm-ui/theme": "^2.10.0"
+    "@prizm-ui/helpers": "^2.11.0",
+    "@prizm-ui/core": "^2.11.0",
+    "@prizm-ui/i18n": "^2.11.0",
+    "@prizm-ui/theme": "^2.11.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/components/package.json.ng16
+++ b/libs/components/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/components",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Prizm UI system design components library http://prizm.zyfra.com",
   "license": "MIT",
   "private": false,
@@ -18,10 +18,10 @@
     "@ng-web-apis/resize-observer": "^3.0.0",
     "@ng-web-apis/intersection-observer": "^3.0.0",
     "@ng-web-apis/mutation-observer": "^3.0.0",
-    "@prizm-ui/helpers": "^3.9.0",
-    "@prizm-ui/core": "^3.9.0",
-    "@prizm-ui/i18n": "^3.9.0",
-    "@prizm-ui/theme": "^3.9.0"
+    "@prizm-ui/helpers": "^3.10.0",
+    "@prizm-ui/core": "^3.10.0",
+    "@prizm-ui/i18n": "^3.10.0",
+    "@prizm-ui/theme": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -20,6 +20,7 @@ import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
 import { PrizmInputHintDirective, PrizmInputLayoutComponent } from '../common';
 import { NgxMaskDirective } from 'ngx-mask';
+import { timer } from 'rxjs';
 
 @Component({
   selector:
@@ -187,7 +188,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     this.parentLayout?.clear
       .pipe(
         tap(() => {
-          this.maybeMask, this.maybeMask?.writeValue(null as any);
+          this.maybeMask?.writeValue(null as any);
         }),
         takeUntil(this.destroy)
       )
@@ -283,14 +284,11 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
 
     this.updateValue(null as VALUE);
 
-    this.ngControl?.control?.markAsDirty();
-
     this.updateEmptyState();
     this.updateErrorState();
 
     this.focus();
-
-    this.stateChanges.next();
+    this.markControl({ touched: true, dirty: true });
     this.onClear.emit(event);
     this.valueChanged.next('' as VALUE);
 
@@ -322,7 +320,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   public markAsTouched(): void {
-    if (this.ngControl?.control instanceof UntypedFormControl) this.ngControl.control.markAsTouched();
-    else this._touched = true;
+    this.markControl({ touched: true });
   }
 }

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -287,7 +287,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     this.updateEmptyState();
     this.updateErrorState();
 
-    this.focus();
     this.markControl({ touched: true, dirty: true });
     this.onClear.emit(event);
     this.valueChanged.next('' as VALUE);

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng14
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng14
@@ -279,14 +279,10 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
 
     this.updateValue(null as VALUE);
 
-    this.ngControl?.control?.markAsDirty();
-
     this.updateEmptyState();
     this.updateErrorState();
 
-    this.focus();
-
-    this.stateChanges.next();
+    this.markControl({ touched: true, dirty: true });
     this.onClear.emit(event);
     this.valueChanged.next('' as VALUE);
 
@@ -318,7 +314,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   public markAsTouched(): void {
-    if (this.ngControl?.control instanceof UntypedFormControl) this.ngControl.control.markAsTouched();
-    else this._touched = true;
+    this.markControl({ touched: true });
   }
 }

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng15
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng15
@@ -278,14 +278,10 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
 
     this.updateValue(null as VALUE);
 
-    this.ngControl?.control?.markAsDirty();
-
     this.updateEmptyState();
     this.updateErrorState();
 
-    this.focus();
-
-    this.stateChanges.next();
+    this.markControl({ touched: true, dirty: true });
     this.onClear.emit(event);
     this.valueChanged.next('' as VALUE);
 
@@ -317,7 +313,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   public markAsTouched(): void {
-    if (this.ngControl?.control instanceof UntypedFormControl) this.ngControl.control.markAsTouched();
-    else this._touched = true;
+    this.markControl({ touched: true });
   }
 }

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng16
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng16
@@ -20,6 +20,7 @@ import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
 import { PrizmInputHintDirective, PrizmInputLayoutComponent } from '../common';
 import { NgxMaskDirective } from 'ngx-mask';
+import { timer } from 'rxjs';
 
 @Component({
   selector:
@@ -72,6 +73,10 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   override hidden = false;
 
   private _disabled = false;
+
+  @Input()
+  @HostBinding('attr.placeholder')
+  placeholder?: string;
 
   /**
    * @deprecated
@@ -183,7 +188,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     this.parentLayout?.clear
       .pipe(
         tap(() => {
-          this.maybeMask, this.maybeMask?.writeValue(null as any);
+          this.maybeMask?.writeValue(null as any);
         }),
         takeUntil(this.destroy)
       )
@@ -279,14 +284,10 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
 
     this.updateValue(null as VALUE);
 
-    this.ngControl?.control?.markAsDirty();
-
     this.updateEmptyState();
     this.updateErrorState();
 
-    this.focus();
-
-    this.stateChanges.next();
+    this.markControl({ touched: true, dirty: true });
     this.onClear.emit(event);
     this.valueChanged.next('' as VALUE);
 
@@ -318,7 +319,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   public markAsTouched(): void {
-    if (this.ngControl?.control instanceof UntypedFormControl) this.ngControl.control.markAsTouched();
-    else this._touched = true;
+    this.markControl({ touched: true });
   }
 }

--- a/libs/components/src/lib/components/tabs/tabs.component.less
+++ b/libs/components/src/lib/components/tabs/tabs.component.less
@@ -2,6 +2,7 @@
   width: 100%;
   display: flex;
   align-items: flex-end;
+  isolation: isolate;
 
   .container {
     height: 100%;

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/core",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "description": "The main library for creating Angular components and elements using Prizm.",
   "private": false,

--- a/libs/core/package.json.ng14
+++ b/libs/core/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/core",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "MIT",
   "description": "The main library for creating Angular components and elements using Prizm.",
   "private": false,

--- a/libs/core/package.json.ng15
+++ b/libs/core/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/core",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "license": "MIT",
   "description": "The main library for creating Angular components and elements using Prizm.",
   "private": false,

--- a/libs/core/package.json.ng16
+++ b/libs/core/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/core",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "description": "The main library for creating Angular components and elements using Prizm.",
   "private": false,

--- a/libs/helpers/package.json
+++ b/libs/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/helpers",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "description": "Library to make it easy to create Angular applications. Contains Injectables Service, RxJS utilities, directives, and standard pipes.",
   "private": false,

--- a/libs/helpers/package.json.ng14
+++ b/libs/helpers/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/helpers",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "MIT",
   "description": "Library to make it easy to create Angular applications. Contains Injectables Service, RxJS utilities, directives, and standard pipes.",
   "private": false,

--- a/libs/helpers/package.json.ng15
+++ b/libs/helpers/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/helpers",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "license": "MIT",
   "description": "Library to make it easy to create Angular applications. Contains Injectables Service, RxJS utilities, directives, and standard pipes.",
   "private": false,

--- a/libs/helpers/package.json.ng16
+++ b/libs/helpers/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/helpers",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "description": "Library to make it easy to create Angular applications. Contains Injectables Service, RxJS utilities, directives, and standard pipes.",
   "private": false,

--- a/libs/i18n/package.json
+++ b/libs/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/i18n",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0"

--- a/libs/i18n/package.json.ng14
+++ b/libs/i18n/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/i18n",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "peerDependencies": {
     "@angular/core": "^14.2.0"
   },

--- a/libs/i18n/package.json.ng15
+++ b/libs/i18n/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/i18n",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0"

--- a/libs/i18n/package.json.ng16
+++ b/libs/i18n/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/i18n",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0"

--- a/libs/icons/base/package.json
+++ b/libs/icons/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Prizm UI base icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/core": "^3.9.0"
+    "@prizm-ui/core": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/base/package.json.ng14
+++ b/libs/icons/base/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Prizm UI base icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^14.2.0",
     "@angular/core": "^14.2.0",
-    "@prizm-ui/core": "^1.13.0"
+    "@prizm-ui/core": "^1.14.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/base/package.json.ng15
+++ b/libs/icons/base/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Prizm UI base icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@prizm-ui/core": "^2.10.0"
+    "@prizm-ui/core": "^2.11.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/base/package.json.ng16
+++ b/libs/icons/base/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Prizm UI base icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/core": "^3.9.0"
+    "@prizm-ui/core": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json
+++ b/libs/icons/flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/flag-icons",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Prizm UI flags icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/core": "^3.9.0"
+    "@prizm-ui/core": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json.ng14
+++ b/libs/icons/flags/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/flag-icons",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Prizm UI flags icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^14.2.0",
     "@angular/core": "^14.2.0",
-    "@prizm-ui/core": "^1.13.0"
+    "@prizm-ui/core": "^1.14.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json.ng15
+++ b/libs/icons/flags/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/flag-icons",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Prizm UI flags icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@prizm-ui/core": "^2.10.0"
+    "@prizm-ui/core": "^2.11.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json.ng16
+++ b/libs/icons/flags/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/flag-icons",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Prizm UI flags icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/core": "^3.9.0"
+    "@prizm-ui/core": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/nxmv/package.json
+++ b/libs/nxmv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-mv",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {

--- a/libs/nxmv/package.json.ng14
+++ b/libs/nxmv/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-mv",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {

--- a/libs/nxmv/package.json.ng15
+++ b/libs/nxmv/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-mv",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {

--- a/libs/nxmv/package.json.ng16
+++ b/libs/nxmv/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-mv",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {

--- a/libs/plugin/package.json
+++ b/libs/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-plugin",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {
@@ -10,6 +10,6 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@prizm-ui/ast": "^3.9.0"
+    "@prizm-ui/ast": "^3.10.0"
   }
 }

--- a/libs/plugin/package.json.ng14
+++ b/libs/plugin/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-plugin",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {
@@ -10,6 +10,6 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@prizm-ui/ast": "^1.13.0"
+    "@prizm-ui/ast": "^1.14.0"
   }
 }

--- a/libs/plugin/package.json.ng15
+++ b/libs/plugin/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-plugin",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {
@@ -10,6 +10,6 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@prizm-ui/ast": "^2.10.0"
+    "@prizm-ui/ast": "^2.11.0"
   }
 }

--- a/libs/plugin/package.json.ng16
+++ b/libs/plugin/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-plugin",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {
@@ -10,6 +10,6 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@prizm-ui/ast": "^3.9.0"
+    "@prizm-ui/ast": "^3.10.0"
   }
 }

--- a/libs/schematics/package.json
+++ b/libs/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/install",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Package installer @prizm-ui/* , Angular schematic ng-add",
   "schematics": "./src/collection.json",
   "private": false,

--- a/libs/schematics/package.json.ng14
+++ b/libs/schematics/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/install",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Package installer @prizm-ui/* , Angular schematic ng-add",
   "schematics": "./src/collection.json",
   "private": false,

--- a/libs/schematics/package.json.ng15
+++ b/libs/schematics/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/install",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Package installer @prizm-ui/* , Angular schematic ng-add",
   "schematics": "./src/collection.json",
   "private": false,

--- a/libs/schematics/package.json.ng16
+++ b/libs/schematics/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/install",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Package installer @prizm-ui/* , Angular schematic ng-add",
   "schematics": "./src/collection.json",
   "private": false,

--- a/libs/theme/package.json
+++ b/libs/theme/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@prizm-ui/theme",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/core": "^3.9.0",
-    "@prizm-ui/helpers": "^3.9.0"
+    "@prizm-ui/core": "^3.10.0",
+    "@prizm-ui/helpers": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/theme/package.json.ng14
+++ b/libs/theme/package.json.ng14
@@ -1,11 +1,11 @@
 {
   "name": "@prizm-ui/theme",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "peerDependencies": {
     "@angular/common": "^14.2.0",
     "@angular/core": "^14.2.0",
-    "@prizm-ui/core": "^1.13.0",
-    "@prizm-ui/helpers": "^1.13.0"
+    "@prizm-ui/core": "^1.14.0",
+    "@prizm-ui/helpers": "^1.14.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/theme/package.json.ng15
+++ b/libs/theme/package.json.ng15
@@ -1,11 +1,11 @@
 {
   "name": "@prizm-ui/theme",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@prizm-ui/core": "^2.10.0",
-    "@prizm-ui/helpers": "^2.10.0"
+    "@prizm-ui/core": "^2.11.0",
+    "@prizm-ui/helpers": "^2.11.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/theme/package.json.ng16
+++ b/libs/theme/package.json.ng16
@@ -1,11 +1,11 @@
 {
   "name": "@prizm-ui/theme",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "peerDependencies": {
     "@angular/common": "^16.1.0 || ^16.2.0",
     "@angular/core": "^16.1.0 || ^16.2.0",
-    "@prizm-ui/core": "^3.9.0",
-    "@prizm-ui/helpers": "^3.9.0"
+    "@prizm-ui/core": "^3.10.0",
+    "@prizm-ui/helpers": "^3.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/theme/src/lib/directive/theme/theme-inverted.directive.ts
+++ b/libs/theme/src/lib/directive/theme/theme-inverted.directive.ts
@@ -39,8 +39,8 @@ export class PrizmThemeInvertedDirective implements OnInit {
             ? of(invertedValues?.['*'])
             : this.themeService.getInvertedThemeByElement$(themeElement, invertedValues)
         ),
-        tap(newTheme => this.themeService.update(newTheme, this.elementRef.nativeElement)),
-        tap(newTheme => this.prizmThemeChange.next(newTheme)),
+        tap(newTheme => newTheme && this.themeService.update(newTheme, this.elementRef.nativeElement)),
+        tap(newTheme => newTheme && this.prizmThemeChange.next(newTheme)),
         takeUntil(this.destroy$)
       )
       .subscribe();

--- a/libs/theme/src/lib/services/theme.service.ts
+++ b/libs/theme/src/lib/services/theme.service.ts
@@ -37,11 +37,14 @@ export class PrizmThemeService implements OnDestroy {
     this.subscription.add(this.change$.pipe(tap(theme => this.setToHtml(theme.theme, theme.el))).subscribe());
   }
 
-  public getLastThemeForElement(el: HTMLElement = this.rootElement): string {
-    return this.themeStorage.get(el) as string;
+  public getLastThemeForElement(el: HTMLElement = this.rootElement): string | null {
+    let theme = this.themeStorage.get(el);
+    if (el !== this.rootElement_)
+      theme = el.closest(`[${this.attThemeKey}}]`)?.getAttribute(this.attThemeKey) as string;
+    return theme ?? null;
   }
 
-  public getLastThemeForElement$(el: HTMLElement = this.rootElement): Observable<string> {
+  public getLastThemeForElement$(el: HTMLElement = this.rootElement): Observable<string | null> {
     return this.change$.pipe(
       map(i => this.getLastThemeForElement(el)),
       distinctUntilChanged()
@@ -54,8 +57,8 @@ export class PrizmThemeService implements OnDestroy {
       light: 'dark',
       dark: 'light',
     }
-  ): Observable<string> {
-    return this.getLastThemeForElement$(element).pipe(map(theme => pairThemeValues[theme]));
+  ): Observable<string | null> {
+    return this.getLastThemeForElement$(element).pipe(map(theme => theme && pairThemeValues[theme]));
   }
 
   public getByElement(el?: HTMLElement): PrizmTheme {

--- a/libs/theme/src/lib/services/theme.service.ts
+++ b/libs/theme/src/lib/services/theme.service.ts
@@ -40,7 +40,7 @@ export class PrizmThemeService implements OnDestroy {
   public getLastThemeForElement(el: HTMLElement = this.rootElement): string | null {
     let theme = this.themeStorage.get(el);
     if (el !== this.rootElement_)
-      theme = el.closest(`[${this.attThemeKey}}]`)?.getAttribute(this.attThemeKey) as string;
+      theme = el.closest(`[${this.attThemeKey}]`)?.getAttribute(this.attThemeKey) as string;
     return theme ?? null;
   }
 

--- a/libs/theme/src/lib/services/theme.service.ts
+++ b/libs/theme/src/lib/services/theme.service.ts
@@ -46,7 +46,7 @@ export class PrizmThemeService implements OnDestroy {
 
   public getLastThemeForElement$(el: HTMLElement = this.rootElement): Observable<string | null> {
     return this.change$.pipe(
-      map(i => this.getLastThemeForElement(el)),
+      map(() => this.getLastThemeForElement(el)),
       distinctUntilChanged()
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "husky": {
     "hooks": {

--- a/package.json.ng14
+++ b/package.json.ng14
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "MIT",
   "husky": {
     "hooks": {

--- a/package.json.ng15
+++ b/package.json.ng15
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "license": "MIT",
   "husky": {
     "hooks": {

--- a/package.json.ng16
+++ b/package.json.ng16
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "husky": {
     "hooks": {


### PR DESCRIPTION
## [1.14.0, 2.11.0, 3.10.0](https://github.com/zyfra/Prizm) (19-01-2023)

## Features

- feat(doc): save current theme in local storage on change

### Bug fixes

- fix(theme/service): recognize current theme #1287 #1292
- fix(components/tabs): set stacking context to isolate #1291
- fix(components/input-text): show status on clear required fields #1284

