### PR TITLE
Fix/calendar markup

### DIFF
--- a/apps/doc/src/app/components/calendars/calendar-month/examples/range/range.component.ts
+++ b/apps/doc/src/app/components/calendars/calendar-month/examples/range/range.component.ts
@@ -10,7 +10,7 @@ import { PrizmMonth, PrizmMonthRange } from '@prizm-ui/components';
 export class PrizmMonthExample2Component {
   value: PrizmMonthRange | null = null;
 
-  max = new PrizmMonth(2021, 7);
+  max = new PrizmMonth(2024, 3);
   min = new PrizmMonth(2019, 7);
 
   public onMonthClick(month: PrizmMonth): void {

--- a/apps/doc/src/app/components/calendars/calendar/calendar.component.html
+++ b/apps/doc/src/app/components/calendars/calendar/calendar.component.html
@@ -15,6 +15,7 @@
         [prizmDocHostElement]="element"
         [value]="day"
         [showAdjacent]="showAdjacent"
+        [rangeState]="rangeState"
         (dayClick)="onDayClick($event)"
       ></prizm-calendar>
     </prizm-doc-demo>
@@ -97,6 +98,14 @@
         documentationPropertyMode="input"
       >
         Marker Handler
+      </ng-template>
+
+      <ng-template
+        documentationPropertyName="rangeState"
+        documentationPropertyType="PrizmRangeState"
+        documentationPropertyMode="input"
+      >
+        Range State
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/calendars/calendar/calendar.component.ts
+++ b/apps/doc/src/app/components/calendars/calendar/calendar.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
-import { PrizmDay } from '@prizm-ui/components';
+import { PrizmDay, PrizmRangeState } from '@prizm-ui/components';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -12,6 +12,7 @@ import { UntypedFormControl } from '@angular/forms';
 export class CalendarComponent {
   public day = new PrizmDay(2017, 0, 15);
   public showAdjacent = true;
+  public rangeState: PrizmRangeState = PrizmRangeState.Single;
   public readonly control = new UntypedFormControl(new PrizmDay(2017, 0, 15));
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 

--- a/apps/doc/src/app/components/calendars/calendar/examples/base/calendar-base-example.component.ts
+++ b/apps/doc/src/app/components/calendars/calendar/examples/base/calendar-base-example.component.ts
@@ -16,7 +16,7 @@ import { PrizmDay, PrizmDayWithStatus } from '@prizm-ui/components';
 export class PrizmCalendarBaseExampleComponent {
   public day = new PrizmDay(2017, 0, 15);
   public daysWithStatus = [
-    new PrizmDayWithStatus(2017, 0, 10, 'index'),
+    new PrizmDayWithStatus(2017, 0, 1, 'index'),
     new PrizmDayWithStatus(2017, 0, 11, 'warning'),
     new PrizmDayWithStatus(2017, 0, 12, 'danger'),
     new PrizmDayWithStatus(2017, 0, 13, 'success'),

--- a/libs/components/src/lib/components/calendar-month/calendar-month.component.html
+++ b/libs/components/src/lib/components/calendar-month/calendar-month.component.html
@@ -4,6 +4,10 @@
     [max]="max"
     [initialItem]="year"
     [value]="value"
+    [intervalSupport]="true"
+    [style.--prizm-year-item-widtn]="'84px'"
+    [style.--prizm-year-item-height]="'44px'"
+    [style.--prizm-year-picker-widtn]="'256px'"
     (yearClick)="onPickerYearClick($event)"
   ></prizm-primitive-year-picker>
 </prizm-scrollbar>

--- a/libs/components/src/lib/components/calendar-month/calendar-month.component.less
+++ b/libs/components/src/lib/components/calendar-month/calendar-month.component.less
@@ -34,12 +34,6 @@
   }
 }
 
-.z-cell_interval:nth-child(4n) {
-  &:before {
-    right: 0;
-  }
-}
-
 .z-scrollbar {
   height: inherit;
   width: inherit;

--- a/libs/components/src/lib/components/calendar-month/calendar-month.component.less
+++ b/libs/components/src/lib/components/calendar-month/calendar-month.component.less
@@ -30,6 +30,7 @@
 
     .z-item {
       color: var(--prizm-v3-button-primary-solid-hover) !important;
+      border-color: var(--prizm-v3-button-ghost-hover);
     }
   }
 }

--- a/libs/components/src/lib/components/calendar-month/calendar-month.component.less
+++ b/libs/components/src/lib/components/calendar-month/calendar-month.component.less
@@ -1,12 +1,15 @@
 @import '../../../styles/ui-local.less';
 
-.picker(3.6875rem);
+@itemWidth: 85px;
+@itemHeight: 45px;
+
+.picker(@itemWidth, @itemHeight);
 
 :host {
   display: block;
-  height: 13.625rem;
-  width: 15.75rem;
-  padding: 1.125rem;
+  height: 222px;
+  width: 256px;
+  padding: 16px;
   box-sizing: content-box;
 
   .year-btn {
@@ -16,15 +19,11 @@
 
 .z-row {
   flex-wrap: wrap;
-  margin-top: 1.4375rem;
+  justify-content: center;
 }
 
 .z-cell {
   box-sizing: content-box;
-
-  &:nth-child(n + 5) {
-    margin-top: 1.75rem;
-  }
 
   &:not([data-range='start']):not([data-range='single']):not([data-range='end']):hover {
     background-color: var(--prizm-v3-button-ghost-hover);

--- a/libs/components/src/lib/components/calendar-month/calendar-month.component.ts
+++ b/libs/components/src/lib/components/calendar-month/calendar-month.component.ts
@@ -180,7 +180,7 @@ export class PrizmCalendarMonthComponent
     }
 
     if (!value.isSingleMonth) {
-      return value.from.monthSameOrBefore(month) && value.to.monthAfter(month);
+      return value.from.monthSameOrBefore(month) && value.to.monthSameOrAfter(month);
     }
 
     if (hoveredItem === null) {

--- a/libs/components/src/lib/components/calendar-month/calendar-month.component.ts
+++ b/libs/components/src/lib/components/calendar-month/calendar-month.component.ts
@@ -28,7 +28,6 @@ import { CommonModule } from '@angular/common';
 import {
   PrizmFocusableModule,
   PrizmHoveredDirective,
-  PrizmHoveredModule,
   PrizmPressedModule,
   PrizmStopPropagationModule,
 } from '../../directives';

--- a/libs/components/src/lib/components/calendar/calendar.component.html
+++ b/libs/components/src/lib/components/calendar/calendar.component.html
@@ -20,6 +20,7 @@
         [max]="max"
         [initialItem]="year"
         [value]="value"
+        [rangeState]="rangeState"
         (yearClick)="onPickerYearClick($event)"
         automation-id="prizm-calendar__year"
       ></prizm-primitive-year-picker>
@@ -30,6 +31,7 @@
           [initialItem]="$any(clickedMonth)"
           [value]="value"
           [currentYear]="month.year"
+          [rangeState]="rangeState"
           (monthClick)="onPickerMonthClick($event)"
           automation-id="prizm-calendar__year"
         ></prizm-primitive-month-picker>

--- a/libs/components/src/lib/components/calendar/calendar.component.less
+++ b/libs/components/src/lib/components/calendar/calendar.component.less
@@ -1,23 +1,17 @@
-@verticalSpace: 1rem;
-@horizontalSpace: 1.125rem;
-@itemSize: 2.25rem;
-@paginationSize: 1.5rem;
-@calendarSize: @itemSize * 7;
-@height: @paginationSize + @verticalSpace + @calendarSize;
+@paddings: 16px;
+@paginationHeight: 40px;
+@calendarWidth: 280px;
+@calendarHeight: 312px + @paginationHeight;
 
 :host {
   display: block;
-  height: calc(@height + var(--prizm-calendar-footer-height, 0));
-  width: @calendarSize;
-  padding: 16px;
+  height: calc(@calendarHeight + var(--prizm-calendar-footer-height, 0));
+  width: @calendarWidth;
+  padding: @paddings;
   box-sizing: content-box;
 }
 
 .z-scrollbar {
-  height: @paginationSize + @verticalSpace + @calendarSize - 2rem;
-  width: @calendarSize + @horizontalSpace;
-}
-
-.z-pagination {
-  margin-bottom: @verticalSpace;
+  height: @calendarHeight - @paginationHeight - (@paddings * 2);
+  width: @calendarWidth + @paddings;
 }

--- a/libs/components/src/lib/components/calendar/calendar.component.ts
+++ b/libs/components/src/lib/components/calendar/calendar.component.ts
@@ -12,7 +12,7 @@ import { PrizmMapper } from '../../types/mapper';
 import { PrizmMarkerHandler } from '../../types/marker-handler';
 import { PrizmWithOptionalMinMax } from '../../types/with-optional-min-max';
 import { prizmNullableSame } from '../../util/common/nullable-same';
-import { PrizmDayWithStatus } from '../../@core';
+import { PrizmDayWithStatus, PrizmRangeState } from '../../@core';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { CommonModule } from '@angular/common';
 import { PrizmPrimitiveCalendarComponent } from '../internal/primitive-calendar';
@@ -82,6 +82,10 @@ export class PrizmCalendarComponent extends PrizmAbstractTestId implements Prizm
   @Input()
   @prizmDefaultProp()
   markerHandler: PrizmMarkerHandler = PRIZM_DEFAULT_MARKER_HANDLER;
+
+  @Input()
+  @prizmDefaultProp()
+  rangeState: PrizmRangeState = PrizmRangeState.Single;
 
   @Output()
   readonly dayClick = new EventEmitter<PrizmDay>();

--- a/libs/components/src/lib/components/internal/primitive-calendar-range/primitive-calendar-range.component.html
+++ b/libs/components/src/lib/components/internal/primitive-calendar-range/primitive-calendar-range.component.html
@@ -8,6 +8,7 @@
   [value]="value"
   [disabledItemHandler]="disabledItemHandler"
   [showAdjacent]="false"
+  [rangeState]="rangeStates[0]"
   (dayClick)="onDayClick($event)"
   (monthChange)="onSectionFirstViewedMonth($event)"
 >
@@ -25,6 +26,7 @@
   [value]="value"
   [disabledItemHandler]="disabledItemHandler"
   [showAdjacent]="false"
+  [rangeState]="rangeStates[1]"
   (dayClick)="onDayClick($event)"
   (monthChange)="onSectionSecondViewedMonth($event)"
 >

--- a/libs/components/src/lib/components/internal/primitive-calendar-range/primitive-calendar-range.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-calendar-range/primitive-calendar-range.component.ts
@@ -24,6 +24,7 @@ import { PrizmBooleanHandler } from '../../../types/handler';
 import { PrizmMapper } from '../../../types/mapper';
 import { PrizmMarkerHandler } from '../../../types/marker-handler';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
+import { PrizmRangeState } from '../../../@core/enums';
 
 /**
  * @internal
@@ -63,6 +64,8 @@ export class PrizmPrimitiveCalendarRangeComponent extends PrizmAbstractTestId im
   @Input()
   @prizmDefaultProp()
   value: PrizmDayRange | null = null;
+
+  readonly rangeStates = [PrizmRangeState.Start, PrizmRangeState.End];
 
   @Output()
   readonly dayClick = new EventEmitter<PrizmDay>();

--- a/libs/components/src/lib/components/internal/primitive-calendar/primitive-calendar.component.less
+++ b/libs/components/src/lib/components/internal/primitive-calendar/primitive-calendar.component.less
@@ -67,7 +67,6 @@
   height: 4px;
   width: 50%;
   bottom: 4px;
-  transform: translateX(50%);
   border-radius: 2px;
   background-color: var(--prizm-status-day-color);
 

--- a/libs/components/src/lib/components/internal/primitive-calendar/primitive-calendar.component.less
+++ b/libs/components/src/lib/components/internal/primitive-calendar/primitive-calendar.component.less
@@ -92,3 +92,14 @@
     );
   }
 }
+
+[data-range='single']:not([data-state='hovered']) {
+  .z-status {
+    &[data-prizm-status='index'] {
+      background-color: var(
+        --prizm-calendar-day-status-secondary-default,
+        var(--prizm-v3-status-info-secondary-default)
+      );
+    }
+  }
+}

--- a/libs/components/src/lib/components/internal/primitive-calendar/primitive-calendar.component.less
+++ b/libs/components/src/lib/components/internal/primitive-calendar/primitive-calendar.component.less
@@ -1,11 +1,15 @@
 @import '../../../../styles/ui-local.less';
 
-@itemSize: 2.25rem;
+@itemSize: 40px;
 
-.picker(@itemSize);
+.picker(@itemSize, @itemSize);
 
 :host {
   width: @itemSize * 7;
+
+  .footer:not(:empty) {
+    margin-top: 8px;
+  }
 }
 
 .z-item {

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.less
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.less
@@ -1,27 +1,14 @@
 @import '../../../../styles/ui-local.less';
 
-@itemSize: 3.9375rem;
+@itemWidth: 93px;
+@itemHeight: 70px;
 
-.picker(@itemSize);
+.picker(@itemWidth, @itemHeight);
 
 :host {
-  width: @itemSize * 4;
-}
-
-.z-row {
-  margin: 16px 0;
-  gap: 4px;
-
-  &:first-child {
-    margin-top: 0;
-  }
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  width: 280px;
 }
 
 .z-cell {
   flex-grow: 1;
-  width: 100%;
 }

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
@@ -133,14 +133,6 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
       return value.month === item && value.year === this.currentYear ? PrizmRangeState.Single : null;
     }
 
-    // TODO finish it after add support intervals or delete
-    // if (
-    //   this.value instanceof PrizmDayRange &&
-    //   this.value.isMonthInRange(new PrizmMonth(this.currentYear, item))
-    // ) {
-    //   return PrizmRangeState.Single;
-    // }
-
     if (
       (value.from.month === item && !value.from.monthSame(value.to)) ||
       (hoveredItem !== null &&

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
@@ -19,6 +19,7 @@ import { PrizmAbstractTestId } from '../../../abstract/interactive';
 import { PrizmLetDirective } from '@prizm-ui/helpers';
 import { CommonModule } from '@angular/common';
 import { PrizmMonthPipeModule } from '../../../pipes';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 
 const ITEMS_IN_ROW = 3;
 const ROWS = 4;
@@ -69,6 +70,17 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
   @Input()
   @prizmDefaultProp()
   disabledItemHandler: PrizmBooleanHandler<number> = PRIZM_ALWAYS_FALSE_HANDLER;
+
+  @Input()
+  @prizmDefaultProp()
+  rangeState: PrizmRangeState = PrizmRangeState.Single;
+
+  @Input()
+  @prizmDefaultProp()
+  set intervalSupport(value: BooleanInput) {
+    this._intervalSupport = coerceBooleanProperty(value);
+  }
+  private _intervalSupport = false;
 
   @Output()
   readonly monthClick = new EventEmitter<PrizmMonth>();
@@ -144,29 +156,22 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
         hoveredItem === value.from.month &&
         value.from.monthSame(value.to))
     ) {
-      return PrizmRangeState.Single;
-
-      // TODO finish it after add support intervals
-      // return PrizmRangeState.Start;
+      return this.rangeState === PrizmRangeState.Start || this._intervalSupport ? this.rangeState : null;
     }
 
-    // TODO finish it after add support intervals
-    // if (
-    //     (value.to.month === item && !value.from.monthSame(value.to)) ||
-    //     (hoveredItem !== null &&
-    //         hoveredItem < value.from.month &&
-    //         value.from.month === item &&
-    //         value.from.monthSame(value.to)) ||
-    //     (hoveredItem !== null &&
-    //         hoveredItem === item &&
-    //         hoveredItem > value.from.month &&
-    //         value.from.monthSame(value.to))
-    // ) {
-    //   return PrizmRangeState.Single;
-    //
-    //
-    //   // return PrizmRangeState.End;
-    // }
+    if (
+      (value.to.month === item && !value.from.monthSame(value.to)) ||
+      (hoveredItem !== null &&
+        hoveredItem < value.from.month &&
+        value.from.month === item &&
+        value.from.monthSame(value.to)) ||
+      (hoveredItem !== null &&
+        hoveredItem === item &&
+        hoveredItem > value.from.month &&
+        value.from.monthSame(value.to))
+    ) {
+      return this.rangeState === PrizmRangeState.End || this._intervalSupport ? this.rangeState : null;
+    }
 
     return value.from.monthSame(value.to) && value.from.month === item && value.from.year === this.currentYear
       ? PrizmRangeState.Single
@@ -181,7 +186,7 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
    * not support interval
    * */
   public itemIsInterval(item: number): boolean {
-    return false;
+    return this._intervalSupport ? this.itemIsIntervalNew(item) : false;
   }
 
   /**

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
@@ -133,12 +133,13 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
       return value.month === item && value.year === this.currentYear ? PrizmRangeState.Single : null;
     }
 
-    if (
-      this.value instanceof PrizmDayRange &&
-      this.value.isMonthInRange(new PrizmMonth(this.currentYear, item))
-    ) {
-      return PrizmRangeState.Single;
-    }
+    // TODO finish it after add support intervals or delete
+    // if (
+    //   this.value instanceof PrizmDayRange &&
+    //   this.value.isMonthInRange(new PrizmMonth(this.currentYear, item))
+    // ) {
+    //   return PrizmRangeState.Single;
+    // }
 
     if (
       (value.from.month === item && !value.from.monthSame(value.to)) ||

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
@@ -135,7 +135,7 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
   }
 
   public getItemRange(item: number): PrizmRangeState | null {
-    const { value, hoveredItem } = this;
+    const { value } = this;
 
     if (value === null) {
       return null;
@@ -145,37 +145,27 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
       return value.month === item && value.year === this.currentYear ? PrizmRangeState.Single : null;
     }
 
-    if (
-      (value.from.month === item && !value.from.monthSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem > value.from.month &&
-        value.from.month === item &&
-        value.from.monthSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem === item &&
-        hoveredItem === value.from.month &&
-        value.from.monthSame(value.to))
-    ) {
-      return this.rangeState === PrizmRangeState.Start || this._intervalSupport ? this.rangeState : null;
+    if (this._intervalSupport) {
+      return value.from.month === item && value.from.year === this.currentYear
+        ? PrizmRangeState.Start
+        : value.to.month === item && value.from.year === this.currentYear
+        ? PrizmRangeState.End
+        : null;
     }
 
-    if (
-      (value.to.month === item && !value.from.monthSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem < value.from.month &&
-        value.from.month === item &&
-        value.from.monthSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem === item &&
-        hoveredItem > value.from.month &&
-        value.from.monthSame(value.to))
-    ) {
-      return this.rangeState === PrizmRangeState.End || this._intervalSupport ? this.rangeState : null;
+    if (this.rangeState === PrizmRangeState.Start && value.from.month === item) {
+      return PrizmRangeState.Start;
     }
 
-    return value.from.monthSame(value.to) && value.from.month === item && value.from.year === this.currentYear
-      ? PrizmRangeState.Single
-      : null;
+    if (this.rangeState === PrizmRangeState.End && value.to.month === item) {
+      return PrizmRangeState.End;
+    }
+
+    if (value.from.monthSame(value.to) && value.from.month === item && value.from.year === this.currentYear) {
+      return PrizmRangeState.Single;
+    }
+
+    return null;
   }
 
   public itemIsToday(item: number): boolean {

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.module.ts
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.module.ts
@@ -1,12 +1,5 @@
 import { NgModule } from '@angular/core';
 import { PrizmPrimitiveMonthPickerComponent } from './primitive-month-picker.component';
-import { PrizmLetModule } from '@prizm-ui/helpers';
-import { PrizmRepeatTimesModule } from '../../../directives/repeat-times/repeat-times.module';
-import { PrizmHoveredModule } from '../../../directives/hovered/hovered.module';
-import { PrizmPressedModule } from '../../../directives/pressed/pressed.module';
-import { PrizmScrollIntoViewModule } from '../../../directives/scroll-into-view/scroll-into-view.module';
-import { PrizmMonthPipeModule } from '../../../pipes/month';
-import { CommonModule } from '@angular/common';
 
 /**
  * @deprecated

--- a/libs/components/src/lib/components/internal/primitive-spin-button/primitive-spin-button.module.ts
+++ b/libs/components/src/lib/components/internal/primitive-spin-button/primitive-spin-button.module.ts
@@ -4,6 +4,7 @@ import {
   PrizmFocusableModule,
   PrizmFocusedModule,
   PrizmFocusVisibleModule,
+  PrizmHintDirective,
   PrizmPreventDefaultModule,
 } from '../../../directives';
 import { PrizmButtonModule } from '../../button/button.module';
@@ -18,6 +19,7 @@ import { PrizmPrimitiveSpinButtonComponent } from './primitive-spin-button.compo
     PrizmFocusableModule,
     PrizmPreventDefaultModule,
     PrizmButtonModule,
+    PrizmHintDirective,
   ],
   declarations: [PrizmPrimitiveSpinButtonComponent],
   exports: [PrizmPrimitiveSpinButtonComponent],

--- a/libs/components/src/lib/components/internal/primitive-spin-button/primitive-spin-button.template.html
+++ b/libs/components/src/lib/components/internal/primitive-spin-button/primitive-spin-button.template.html
@@ -19,7 +19,7 @@
     icon="arrows-chevron-left"
     appearance="secondary"
     [class.z-arrow_hidden]="leftComputedDisabled"
-    [title]="texts[0]"
+    [prizmHint]="texts[0]"
     [focusable]="false"
     (click)="onLeftClick()"
   ></button>
@@ -36,7 +36,7 @@
     icon="arrows-chevron-right"
     [appearanceType]="mode"
     [class.z-arrow_hidden]="rightComputedDisabled"
-    [title]="texts[1]"
+    [prizmHint]="texts[1]"
     [focusable]="false"
     (click)="onRightClick()"
   ></button>

--- a/libs/components/src/lib/components/internal/primitive-spin-button/primitive-spin-button.template.html
+++ b/libs/components/src/lib/components/internal/primitive-spin-button/primitive-spin-button.template.html
@@ -20,6 +20,7 @@
     appearance="secondary"
     [class.z-arrow_hidden]="leftComputedDisabled"
     [prizmHint]="texts[0]"
+    [prizmHintDirection]="'b'"
     [focusable]="false"
     (click)="onLeftClick()"
   ></button>
@@ -37,6 +38,7 @@
     [appearanceType]="mode"
     [class.z-arrow_hidden]="rightComputedDisabled"
     [prizmHint]="texts[1]"
+    [prizmHintDirection]="'b'"
     [focusable]="false"
     (click)="onRightClick()"
   ></button>

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.less
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.less
@@ -1,21 +1,14 @@
 @import '../../../../styles/ui-local.less';
 
-@itemSize: 3.9375rem;
+@itemWidth: 93px;
+@itemHeight: 56px;
 
-.picker(@itemSize);
+.picker(@itemWidth, @itemHeight);
 
 :host {
-  width: @itemSize * 4;
+  width: 280px;
 }
 
-.z-row {
-  margin: 0.875rem 0;
-
-  &:first-child {
-    margin-top: 0;
-  }
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+.z-cell {
+  flex-grow: 1;
 }

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.less
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.less
@@ -1,12 +1,12 @@
 @import '../../../../styles/ui-local.less';
 
-@itemWidth: 93px;
-@itemHeight: 56px;
+@itemWidth: var(--prizm-year-item-widtn, 93px);
+@itemHeight: var(--prizm-year-item-height, 56px);
 
 .picker(@itemWidth, @itemHeight);
 
 :host {
-  width: 280px;
+  width: var(--prizm-year-picker-widtn, 280px);
 }
 
 .z-cell {

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
@@ -135,14 +135,6 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
       return value.year === item ? PrizmRangeState.Single : null;
     }
 
-    // TODO add after add support intervals or delete
-    // if (
-    //   (value instanceof PrizmDayRange || value instanceof PrizmMonthRange) &&
-    //   value.isYearInRange(new PrizmYear(item))
-    // ) {
-    //   return PrizmRangeState.Single;
-    // }
-
     if (
       (value.from.year === item && !value.from.yearSame(value.to)) ||
       (hoveredItem !== null &&
@@ -192,7 +184,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
   }
 
   /**
-   * TODO with support intervals
+   *  with support intervals
    * */
   public itemIsIntervalNew(item: number): boolean {
     const { value, hoveredItem } = this;

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
@@ -154,7 +154,9 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
         hoveredItem < value.from.year &&
         value.from.yearSame(value.to))
     ) {
-      return this.rangeState === PrizmRangeState.Start || this._intervalSupport ? this.rangeState : null;
+      return this.rangeState === PrizmRangeState.Start || this._intervalSupport
+        ? PrizmRangeState.Start
+        : null;
     }
 
     if (
@@ -168,7 +170,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
         hoveredItem > value.from.year &&
         value.from.yearSame(value.to))
     ) {
-      return this.rangeState === PrizmRangeState.End || this._intervalSupport ? this.rangeState : null;
+      return this.rangeState === PrizmRangeState.End || this._intervalSupport ? PrizmRangeState.End : null;
     }
 
     return value.from.yearSame(value.to) && value.from.year === item ? PrizmRangeState.Single : null;
@@ -196,7 +198,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
     }
 
     if (!value.from.yearSame(value.to)) {
-      return value.from.year <= item && value.to.year > item;
+      return value.from.year <= item && value.to.year >= item;
     }
 
     if (hoveredItem === null || value.from.year === hoveredItem) {

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
@@ -133,7 +133,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
   }
 
   public getItemRange(item: number): PrizmRangeState | null {
-    const { value, hoveredItem } = this;
+    const { value } = this;
 
     if (value === null) {
       return null;
@@ -143,37 +143,27 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
       return value.year === item ? PrizmRangeState.Single : null;
     }
 
-    if (
-      (value.from.year === item && !value.from.yearSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem > value.from.year &&
-        value.from.year === item &&
-        value.from.yearSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem === item &&
-        hoveredItem < value.from.year &&
-        value.from.yearSame(value.to))
-    ) {
-      return this.rangeState === PrizmRangeState.Start || this._intervalSupport
+    if (this._intervalSupport) {
+      return value.from.year === item
         ? PrizmRangeState.Start
+        : value.to.year === item
+        ? PrizmRangeState.End
         : null;
     }
 
-    if (
-      (value.to.year === item && !value.from.yearSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem < value.from.year &&
-        value.from.year === item &&
-        value.from.yearSame(value.to)) ||
-      (hoveredItem !== null &&
-        hoveredItem === item &&
-        hoveredItem > value.from.year &&
-        value.from.yearSame(value.to))
-    ) {
-      return this.rangeState === PrizmRangeState.End || this._intervalSupport ? PrizmRangeState.End : null;
+    if (this.rangeState === PrizmRangeState.Start && value.from.year === item) {
+      return PrizmRangeState.Start;
     }
 
-    return value.from.yearSame(value.to) && value.from.year === item ? PrizmRangeState.Single : null;
+    if (this.rangeState === PrizmRangeState.End && value.to.year === item) {
+      return PrizmRangeState.End;
+    }
+
+    if (value.from.yearSame(value.to) && value.from.year === item) {
+      return PrizmRangeState.Single;
+    }
+
+    return null;
   }
 
   public itemIsToday(item: number): boolean {

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
@@ -59,6 +59,10 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
   @prizmDefaultProp()
   disabledItemHandler: PrizmBooleanHandler<number> = PRIZM_ALWAYS_FALSE_HANDLER;
 
+  @Input()
+  @prizmDefaultProp()
+  intervalSupport = false;
+
   @Output()
   readonly yearClick = new EventEmitter<PrizmYear>();
 
@@ -131,12 +135,13 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
       return value.year === item ? PrizmRangeState.Single : null;
     }
 
-    if (
-      (value instanceof PrizmDayRange || value instanceof PrizmMonthRange) &&
-      value.isYearInRange(new PrizmYear(item))
-    ) {
-      return PrizmRangeState.Single;
-    }
+    // TODO add after add support intervals or delete
+    // if (
+    //   (value instanceof PrizmDayRange || value instanceof PrizmMonthRange) &&
+    //   value.isYearInRange(new PrizmYear(item))
+    // ) {
+    //   return PrizmRangeState.Single;
+    // }
 
     if (
       (value.from.year === item && !value.from.yearSame(value.to)) ||
@@ -183,7 +188,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
    * not support interval
    * */
   public itemIsInterval(item: number): boolean {
-    return false;
+    return this.intervalSupport ? this.itemIsIntervalNew(item) : false;
   }
 
   /**

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
@@ -16,6 +16,7 @@ import {
 import { PrizmRangeState } from '../../../@core/enums/range-state';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
 import { PrizmLetDirective } from '@prizm-ui/helpers';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 
 const LIMIT = 100;
 const ITEMS_IN_ROW = 3;
@@ -61,7 +62,14 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
 
   @Input()
   @prizmDefaultProp()
-  intervalSupport = false;
+  rangeState: PrizmRangeState = PrizmRangeState.Single;
+
+  @Input()
+  @prizmDefaultProp()
+  set intervalSupport(value: BooleanInput) {
+    this._intervalSupport = coerceBooleanProperty(value);
+  }
+  private _intervalSupport = false;
 
   @Output()
   readonly yearClick = new EventEmitter<PrizmYear>();
@@ -146,10 +154,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
         hoveredItem < value.from.year &&
         value.from.yearSame(value.to))
     ) {
-      return PrizmRangeState.Single;
-
-      // TODO add after add support intervals
-      // return PrizmRangeState.Start;
+      return this.rangeState === PrizmRangeState.Start || this._intervalSupport ? this.rangeState : null;
     }
 
     if (
@@ -163,10 +168,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
         hoveredItem > value.from.year &&
         value.from.yearSame(value.to))
     ) {
-      return PrizmRangeState.Single;
-
-      // TODO add after add support intervals
-      // return PrizmRangeState.End;
+      return this.rangeState === PrizmRangeState.End || this._intervalSupport ? this.rangeState : null;
     }
 
     return value.from.yearSame(value.to) && value.from.year === item ? PrizmRangeState.Single : null;
@@ -180,7 +182,7 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
    * not support interval
    * */
   public itemIsInterval(item: number): boolean {
-    return this.intervalSupport ? this.itemIsIntervalNew(item) : false;
+    return this._intervalSupport ? this.itemIsIntervalNew(item) : false;
   }
 
   /**

--- a/libs/components/src/styles/mixins/picker.less
+++ b/libs/components/src/styles/mixins/picker.less
@@ -1,4 +1,4 @@
-.picker(@itemSize) {
+.picker(@itemWidth, @itemHeight) {
   :host {
     display: block;
     font: var(--prizm-font-text-m);
@@ -8,13 +8,17 @@
     .createStackingContext();
     display: flex;
     justify-content: space-between;
-    height: 2.25rem;
+    height: @itemHeight;
   }
 
   .z-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: relative;
     flex: 1;
-    line-height: 2rem;
+    // height: 100%;
+    height: @itemHeight;
     border-radius: 2px;
     color: var(--prizm-v3-text-icon-secondary);
     font-weight: 600;
@@ -37,13 +41,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: @itemSize;
+    width: @itemWidth;
     text-align: center;
     outline: none;
     cursor: pointer;
     background-clip: content-box;
     box-sizing: border-box;
-    border: 2px solid transparent;
 
     &_today {
       border-radius: 2px;
@@ -59,6 +62,8 @@
       .z-item {
         border: 1px solid var(--prizm-v3-button-primary-solid-default);
         color: var(--prizm-v3-button-primary-solid-default);
+        // height: @itemHeight;
+        width: @itemWidth;
 
         &_unavailable {
           color: var(--prizm-v3-text-icon-disable);
@@ -87,7 +92,7 @@
       }
 
       &:not(:last-child):before {
-        right: -@itemSize;
+        // right: -@itemWidth;
       }
 
       &:last-child:first-child:before {

--- a/libs/components/src/styles/mixins/picker.less
+++ b/libs/components/src/styles/mixins/picker.less
@@ -85,6 +85,7 @@
     &_interval {
       &:before {
         background: var(--prizm-v3-button-primary-ghost-active);
+        border-radius: unset;
 
         :host._single & {
           background-color: var(--prizm-v3-button-primary-ghost-active);

--- a/libs/components/src/styles/mixins/picker.less
+++ b/libs/components/src/styles/mixins/picker.less
@@ -12,12 +12,12 @@
   }
 
   .z-item {
+    border: 1px solid transparent;
     display: flex;
     align-items: center;
     justify-content: center;
     position: relative;
     flex: 1;
-    // height: 100%;
     height: @itemHeight;
     border-radius: 2px;
     color: var(--prizm-v3-text-icon-secondary);
@@ -62,7 +62,6 @@
       .z-item {
         border: 1px solid var(--prizm-v3-button-primary-solid-default);
         color: var(--prizm-v3-button-primary-solid-default);
-        // height: @itemHeight;
         width: @itemWidth;
 
         &_unavailable {

--- a/libs/components/src/styles/mixins/picker.less
+++ b/libs/components/src/styles/mixins/picker.less
@@ -91,10 +91,6 @@
         }
       }
 
-      &:not(:last-child):before {
-        // right: -@itemWidth;
-      }
-
       &:last-child:first-child:before {
         right: 0;
       }

--- a/libs/components/src/styles/mixins/picker.less
+++ b/libs/components/src/styles/mixins/picker.less
@@ -110,6 +110,18 @@
         border-radius: 0;
         color: var(--prizm-v3-button-primary-solid-default);
       }
+
+      &[data-range='start'] > .z-item:before,
+      &[data-range='start'] > .z-item:after {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      &[data-range='end'] > .z-item:before,
+      &[data-range='end'] > .z-item:after {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
     }
 
     &[data-range] {

--- a/libs/components/src/styles/mixins/picker.less
+++ b/libs/components/src/styles/mixins/picker.less
@@ -60,7 +60,7 @@
       }
 
       .z-item {
-        border: 1px solid var(--prizm-v3-button-primary-solid-default);
+        border-color: var(--prizm-v3-button-primary-solid-default);
         color: var(--prizm-v3-button-primary-solid-default);
         width: @itemWidth;
 
@@ -82,6 +82,9 @@
     }
 
     &_interval {
+      & > .z-item {
+        border-color: var(--prizm-v3-button-primary-ghost-active);
+      }
       &:before {
         background: var(--prizm-v3-button-primary-ghost-active);
         border-radius: unset;
@@ -126,6 +129,7 @@
     &[data-range] {
       &:not([data-state='hovered']) > .z-item {
         color: var(--prizm-v3-text-icon-exception);
+        border-color: var(--prizm-v3-button-primary-solid-default);
 
         &:before,
         &:after {
@@ -136,6 +140,7 @@
       &[data-state='hovered'] > .z-item {
         background-color: var(--prizm-v3-button-ghost-hover);
         color: var(--prizm-v3-button-primary-solid-hover);
+        border-color: var(--prizm-v3-button-ghost-hover);
       }
 
       &[data-state='hovered'] > .z-item:before,
@@ -188,6 +193,7 @@
 
     &[data-state='hovered']:not([data-range]):not(.z-cell_today) > .z-item {
       background-color: var(--prizm-v3-button-ghost-hover);
+      border-color: var(--prizm-v3-button-ghost-hover);
       color: var(--prizm-v3-button-primary-solid-hover);
     }
 


### PR DESCRIPTION
fix(components/calendar): replace default 'title' attribute by prizm hint in calendar year pagination buttons #1457
fix(components/calendar-range): incorrect markup for year and month screens fix #1445
fix(components/input-layout-date-time): incorrect control markup fix  #1242 
fix(components/input-layout-date-time-range): incorrect control markup fix  #1242 
fix(components/calendar-month): incorrect control markup fix  #1242 
fix(components/calendar-range): single year should be highlighted in calendar range  #1465
fix(components/calendar-range): single month should be highlighted in calendar range  #1464
fix(components/calendar): index marker color blends with the background of the selected date  #1461

Resolved #1457
Resolved #1445
Resolved #1242
Resolved #1465
Resolved #1464
Resolved #1461