### PR TITLE
feat: label text removed from select and multiselect default options // breaking change

### DIFF
--- a/libs/components/src/lib/components/dropdowns/multi-select/multi-select.options.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/multi-select.options.ts
@@ -80,7 +80,6 @@ export const PRIZM_MULTI_SELECT_DEFAULT_OPTIONS: PrizmMultiSelectOptions<unknown
   valueContent: '',
   placeholder: '',
   size: 'l',
-  label: 'Выберите из списка',
 };
 
 export const PRIZM_MULTI_SELECT_OPTIONS = new InjectionToken<PrizmMultiSelectOptions<unknown>>(

--- a/libs/components/src/lib/components/dropdowns/select/select.options.ts
+++ b/libs/components/src/lib/components/dropdowns/select/select.options.ts
@@ -83,7 +83,6 @@ export const PRIZM_SELECT_DEFAULT_OPTIONS: PrizmSelectOptions<unknown> = {
   listItemTemplate: null as any,
   placeholder: '',
   size: 'l',
-  label: 'Выберите из списка',
 };
 
 export const PRIZM_SELECT_OPTIONS = new InjectionToken<PrizmSelectOptions<unknown>>(


### PR DESCRIPTION
feat: label text removed from select and multiselect default options #1362 BREACKING CHANGE

Resolved #1362 