### PR TITLE
fix: hidden overflow for navigation titles #1510

### DIFF
--- a/apps/doc/src/app/components/navigation/navigation-example.const.ts
+++ b/apps/doc/src/app/components/navigation/navigation-example.const.ts
@@ -85,4 +85,29 @@ export const NAVIGATION_EXAMPLE: INavigationTree[] = [
       },
     ],
   },
+  {
+    title: 'Очень очень длинный раздел 4',
+    icon: 'clapperboard-open',
+    isExpanded: true,
+    children: [
+      {
+        title: 'Очень очень длинный подраздел 4.1',
+      },
+      {
+        title: 'Очень очень длинный подраздел 4.2',
+        isExpanded: true,
+        children: [
+          {
+            title: 'Очень очень длинный подраздел 4.2.1',
+          },
+          {
+            title: 'Подраздел 4.2.2',
+          },
+        ],
+      },
+      {
+        title: 'Подраздел 4.3',
+      },
+    ],
+  },
 ];

--- a/apps/doc/src/app/components/navigation/navigation-example.const.ts
+++ b/apps/doc/src/app/components/navigation/navigation-example.const.ts
@@ -87,7 +87,7 @@ export const NAVIGATION_EXAMPLE: INavigationTree[] = [
   },
   {
     title: 'Очень очень длинный раздел 4',
-    icon: 'clapperboard-open',
+    icon: 'transport-airplane',
     isExpanded: true,
     children: [
       {

--- a/apps/doc/src/app/components/navigation/navigation-example.const.ts
+++ b/apps/doc/src/app/components/navigation/navigation-example.const.ts
@@ -87,7 +87,7 @@ export const NAVIGATION_EXAMPLE: INavigationTree[] = [
   },
   {
     title: 'Очень очень длинный раздел 4',
-    icon: 'transport-airplane',
+    icon: 'battery-80',
     isExpanded: true,
     children: [
       {

--- a/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.html
+++ b/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.html
@@ -9,20 +9,17 @@
     class="dropdown"
     *ngIf="data.length > 0"
     [class.dropdown_active]="openDropdown"
+    [prizmHint]="data[currentScreenIdx]?.title"
+    [prizmHintCanShow]="prizmIsTextOverflow(title)"
     (click)="openDropdown = !openDropdown"
+    prizmHintDirection="b"
   >
     <div class="screen">
       <prizm-icon
         class="screen__icon"
         [iconClass]="data[currentScreenIdx]?.icon || 'files-folder'"
       ></prizm-icon>
-      <span
-        class="screen__title"
-        #title
-        [prizmHint]="data[currentScreenIdx]?.title"
-        [prizmHintCanShow]="prizmIsTextOverflow(title)"
-        prizmHintDirection="b"
-      >
+      <span class="screen__title" #title>
         {{ data[currentScreenIdx]?.title }}
       </span>
     </div>
@@ -36,16 +33,13 @@
       class="screen-list__item"
       *ngFor="let item of data; let i = index"
       [class.selected]="i === currentScreenIdx"
+      [prizmHint]="item?.title"
+      [prizmHintCanShow]="prizmIsTextOverflow(title)"
       (click)="changeScreen(i)"
     >
       <div class="screen">
         <prizm-icon class="screen__icon" [iconClass]="item?.icon || 'files-folder'"></prizm-icon>
-        <span
-          class="screen__title"
-          #title
-          [prizmHint]="item?.title"
-          [prizmHintCanShow]="prizmIsTextOverflow(title)"
-        >
+        <span class="screen__title" #title>
           {{ item?.title }}
         </span>
       </div>

--- a/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.html
+++ b/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.html
@@ -12,7 +12,6 @@
     [prizmHint]="data[currentScreenIdx]?.title"
     [prizmHintCanShow]="prizmIsTextOverflow(title)"
     (click)="openDropdown = !openDropdown"
-    prizmHintDirection="b"
   >
     <div class="screen">
       <prizm-icon

--- a/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.html
+++ b/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.html
@@ -16,7 +16,15 @@
         class="screen__icon"
         [iconClass]="data[currentScreenIdx]?.icon || 'files-folder'"
       ></prizm-icon>
-      <span class="screen__title">{{ data[currentScreenIdx]?.title }}</span>
+      <span
+        class="screen__title"
+        #title
+        [prizmHint]="data[currentScreenIdx]?.title"
+        [prizmHintCanShow]="prizmIsTextOverflow(title)"
+        prizmHintDirection="b"
+      >
+        {{ data[currentScreenIdx]?.title }}
+      </span>
     </div>
     <prizm-icon class="dropdown__icon" iconClass="chevrons-menu-right"></prizm-icon>
   </button>
@@ -32,7 +40,14 @@
     >
       <div class="screen">
         <prizm-icon class="screen__icon" [iconClass]="item?.icon || 'files-folder'"></prizm-icon>
-        <span class="screen__title">{{ item?.title }}</span>
+        <span
+          class="screen__title"
+          #title
+          [prizmHint]="item?.title"
+          [prizmHintCanShow]="prizmIsTextOverflow(title)"
+        >
+          {{ item?.title }}
+        </span>
       </div>
     </div>
   </prizm-data-list>

--- a/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.less
+++ b/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.less
@@ -53,6 +53,8 @@
   display: flex;
   gap: 8px;
 
+  overflow: hidden;
+
   &__icon {
     color: var(--prizm-v3-status-info-primary-default);
   }

--- a/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.ts
+++ b/libs/components/src/lib/components/header/components/prizm-header-dropdown/prizm-header-dropdown.component.ts
@@ -7,6 +7,7 @@ import { PrizmDropdownHostModule } from '../../../dropdowns/dropdown-host';
 import { PrizmDataListModule } from '../../../data-list';
 import { PrizmButtonModule } from '../../../button';
 import { PrizmHintModule } from '../../../../directives';
+import { prizmIsTextOverflow } from '../../../../util';
 
 @Component({
   selector: 'prizm-header-dropdown',
@@ -28,6 +29,8 @@ export class PrizmHeaderDropdownComponent {
   @Input() public data: IScreen[] = [];
   @Input() public currentScreenIdx = 0;
   @Output() screenIdxChange: EventEmitter<number> = new EventEmitter<number>();
+
+  readonly prizmIsTextOverflow = prizmIsTextOverflow;
 
   public openDropdown = false;
 

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -1,6 +1,7 @@
 <div class="container">
   <div
     class="nav"
+    #container
     [class.nav_active]="isActive$ | async"
     [prizmHint]="menuItem?.title"
     [prizmHintCanShow]="prizmIsTextOverflow(title)"

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -5,7 +5,6 @@
     [prizmHint]="menuItem?.title"
     [prizmHintCanShow]="prizmIsTextOverflow(title)"
     (click)="navClick()"
-    prizmHintDirection="b"
   >
     <div class="nav__icon" [style.marginLeft.px]="deep > 0 ? 8 + 16 * deep : 0">
       <prizm-icon [iconClass]="menuItem?.icon || 'files-folder'"></prizm-icon>

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -1,15 +1,16 @@
 <div class="container">
-  <div class="nav" [class.nav_active]="isActive$ | async" (click)="navClick()">
+  <div
+    class="nav"
+    [class.nav_active]="isActive$ | async"
+    [prizmHint]="menuItem?.title"
+    [prizmHintCanShow]="prizmIsTextOverflow(title)"
+    (click)="navClick()"
+    prizmHintDirection="b"
+  >
     <div class="nav__icon" [style.marginLeft.px]="deep > 0 ? 8 + 16 * deep : 0">
       <prizm-icon [iconClass]="menuItem?.icon || 'files-folder'"></prizm-icon>
     </div>
-    <span
-      class="nav__title"
-      #title
-      [prizmHint]="menuItem?.title"
-      [prizmHintCanShow]="prizmIsTextOverflow(title)"
-      prizmHintDirection="b"
-    >
+    <span class="nav__title" #title>
       {{ menuItem?.title }}
     </span>
 

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -3,7 +3,15 @@
     <div class="nav__icon" [style.marginLeft.px]="deep > 0 ? 8 + 16 * deep : 0">
       <prizm-icon [iconClass]="menuItem?.icon || 'files-folder'"></prizm-icon>
     </div>
-    <span class="nav__title">{{ menuItem?.title }}</span>
+    <span
+      class="nav__title"
+      #title
+      [prizmHint]="menuItem?.title"
+      [prizmHintCanShow]="prizmIsTextOverflow(title)"
+      prizmHintDirection="b"
+    >
+      {{ menuItem?.title }}
+    </span>
 
     <div class="nav__status">
       <div

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActiveNavigationItemService } from '../../services/active-navigation-item.service';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
-import { prizmIsTextOverflow } from '@prizm-ui/components';
+import { prizmIsTextOverflow } from '../../../../util';
 
 @Component({
   selector: 'prizm-navigation-item-expandable',

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActiveNavigationItemService } from '../../services/active-navigation-item.service';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
+import { prizmIsTextOverflow } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-navigation-item-expandable',
@@ -21,6 +22,8 @@ export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId 
 
   public isExpanded = false;
   override readonly testId_ = 'ui_navigation--item-expandable';
+
+  readonly prizmIsTextOverflow = prizmIsTextOverflow;
 
   public data$ = new BehaviorSubject<INavigationTree | null>(null);
   public isActive$: Observable<boolean> = combineLatest([

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
@@ -1,4 +1,13 @@
-import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  Input,
+  ViewChild,
+  ElementRef,
+  ChangeDetectorRef,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import { INavigationTree } from './../../navigation.interfaces';
 import { expandAnimation } from '../../../accordion/accordion.animation';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
@@ -14,8 +23,10 @@ import { prizmIsTextOverflow } from '../../../../util';
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [expandAnimation],
 })
-export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId {
-  @Input() public set data(tree: INavigationTree) {
+export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId implements OnInit, OnDestroy {
+  @ViewChild('container', { static: true }) container!: ElementRef;
+  @Input()
+  public set data(tree: INavigationTree) {
     this.data$.next(tree);
   }
   @Input() public deep!: number;
@@ -35,8 +46,24 @@ export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId 
     return this.data$.getValue();
   }
 
-  constructor(public activeItemService: ActiveNavigationItemService) {
+  private resizeObserver!: ResizeObserver;
+
+  constructor(
+    public activeItemService: ActiveNavigationItemService,
+    private readonly cdRef: ChangeDetectorRef
+  ) {
     super();
+  }
+
+  ngOnInit(): void {
+    this.resizeObserver = new ResizeObserver(() => {
+      this.cdRef.markForCheck();
+    });
+    this.resizeObserver.observe(this.container.nativeElement);
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver.disconnect();
   }
 
   public toggle($event: Event): void {

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
@@ -1,5 +1,13 @@
 <div class="nav" [class.nav_active]="isActive$ | async" (click)="navClick()">
-  <span class="nav__title" [style.marginLeft.px]="deep > 0 ? (deep - 1) * 24 : 0">{{ menuItem?.title }}</span>
+  <span
+    class="nav__title"
+    #title
+    [style.marginLeft.px]="deep > 0 ? (deep - 1) * 24 : 0"
+    [prizmHint]="menuItem?.title"
+    [prizmHintCanShow]="prizmIsTextOverflow(title)"
+  >
+    {{ menuItem?.title }}
+  </span>
   <div class="nav__status">
     <div
       class="indicator indicator_{{ menuItem?.indicatorStatus }}"

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
@@ -1,11 +1,11 @@
-<div class="nav" [class.nav_active]="isActive$ | async" (click)="navClick()">
-  <span
-    class="nav__title"
-    #title
-    [style.marginLeft.px]="deep > 0 ? (deep - 1) * 24 : 0"
-    [prizmHint]="menuItem?.title"
-    [prizmHintCanShow]="prizmIsTextOverflow(title)"
-  >
+<div
+  class="nav"
+  [class.nav_active]="isActive$ | async"
+  [prizmHint]="menuItem?.title"
+  [prizmHintCanShow]="prizmIsTextOverflow(title)"
+  (click)="navClick()"
+>
+  <span class="nav__title" #title [style.marginLeft.px]="deep > 0 ? (deep - 1) * 24 : 0">
     {{ menuItem?.title }}
   </span>
   <div class="nav__status">

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
@@ -1,5 +1,6 @@
 <div
   class="nav"
+  #container
   [class.nav_active]="isActive$ | async"
   [prizmHint]="menuItem?.title"
   [prizmHintCanShow]="prizmIsTextOverflow(title)"

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { ActiveNavigationItemService } from '../../services/active-navigation-item.service';
 import { map } from 'rxjs/operators';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
-import { prizmIsTextOverflow } from '@prizm-ui/components';
+import { prizmIsTextOverflow } from '../../../../util';
 
 @Component({
   selector: 'prizm-navigation-item-simple',

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.ts
@@ -1,4 +1,13 @@
-import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  Input,
+  ViewChild,
+  ElementRef,
+  ChangeDetectorRef,
+  OnInit,
+  OnDestroy,
+} from '@angular/core';
 import { INavigationTree } from '../../navigation.interfaces';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { ActiveNavigationItemService } from '../../services/active-navigation-item.service';
@@ -12,7 +21,8 @@ import { prizmIsTextOverflow } from '../../../../util';
   styleUrls: ['./prizm-navigation-item-simple.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PrizmNavigationItemSimpleComponent extends PrizmAbstractTestId {
+export class PrizmNavigationItemSimpleComponent extends PrizmAbstractTestId implements OnInit, OnDestroy {
+  @ViewChild('container', { static: true }) container!: ElementRef;
   @Input() public set data(tree: INavigationTree) {
     this.data$.next(tree);
   }
@@ -30,8 +40,24 @@ export class PrizmNavigationItemSimpleComponent extends PrizmAbstractTestId {
     return this.data$.getValue();
   }
 
-  constructor(public activeItemService: ActiveNavigationItemService) {
+  private resizeObserver!: ResizeObserver;
+
+  constructor(
+    public activeItemService: ActiveNavigationItemService,
+    private readonly cdRef: ChangeDetectorRef
+  ) {
     super();
+  }
+
+  ngOnInit(): void {
+    this.resizeObserver = new ResizeObserver(() => {
+      this.cdRef.markForCheck();
+    });
+    this.resizeObserver.observe(this.container.nativeElement);
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver.disconnect();
   }
 
   public navClick(): void {

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { ActiveNavigationItemService } from '../../services/active-navigation-item.service';
 import { map } from 'rxjs/operators';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
+import { prizmIsTextOverflow } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-navigation-item-simple',
@@ -17,6 +18,7 @@ export class PrizmNavigationItemSimpleComponent extends PrizmAbstractTestId {
   }
   @Input() public deep!: number;
   override readonly testId_ = 'ui_navigation--item-simple';
+  readonly prizmIsTextOverflow = prizmIsTextOverflow;
 
   public data$: BehaviorSubject<INavigationTree | null> = new BehaviorSubject<INavigationTree | null>(null);
   public isActive$: Observable<boolean> = combineLatest([


### PR DESCRIPTION
fix(component/navigation):  hidden overflow for navigation titles. added hints #1510 
fix(component/header): hidden overflow for header. added hints https://github.com/zyfra/Prizm/issues/1510
resolved #1510 