### PR TITLE
fix: circular import by LinkComponent #1535

### DIFF
--- a/libs/components/src/lib/components/index.ts
+++ b/libs/components/src/lib/components/index.ts
@@ -10,6 +10,7 @@ export * from './chips';
 export * from './calendar';
 export * from './calendar-range';
 export * from './calendar-month';
+export * from './link';
 export * from './loader';
 export * from './paginator';
 export * from './data-list';

--- a/libs/components/src/lib/components/index.ts
+++ b/libs/components/src/lib/components/index.ts
@@ -10,7 +10,6 @@ export * from './chips';
 export * from './calendar';
 export * from './calendar-range';
 export * from './calendar-month';
-export * from './link';
 export * from './loader';
 export * from './paginator';
 export * from './data-list';

--- a/libs/components/src/lib/components/link/link.component.ts
+++ b/libs/components/src/lib/components/link/link.component.ts
@@ -39,7 +39,6 @@ import { PrizmAbstractTestId } from '../../abstract/interactive';
   changeDetection: ChangeDetectionStrategy.OnPush,
   exportAs: `prizmLink`,
   standalone: true,
-  imports: [PrizmLinkComponent],
 })
 export class PrizmLinkComponent extends PrizmAbstractTestId implements PrizmFocusableElementAccessor {
   @Input()


### PR DESCRIPTION
Removed circular dependency. Also, exported the component and module by the library (I believe it was missed)

Resolves https://github.com/zyfra/Prizm/issues/1535