### PR TITLE
fix: changed filesValidationErrors type in examples #1371

### DIFF
--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.html
@@ -6,7 +6,7 @@
   [maxFileSize]="1000000"
   [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
-  (filesValidationErrors)="onfilesValidationErrors($any($event))"
+  (filesValidationErrors)="onfilesValidationErrors($event)"
   (filesCountError)="onFilesCountError($event)"
   (retry)="retry($event)"
 >

--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
@@ -21,7 +21,7 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
     }
   }
 
-  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+  public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {
     for (const filename of Object.keys(errors)) {
       this.toastService.create(JSON.stringify(errors[filename]), {
         title: `Файл ${filename} не прошел валидацию`,

--- a/apps/doc/src/app/components/file-upload/examples/basic/basic.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/basic/basic.component.html
@@ -6,7 +6,7 @@
   [maxFileSize]="1000000"
   [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
-  (filesValidationErrors)="onfilesValidationErrors($any($event))"
+  (filesValidationErrors)="onfilesValidationErrors($event)"
   (filesCountError)="onFilesCountError($event)"
   (retry)="retry($event)"
 >

--- a/apps/doc/src/app/components/file-upload/examples/basic/basic.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/basic/basic.component.ts
@@ -19,7 +19,7 @@ export class PrizmFileUploadBasicExampleComponent implements OnDestroy {
     this.files = files;
   }
 
-  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+  public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {
     for (const filename of Object.keys(errors)) {
       this.toastService.create(JSON.stringify(errors[filename]), {
         title: `Файл ${filename} не прошел валидацию`,

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
@@ -6,7 +6,7 @@
   [maxFileSize]="1000000"
   [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
-  (filesValidationErrors)="onfilesValidationErrors($any($event))"
+  (filesValidationErrors)="onfilesValidationErrors($event)"
   (filesCountError)="onFilesCountError($event)"
   (retry)="retry($event)"
 >

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -41,7 +41,7 @@ export class PrizmFileUploadI18nExampleComponent {
     }
   }
 
-  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+  public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {
     for (const filename of Object.keys(errors)) {
       this.toastService.create(JSON.stringify(errors[filename]), {
         title: `Файл ${filename} не прошел валидацию`,

--- a/apps/doc/src/app/components/file-upload/file-upload-example.component.html
+++ b/apps/doc/src/app/components/file-upload/file-upload-example.component.html
@@ -29,7 +29,7 @@
         [maxFileSize]="maxFileSize"
         [disabled]="disabled"
         (filesChange)="onFilesChange($event)"
-        (filesValidationErrors)="onfilesValidationErrors($any($event))"
+        (filesValidationErrors)="onfilesValidationErrors($event)"
         (filesCountError)="onFilesCountError($event)"
         (retry)="retry($event)"
       >
@@ -144,7 +144,7 @@
         documentationPropertyName="filesValidationErrors"
         documentationPropertyType="Event"
         documentationPropertyMode="output"
-        documentationPropertyType="Map<filename, PrizmFileValidationErrors>"
+        documentationPropertyType="[p: string]: PrizmFileValidationErrors"
       >
         FilesValidationErrors
       </ng-template>

--- a/apps/doc/src/app/components/file-upload/file-upload-example.component.html
+++ b/apps/doc/src/app/components/file-upload/file-upload-example.component.html
@@ -144,7 +144,7 @@
         documentationPropertyName="filesValidationErrors"
         documentationPropertyType="Event"
         documentationPropertyMode="output"
-        documentationPropertyType="[p: string]: PrizmFileValidationErrors"
+        documentationPropertyType="Map<filename, PrizmFileValidationErrors>"
       >
         FilesValidationErrors
       </ng-template>

--- a/apps/doc/src/app/components/file-upload/file-upload-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/file-upload-example.component.ts
@@ -50,7 +50,7 @@ export class PrizmFileUploadExampleComponent implements OnDestroy {
     this.files = files;
   }
 
-  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+  public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {
     for (const filename of Object.keys(errors)) {
       this.toastService.create(JSON.stringify(errors[filename]), {
         title: `Файл ${filename} не прошел валидацию`,

--- a/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.ts
+++ b/apps/doc/src/app/how-to-work/internationalization/examples/language-switcher/language-switcher-example.component.ts
@@ -53,7 +53,7 @@ export class PrizmLanguageSwitcherExampleComponent {
     }
   }
 
-  public onfilesValidationErrors(errors: PrizmFileValidationErrors): void {
+  public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {
     for (const filename of Object.keys(errors)) {
       this.toastService.create(JSON.stringify(errors[filename]), {
         title: `Файл ${filename} не прошел валидацию`,


### PR DESCRIPTION
fix(documentation): changed filesValidationErrors type in examples and live demo https://github.com/zyfra/Prizm/issues/1371
resolved https://github.com/zyfra/Prizm/issues/1371