### PR TITLE
fix(components/paginator): updated i18n #1390

### DIFF
--- a/libs/components/src/lib/components/paginator/prizm-paginator.component.html
+++ b/libs/components/src/lib/components/paginator/prizm-paginator.component.html
@@ -27,7 +27,7 @@
       {{ paginator$ | async | prizmPluck : ['linesShown'] }} {{ (currentPage - 1) * rows + 1 }}-{{
         currentPage * rows > $any(totalRecords) ? totalRecords : currentPage * rows
       }}
-      из {{ realTotalRecord }}
+      {{ paginator$ | async | prizmPluck : ['fromText'] }} {{ realTotalRecord }}
     </span>
     <div
       class="paginator paginator__finite"

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -60,6 +60,7 @@ export interface PrizmLanguageColumnSettings {
 export interface PrizmLanguagePaginator {
   paginator: {
     linesShown: string;
+    fromText: string;
   };
 }
 

--- a/libs/i18n/src/lib/languages/russian/paginator.ts
+++ b/libs/i18n/src/lib/languages/russian/paginator.ts
@@ -3,5 +3,6 @@ import { PrizmLanguagePaginator } from '../../interfaces';
 export const PRIZM_RUSSIAN_PAGINATOR: PrizmLanguagePaginator = {
   paginator: {
     linesShown: 'Показано строк:',
+    fromText: 'из',
   },
 };


### PR DESCRIPTION
Resolved #1390

- fix(components/paginator): updated i18n #1390
if you use custom i18n dictionary you can get bc (our [ADR](https://jira.zyfra.com/wiki/x/crs6Dw))

@alexhawkins94 
вот тут важно просто посмотреть текст из выводиться или нет 
так как он теперь из словаря