### PR TITLE
fix: file name display #1541

### DIFF
--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -48,7 +48,8 @@
       </div>
 
       <div class="file__info">
-        <span class="file__name">{{ item.key }}</span>
+        <span class="file__name">{{ item.key | prizmFileName }}</span>
+        <span class="file__extension">{{ item.key | prizmFileExtension }}</span>
         <span class="file__size">{{ item.value.file.size | prizmFileSize }}</span>
       </div>
 

--- a/libs/components/src/lib/components/file-upload/file-upload.component.less
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.less
@@ -96,17 +96,23 @@
     overflow: hidden;
     text-overflow: ellipsis;
     display: flex;
-    gap: 8px;
     align-items: baseline;
   }
 
-  &__name {
+  &__name,
+  &__extension {
     font-weight: 600;
     font-size: 14px;
     line-height: 20px;
     color: var(--prizm-v3-text-icon-primary);
   }
+  &__name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   &__size {
+    margin-left: 8px;
     font-size: 10px;
     line-height: 12px;
     color: var(--prizm-v3-text-icon-tertiary);

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -37,6 +37,8 @@ import { PrizmButtonComponent } from '../button';
 import { PrizmProgressBarComponent } from '../progress';
 import { PrizmIconComponent } from '../icon';
 import { PrizmUploadStatusPipe } from './pipes/upload-status.pipe';
+import { PrizmFileNamePipe } from './pipes/file-name.pipe';
+import { PrizmFileExtensionPipe } from './pipes/file-extension.pipe';
 import { PrizmFileSizePipe } from './pipes/file-size.pipe';
 
 @Component({
@@ -47,6 +49,8 @@ import { PrizmFileSizePipe } from './pipes/file-size.pipe';
   imports: [
     CommonModule,
     PrizmUploadStatusPipe,
+    PrizmFileNamePipe,
+    PrizmFileExtensionPipe,
     PrizmFileSizePipe,
     PrizmSanitizerPipe,
     PrizmPluckPipe,

--- a/libs/components/src/lib/components/file-upload/pipes/file-extension.pipe.ts
+++ b/libs/components/src/lib/components/file-upload/pipes/file-extension.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'prizmFileExtension', standalone: true })
+export class PrizmFileExtensionPipe implements PipeTransform {
+  public transform(fileFullName: string): string {
+    return `.${fileFullName.split('.').pop()}` || '';
+  }
+}

--- a/libs/components/src/lib/components/file-upload/pipes/file-name.pipe.ts
+++ b/libs/components/src/lib/components/file-upload/pipes/file-name.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'prizmFileName', standalone: true })
+export class PrizmFileNamePipe implements PipeTransform {
+  public transform(fileFullName: string): string {
+    return fileFullName.split('.').slice(0, -1).join('.');
+  }
+}


### PR DESCRIPTION
fix(component/file-upload): if the name is long it doesn't overlap upload bar. name becomes truncated. expansion remains #1541
resolved #1541