### PR TITLE
fix(components/input-date-time-range): afte clear time values in calendar got error #1368

### DIFF
--- a/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.ts
@@ -36,7 +36,7 @@ export class InputLayoutDateTimeRangeComponent {
     new PrizmDateTimeRange(new PrizmDayRange(new PrizmDay(2018, 2, 10), new PrizmDay(2018, 2, 10)))
   );
   readonly min = new PrizmDateTime(new PrizmDay(2000, 2, 20), new PrizmTime(0, 0));
-  readonly max = new PrizmDateTime(new PrizmDay(2040, 2, 20), new PrizmTime(0, 0));
+  readonly max = new PrizmDateTime(new PrizmDay(2040, 2, 20), new PrizmTime(23, 59));
   public placeholder = 'Выберите период';
   public testIdPostfix!: string;
   public sizeVariants: ReadonlyArray<PrizmInputSize> = ['l', 'm', 's'];

--- a/libs/components/src/lib/@core/date-time/index.ts
+++ b/libs/components/src/lib/@core/date-time/index.ts
@@ -14,3 +14,4 @@ export * from './time';
 export * from './time-range';
 export * from './year';
 export * from './day-time-range';
+export * from './time-limit';

--- a/libs/components/src/lib/@core/date-time/time-limit.ts
+++ b/libs/components/src/lib/@core/date-time/time-limit.ts
@@ -1,0 +1,42 @@
+import { PrizmDay } from './day';
+import { PrizmTime } from './time';
+
+export function prizmTimeLimitWithinRange(
+  date: PrizmDay,
+  time: PrizmTime | null,
+  dateMin: PrizmDay,
+  dateMax: PrizmDay,
+  timeMin: PrizmTime | null = null,
+  timeMax: PrizmTime | null = null
+) {
+  if (!date || !time || (!timeMin && !timeMax)) {
+    return time;
+  }
+
+  time = handleTimeLimit(date, time, dateMin, timeMin);
+  time = handleTimeLimit(date, time, dateMax, timeMax, false);
+
+  return time;
+}
+
+export const handleTimeLimit = (
+  date: PrizmDay,
+  time: PrizmTime,
+  limitDate: PrizmDay,
+  limitTime: PrizmTime | null,
+  isMin: boolean = true
+) => {
+  if (!limitTime || !limitDate || !limitDate.daySame(date)) {
+    return time;
+  }
+
+  const shouldSetTime = isMin
+    ? limitTime.toAbsoluteMilliseconds() > time.toAbsoluteMilliseconds()
+    : limitTime.toAbsoluteMilliseconds() < time.toAbsoluteMilliseconds();
+
+  if (shouldSetTime) {
+    time = time.timeLimit(isMin ? limitTime : null, isMin ? null : limitTime);
+  }
+
+  return time;
+};

--- a/libs/components/src/lib/@core/date-time/time.ts
+++ b/libs/components/src/lib/@core/date-time/time.ts
@@ -10,6 +10,7 @@ import {
   PRIZM_SECONDS_IN_MINUTE,
 } from './date-time';
 import { prizmAssert, prizmPadStart } from '@prizm-ui/core';
+import { PrizmDay } from './day';
 
 /**
  * Immutable time object with hours, minutes, seconds and ms

--- a/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
@@ -369,10 +369,10 @@ export class PrizmInputLayoutDateTimeRangeComponent
           if (!toTimeValue || toTimeValue.length !== this.computedTimeMask.length) return;
 
           if (
-            fromValue === this.value?.dayRange?.from.toString() &&
-            fromTimeValue === this.value?.timeRange?.from.toString(this.timeMode) &&
-            toValue === this.value?.dayRange?.to.toString() &&
-            toTimeValue === this.value?.timeRange?.to.toString(this.timeMode)
+            fromValue === this.value?.dayRange?.from?.toString() &&
+            fromTimeValue === this.value?.timeRange?.from?.toString(this.timeMode) &&
+            toValue === this.value?.dayRange?.to?.toString() &&
+            toTimeValue === this.value?.timeRange?.to?.toString(this.timeMode)
           ) {
             return;
           }

--- a/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
@@ -517,7 +517,7 @@ export class PrizmInputLayoutDateTimeRangeComponent
   }
 
   public updateTimeTo(value: PrizmTime): void {
-    // TODO: #mz add min max
+    // TODO: feature > safe add min max limiter
     if (
       value &&
       this.value?.timeRange?.to instanceof PrizmTime &&
@@ -529,16 +529,14 @@ export class PrizmInputLayoutDateTimeRangeComponent
   }
 
   public updateTimeFrom(value: PrizmTime): void {
-    // TODO: #mz add min max
+    // TODO: feature > safe add min max limiter
     if (
       value &&
       this.value?.timeRange?.from instanceof PrizmTime &&
       this.value?.timeRange?.from?.isSameTime(value)
     )
       return;
-    // const range = PrizmDateTimeRange.safeUpdateTimeFrom(this.value, value);
-    // this.updateValue(range?.copy());
-    this.nativeValueTimeFrom$$.next(value.toString(this.timeMode));
+    this.nativeValueTimeFrom$$.next(value?.toString(this.timeMode) ?? '');
   }
 
   public referFocusToMain(referFocus = true) {

--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
@@ -59,6 +59,7 @@ import { PrizmLinkComponent } from '../../link';
 import { PrizmValueAccessorModule } from '../../../directives/value-accessor/value-accessor.module';
 import { PrizmListingItemComponent } from '../../listing-item';
 import { PrizmLanguageInputLayoutDateTime } from '@prizm-ui/i18n';
+import { prizmTimeLimitWithinRange } from '../../../@core/date-time/time-limit';
 
 @Component({
   selector: `prizm-input-layout-date-time`,
@@ -324,18 +325,14 @@ export class PrizmInputLayoutDateTimeComponent
   private updateWithCorrectDateAndTime(value: [PrizmDay | null, PrizmTime | null]): void {
     if (!value) return;
     let [date, time] = value;
-    // correct min max time
-    if (date)
-      date = date.dayLimit(
-        this.min instanceof PrizmDay ? this.min : this.min && this.min[0],
-        this.max instanceof PrizmDay ? this.max : this.max && this.max[0]
-      );
 
-    const timeMin = Array.isArray(this.min) && this.min[1] ? this.min[1] : null;
-    const timeMax = Array.isArray(this.max) && this.max[1] ? this.max[1] : null;
-    if (time && (timeMin || timeMax)) {
-      time = time.timeLimit(timeMin, timeMax);
-    }
+    const dateMin = this.min instanceof PrizmDay ? this.min : this.min && this.min[0];
+    const dateMax = this.max instanceof PrizmDay ? this.max : this.max && this.max[0];
+
+    // correct min max time
+    if (date) date = date.dayLimit(dateMin, dateMax);
+
+    if (date) time = this.limitTime(date, time, dateMin, dateMax);
 
     this.focusableElement?.updateNativeValues({
       idx: 0,
@@ -349,6 +346,13 @@ export class PrizmInputLayoutDateTimeComponent
     ]);
 
     this.updateValue([date, time]);
+  }
+
+  private limitTime(date: PrizmDay, time: PrizmTime | null, dateMin: PrizmDay, dateMax: PrizmDay) {
+    const timeMin = Array.isArray(this.min) && this.min[1] ? this.min[1] : null;
+    const timeMax = Array.isArray(this.max) && this.max[1] ? this.max[1] : null;
+
+    return prizmTimeLimitWithinRange(date, time, dateMin, dateMax, timeMin, timeMax);
   }
 
   public onTimeValueChange(value: string): void {


### PR DESCRIPTION
- fix(components/input-date-time-range): afte clear time values in calendar got error #1368
- fix(components/input-date-time): min/max does not work correctly in InputLayoutDateTime #1421

Resolved #1368
Resolved #1421