### PR TITLE
fix: hint icon margins added for navigation menu #1329

### DIFF
--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.less
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.less
@@ -52,6 +52,10 @@
     margin: 0;
   }
 
+  &__extra:not(:empty) {
+    margin: 0 8px;
+  }
+
   /* expand icon */
   .expand-button {
     .transition(transform);


### PR DESCRIPTION
Fix(components/navigation-menu): hint icon margins added for navigation menu #1329

Resolved #1329