### PR TITLE
fix: input height fixes #1179, #1308

### DIFF
--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.less
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.less
@@ -1,3 +1,3 @@
-prizm-chips.single-line:not(empty) {
+prizm-chips.single-line:not(:empty) {
   margin-bottom: 11px;
 }

--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.less
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.less
@@ -1,3 +1,3 @@
-prizm-chips.single-line {
+prizm-chips.single-line:not(empty) {
   margin-bottom: 11px;
 }

--- a/apps/doc/src/app/components/input/input-text/input-example.module.ts
+++ b/apps/doc/src/app/components/input/input-text/input-example.module.ts
@@ -4,9 +4,7 @@ import { RouterModule } from '@angular/router';
 import {
   PrizmButtonModule,
   PrizmHintDirective,
-  PrizmHintModule,
   PrizmIconComponent,
-  PrizmIconModule,
   PrizmInputTextModule,
 } from '@prizm-ui/components';
 import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';

--- a/libs/components/src/lib/components/input/carousel/input-carousel-auxiliary-left.component.ts
+++ b/libs/components/src/lib/components/input/carousel/input-carousel-auxiliary-left.component.ts
@@ -26,6 +26,7 @@ import { PrizmInputCommonModule } from '../common';
       :host {
         display: flex;
         align-items: center;
+        height: 100%;
       }
     `,
   ],

--- a/libs/components/src/lib/components/input/carousel/input-carousel-auxiliary-right.component.ts
+++ b/libs/components/src/lib/components/input/carousel/input-carousel-auxiliary-right.component.ts
@@ -26,6 +26,7 @@ import { PrizmInputCommonModule } from '../common';
       :host {
         display: flex;
         align-items: center;
+        height: 100%;
       }
     `,
   ],

--- a/libs/components/src/lib/components/input/common/input-icon-button/input-icon-button.component.less
+++ b/libs/components/src/lib/components/input/common/input-icon-button/input-icon-button.component.less
@@ -31,6 +31,7 @@
     }
 
     cursor: pointer;
+    height: 100%;
   }
 
   color: var(--prizm-v3-button-secondary-solid-default);

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -209,21 +209,21 @@
   &-inner {
     min-height: 44px;
 
-    &:not(:has(prizm-chips)) {
+    &:not(:has(prizm-chips > .chips-list)) {
       max-height: 44px;
     }
 
     &[data-size='l'] {
       min-height: 44px;
 
-      &:not(:has(prizm-chips)) {
+      &:not(:has(prizm-chips > .chips-list)) {
         max-height: 44px;
       }
     }
     &[data-size='m'] {
       min-height: 36px;
 
-      &:not(:has(prizm-chips)) {
+      &:not(:has(prizm-chips > .chips-list)) {
         max-height: 36px;
       }
     }
@@ -235,28 +235,28 @@
   &-outer {
     min-height: 32px;
 
-    &:not(:has(prizm-chips)) {
+    &:not(:has(prizm-chips > .chips-list)) {
       max-height: 32px;
     }
 
     &[data-size='l'] {
       min-height: 40px;
 
-      &:not(:has(prizm-chips)) {
+      &:not(:has(prizm-chips > .chips-list)) {
         max-height: 40px;
       }
     }
     &[data-size='m'] {
       min-height: 32px;
 
-      &:not(:has(prizm-chips)) {
+      &:not(:has(prizm-chips > .chips-list)) {
         max-height: 32px;
       }
     }
     &[data-size='s'] {
       min-height: 24px;
 
-      &:not(:has(prizm-chips)) {
+      &:not(:has(prizm-chips > .chips-list)) {
         max-height: 24px;
       }
     }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -118,7 +118,9 @@
     display: flex;
     align-items: center;
     flex-grow: 1;
+  }
 
+  &:not(:has([prizm-input-bottom])) &__first {
     // Hack for height in percents for buttons inside controls
     height: 1px;
   }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -6,7 +6,6 @@
   .prizm-input-form-status-button,
   .prizm-input-button-default {
     flex-shrink: 0;
-    height: 100%;
   }
 
   .prizm-input-button-default {
@@ -269,6 +268,7 @@
         position: absolute;
         z-index: 100;
         background-color: var(--prizm-v3-form-fill-default);
+        height: auto;
       }
 
       .prizm-input-button-default {

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -120,7 +120,7 @@
     flex-grow: 1;
   }
 
-  &:not(:has([prizm-input-bottom])) &__first {
+  &:not(:has([prizm-input-bottom])):not(.prizm-input-form-textarea) &__first {
     // Hack for height in percents for buttons inside controls
     height: 1px;
   }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -8,6 +8,10 @@
     flex-shrink: 0;
   }
 
+  .prizm-input-form-status-button {
+    align-self: center;
+  }
+
   .prizm-input-button-default {
     display: none;
   }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -118,6 +118,9 @@
     display: flex;
     align-items: center;
     flex-grow: 1;
+
+    // Hack for height in percents for buttons inside controls
+    height: 1px;
   }
 
   &-body {
@@ -204,11 +207,23 @@
   &-inner {
     min-height: 44px;
 
+    &:not(:has(prizm-chips)) {
+      max-height: 44px;
+    }
+
     &[data-size='l'] {
       min-height: 44px;
+
+      &:not(:has(prizm-chips)) {
+        max-height: 44px;
+      }
     }
     &[data-size='m'] {
       min-height: 36px;
+
+      &:not(:has(prizm-chips)) {
+        max-height: 36px;
+      }
     }
   }
 
@@ -218,14 +233,30 @@
   &-outer {
     min-height: 32px;
 
+    &:not(:has(prizm-chips)) {
+      max-height: 32px;
+    }
+
     &[data-size='l'] {
       min-height: 40px;
+
+      &:not(:has(prizm-chips)) {
+        max-height: 40px;
+      }
     }
     &[data-size='m'] {
       min-height: 32px;
+
+      &:not(:has(prizm-chips)) {
+        max-height: 32px;
+      }
     }
     &[data-size='s'] {
       min-height: 24px;
+
+      &:not(:has(prizm-chips)) {
+        max-height: 24px;
+      }
     }
   }
 

--- a/libs/components/src/lib/components/input/input-number/input-number-auxiliary-controls.component.less
+++ b/libs/components/src/lib/components/input/input-number/input-number-auxiliary-controls.component.less
@@ -1,6 +1,14 @@
+:host {
+  height: 100%;
+}
 .container {
   display: flex;
   flex-direction: column;
+  height: 100%;
+
+  [prizmInputIconButton] {
+    height: 50%;
+  }
 }
 
 :host-context(.prizm-input-form-outer[data-size='m']) {


### PR DESCRIPTION
fix(components/input-number): incorrect height of PrizmInputNumberDefaultControlsComponent #1308
fix(components/inputs): incorrect controls height #1179 
fix(components/input-button): input button size set to 100% height of conttainer

Resolved #1308
Resolved #1179

