### PR TITLE
feat: file upload translation model // breaking change

### DIFF
--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -53,7 +53,7 @@
       </div>
 
       <div class="file__stage">
-        {{  options.statusNames?.[item.value.progress | prizmUploadStatus : item.value.error] ?? (translations | prizmPluck : [item.value.progress | prizmUploadStatus : item.value.error]) }}
+        {{ translations | prizmPluck : [item.value.progress | prizmUploadStatus : item.value.error] }}
       </div>
 
       <button

--- a/libs/components/src/lib/components/file-upload/types.ts
+++ b/libs/components/src/lib/components/file-upload/types.ts
@@ -1,5 +1,3 @@
-import { UploadingStatusEnum } from './file-upload.enums';
-
 export type PrizmFileValidationErrors = {
   accept?: { expect: string; current: string };
   size?: { max: number; current: number };
@@ -14,9 +12,6 @@ export type PrizmFilesProgress = {
 
 export type PrizmFileUploadOptions = {
   showRetryButtons: boolean;
-  statusNames?: {
-    [key in UploadingStatusEnum]: string;
-  };
 };
 
 export type PrizmFilesMap = Map<string, { file: File; progress: number; error: boolean; url?: string }>;

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -10,10 +10,10 @@ export interface PrizmLanguageFileUpload {
     dropzone__title: string;
     dropzone__description: string;
     btn__select: string;
-    idle?: string;
-    progress?: string;
-    warning?: string;
-    success?: string;
+    idle: string;
+    progress: string;
+    warning: string;
+    success: string;
   };
 }
 export interface PrizmLanguageInputLayoutDateRelative {


### PR DESCRIPTION
feat(components/file-upload): file upload translation model BREAKING CHANGE
feat(components/file-upload): file upload options model and token BREAKING CHANGE

изменены интерфейсы для текстов PrizmLanguageFileUpload и для опций PrizmFileUploadOptions: тексты статусов загрузки теперь можно изменять только через переводы 

