### PR TITLE
Fix/input number min error v4

### DIFF
--- a/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.html
@@ -1,0 +1,33 @@
+<prizm-input-layout label="Заголовок" size="l" status="default">
+  <input
+    #inputNumber="prizmInputNumber"
+    [min]="min"
+    [max]="max"
+    [formControl]="minMaxInputControl"
+    type="number"
+    prizmInput
+    placeholder="Введите число"
+  />
+  <ng-template [control]="inputNumber" prizmInputStatusText></ng-template>
+</prizm-input-layout>
+
+<br />
+
+<p>Пользовательский текст валидации</p>
+
+<br />
+
+<prizm-input-layout label="Заголовок" size="l" status="default">
+  <input
+    #inputNumber="prizmInputNumber"
+    [min]="min"
+    [max]="max"
+    [formControl]="minMaxInputControlCustom"
+    type="number"
+    prizmInput
+    placeholder="Введите число"
+  />
+  <ng-template [control]="inputNumber" prizmInputStatusText>
+    Максимально допустимное значение - {{ max }}, минимально допустимое значение - {{ min }}
+  </ng-template>
+</prizm-input-layout>

--- a/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.html
@@ -20,7 +20,12 @@
 
 <br />
 
-<prizm-input-layout label="Заголовок" size="l" status="default">
+<prizm-input-layout
+  [status]="minMaxInputControlCustom.valid ? 'default' : 'danger'"
+  label="Заголовок"
+  size="l"
+  status="default"
+>
   <input
     #inputNumber="prizmInputNumber"
     [min]="min"
@@ -30,10 +35,11 @@
     prizmInput
     placeholder="Введите число"
   />
-  <ng-template [control]="inputNumber" prizmInputStatusText>
+  <ng-template #statusText [control]="inputNumber" prizmInputStatusText>
     <ng-container *prizmIfLang="'russian'; else eng">
       Максимально допустимное значение - {{ max }}, минимально допустимое значение - {{ min }}
     </ng-container>
     <ng-template #eng> The maximum value is {{ max }}, the minimum value is {{ min }}. </ng-template>
   </ng-template>
+  <div *ngTemplateOutlet="statusText" prizm-input-subtext></div>
 </prizm-input-layout>

--- a/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.html
@@ -13,7 +13,10 @@
 
 <br />
 
-<p>Пользовательский текст валидации</p>
+<p>
+  <ng-container *prizmIfLang="'russian'; else eng"> Пользовательский текст валидации </ng-container>
+  <ng-template #eng> Custom validation text </ng-template>
+</p>
 
 <br />
 
@@ -28,6 +31,9 @@
     placeholder="Введите число"
   />
   <ng-template [control]="inputNumber" prizmInputStatusText>
-    Максимально допустимное значение - {{ max }}, минимально допустимое значение - {{ min }}
+    <ng-container *prizmIfLang="'russian'; else eng">
+      Максимально допустимное значение - {{ max }}, минимально допустимое значение - {{ min }}
+    </ng-container>
+    <ng-template #eng> The maximum value is {{ max }}, the minimum value is {{ min }}. </ng-template>
   </ng-template>
 </prizm-input-layout>

--- a/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.ts
+++ b/apps/doc/src/app/components/input/input-number/examples/input-number-min-max-example/input-number-min-max-example.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { UntypedFormControl } from '@angular/forms';
+
+@Component({
+  selector: 'prizm-input-number-min-max-example',
+  templateUrl: './input-number-min-max-example.component.html',
+  styleUrls: ['./input-number-min-max-example.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InputNumberMinMaxExampleComponent {
+  public minMaxInputControl = new UntypedFormControl();
+  public minMaxInputControlCustom = new UntypedFormControl();
+
+  public min = 10;
+  public max = 80;
+}

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.html
@@ -23,6 +23,14 @@
     <prizm-doc-example id="counter-invalid" [content]="prizmInputNumberInvalid" heading="Form group">
       <prizm-input-number-invalid-example></prizm-input-number-invalid-example>
     </prizm-doc-example>
+
+    <prizm-doc-example
+      id="number-min-max"
+      [content]="prizmInputNumberMinMax"
+      heading="Input number min max example"
+    >
+      <prizm-input-number-min-max-example></prizm-input-number-min-max-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.html
@@ -114,6 +114,7 @@
               [prizmHintDirection]="prizmHintDirection"
               [prizmHintCanShow]="prizmHintCanShow"
               [required]="required"
+              [title]="title"
               prizmInputNumber
             />
 
@@ -165,6 +166,15 @@
         documentationPropertyMode="input"
       >
         Placeholder
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="title"
+        documentationPropertyName="title"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Title attributre
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.ts
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.ts
@@ -35,6 +35,7 @@ export class InputNumberExampleComponent {
   nullContent = 'Не выбрано';
   minDropdownHeight = 0;
   maxDropdownHeight = 342;
+  title = '';
 
   value = 1;
   public requiredInputControl = new UntypedFormControl('', Validators.required);

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.ts
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.ts
@@ -91,5 +91,12 @@ export class InputNumberExampleComponent {
     HTML: import('./examples/input-number-invalid-example/input-number-invalid-example.component.html?raw'),
   };
 
+  public readonly prizmInputNumberMinMax: TuiDocExample = {
+    TypeScript: import(
+      './examples/input-number-min-max-example/input-number-min-max-example.component.ts?raw'
+    ),
+    HTML: import('./examples/input-number-min-max-example/input-number-min-max-example.component.html?raw'),
+  };
+
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 }

--- a/apps/doc/src/app/components/input/input-number/input-number-example.module.ts
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.module.ts
@@ -10,6 +10,7 @@ import { PrizmInputNumberModule } from '@prizm-ui/components';
 import { InputNumberCounterExampleComponent } from './examples/input-number-counter-example/input-number-counter-example.component';
 import { InputNumberCounterFloatExampleComponent } from './examples/input-number-counter-float-example/input-number-counter-float-example.component';
 import { InputNumberInvalidExampleComponent } from './examples/input-number-invalid-example/input-number-invalid-example.component';
+import { InputNumberMinMaxExampleComponent } from './examples/input-number-min-max-example/input-number-min-max-example.component';
 
 @NgModule({
   imports: [
@@ -26,6 +27,7 @@ import { InputNumberInvalidExampleComponent } from './examples/input-number-inva
     InputNumberBasicExampleComponent,
     InputNumberExampleComponent,
     InputNumberCounterExampleComponent,
+    InputNumberMinMaxExampleComponent,
   ],
   exports: [InputNumberExampleComponent],
 })

--- a/apps/doc/src/app/components/input/input-number/input-number-example.module.ts
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.module.ts
@@ -11,6 +11,7 @@ import { InputNumberCounterExampleComponent } from './examples/input-number-coun
 import { InputNumberCounterFloatExampleComponent } from './examples/input-number-counter-float-example/input-number-counter-float-example.component';
 import { InputNumberInvalidExampleComponent } from './examples/input-number-invalid-example/input-number-invalid-example.component';
 import { InputNumberMinMaxExampleComponent } from './examples/input-number-min-max-example/input-number-min-max-example.component';
+import { PrizmIfLanguageDirective } from '@prizm-ui/i18n';
 
 @NgModule({
   imports: [
@@ -20,6 +21,7 @@ import { InputNumberMinMaxExampleComponent } from './examples/input-number-min-m
     ReactiveFormsModule,
     FormsModule,
     PrizmInputNumberModule,
+    PrizmIfLanguageDirective,
   ],
   declarations: [
     InputNumberInvalidExampleComponent,

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
@@ -150,6 +150,7 @@ export class PrizmInputLayoutComponent
   readonly onClearClick = (event: MouseEvent) => {
     this.clear.next(event);
     this.control.clear(event);
+    this.control.stateChanges.next();
     this.actualizeStatusIcon();
   };
 

--- a/libs/components/src/lib/components/input/input-number/input-number.component.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.component.ts
@@ -113,11 +113,15 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
   @HostListener('input', ['$event.data'])
   @HostListener('paste', ['$event.clipboardData.getData("Text")'])
   public onInput(data: string) {
-    this.validateMinMax();
+    this.validateMax();
     this.input$$.next(data);
   }
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
+  @HostListener('blur')
+  public onBlur() {
+    this.validateMin();
+  }
 
   constructor(
     @Self() public readonly ngControl: NgControl,
@@ -134,15 +138,15 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
     this.stateChanges.next();
   }
 
-  private validateMinMax() {
+  private validateMax() {
     if (this.max !== null && this.max < this.value) {
       this.el.nativeElement.value = this.max.toString();
       this.stateChanges.next();
-      return;
     }
+  }
 
+  private validateMin() {
     if (this.min !== null && this.min > this.value) {
-      this.el.nativeElement.value = this.min.toString();
       this.stateChanges.next();
       return;
     }

--- a/libs/components/src/lib/components/input/input-number/input-number.component.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.component.ts
@@ -82,6 +82,10 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
   @HostBinding('attr.placeholder')
   placeholder?: string;
 
+  @Input()
+  @HostBinding('attr.title')
+  title = '';
+
   @Input() min: number | null = null;
   @Input() max: number | null = null;
   // TODO later create input with support zero postfix for number

--- a/libs/components/src/lib/components/input/input-number/input-number.component.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.component.ts
@@ -113,15 +113,10 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
   @HostListener('input', ['$event.data'])
   @HostListener('paste', ['$event.clipboardData.getData("Text")'])
   public onInput(data: string) {
-    this.validateMax();
     this.input$$.next(data);
   }
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
-  @HostListener('blur')
-  public onBlur() {
-    this.validateMin();
-  }
 
   constructor(
     @Self() public readonly ngControl: NgControl,
@@ -136,20 +131,6 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
   private detectSymbols(value: boolean): void {
     this.hasSymbol = value;
     this.stateChanges.next();
-  }
-
-  private validateMax() {
-    if (this.max !== null && this.max < this.value) {
-      this.el.nativeElement.value = this.max.toString();
-      this.stateChanges.next();
-    }
-  }
-
-  private validateMin() {
-    if (this.min !== null && this.min > this.value) {
-      this.stateChanges.next();
-      return;
-    }
   }
 
   public clear(ev: MouseEvent): void {


### PR DESCRIPTION
fix(components/input-number): manual input works incorrect when min set for input number https://github.com/zyfra/Prizm/issues/1580
fix(components/input-number) remove default title for input number #1599
fix(components/inputs): hint status text for required input not shown after force clear #1598

resolved https://github.com/zyfra/Prizm/issues/1580
resolved #1599 
resolved #1598 