### PR TITLE
fix: table buttons #1486 #1561

### DIFF
--- a/apps/doc/src/app/components/table/examples/table-dynamic-row-group-example/table-dynamic-row-group-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-dynamic-row-group-example/table-dynamic-row-group-example.component.html
@@ -11,7 +11,7 @@
       </tr>
     </thead>
 
-    <tbody [data]="products" prizmTbody heading="Группа 1 (5-6 колонок))">
+    <tbody [data]="products" prizmTbody heading="Группа 1 (5-6 колонок)">
       <ng-container
         *prizmRow="
           let item of products;

--- a/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.html
@@ -50,36 +50,41 @@
         </td>
         <td *prizmCell="'actions'" prizmTd>
           <div class="edit-buttons-container" (click)="$event.stopPropagation()">
-            <prizm-icon
-              class="edit-buttons"
+            <button
               *ngIf="currentEditableRow !== item"
               (click)="onRowEditInit(item)"
-              size="16"
-              iconClass="editor-mode"
-            ></prizm-icon>
-
-            <prizm-icon
-              class="edit-buttons"
+              appearance="secondary"
+              icon="editor-mode"
+              prizmIconButton
+              appearanceType="ghost"
+              size="s"
+            ></button>
+            <button
               *ngIf="currentEditableRow === item"
               (click)="onRowEditSave()"
-              size="16"
-              iconClass="selection-choice"
-            ></prizm-icon>
-
-            <prizm-icon
-              class="edit-buttons"
+              appearance="secondary"
+              icon="selection-choice"
+              prizmIconButton
+              appearanceType="ghost"
+              size="s"
+            ></button>
+            <button
               *ngIf="currentEditableRow === item"
               (click)="onRowEditCancel(item)"
-              size="16"
-              iconClass="cancel-close"
-            ></prizm-icon>
-
-            <prizm-icon
-              class="edit-buttons"
+              appearance="secondary"
+              icon="cancel-close"
+              prizmIconButton
+              appearanceType="ghost"
+              size="s"
+            ></button>
+            <button
               (click)="onRowDelete(item)"
-              size="16"
-              iconClass="delete"
-            ></prizm-icon>
+              appearance="secondary"
+              icon="delete-empty"
+              prizmIconButton
+              appearanceType="ghost"
+              size="s"
+            ></button>
           </div>
         </td>
       </tr>

--- a/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
@@ -17,18 +17,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
-
-    .edit-buttons {
-      height: 16px;
-      width: 16px;
-
-      display: flex;
-
-      &:hover {
-        color: #337eff;
-      }
-    }
+    gap: 4px;
   }
 
   .row {

--- a/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
@@ -14,7 +14,6 @@
   }
 
   .edit-buttons-container {
-    cursor: default;
     height: 100%;
     width: 100%;
     padding: 0 8px;

--- a/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
@@ -49,7 +49,7 @@
 
   .head {
     &__actions {
-      width: 100px;
+      width: 113px;
     }
   }
 }

--- a/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-editable-row-example/table-editable-row-example.component.less
@@ -9,7 +9,12 @@
     }
   }
 
+  td:has(.edit-buttons-container) {
+    padding: 0;
+  }
+
   .edit-buttons-container {
+    cursor: default;
     height: 100%;
     width: 100%;
     padding: 0 8px;

--- a/apps/doc/src/app/components/table/examples/table-filter-example/table-filter-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-filter-example/table-filter-example.component.html
@@ -12,12 +12,15 @@
             [content]="dropdown"
             prizmDropdownHostWidth="auto"
           >
-            <prizm-icon
+            <button
               class="filter__category"
-              [class.filter__category_active]="filterOpen || filterOn"
+              [appearance]="filterOpen || filterOn ? 'primary' : 'secondary'"
               (click)="filterOpen = !filterOpen"
-              iconClass="sort-filter"
-            ></prizm-icon>
+              icon="sort-filter"
+              prizmIconButton
+              appearanceType="ghost"
+              size="s"
+            ></button>
           </prizm-dropdown-host>
         </th>
         <th *prizmHead="'count'" prizmTh>Количество</th>

--- a/apps/doc/src/app/components/table/examples/table-filter-example/table-filter-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-filter-example/table-filter-example.component.less
@@ -11,21 +11,7 @@
     margin-left: auto;
 
     &__category {
-      height: 24px;
-      width: 24px;
-
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      color: #777b92;
-
-      cursor: pointer;
-
-      &_active,
-      &:hover {
-        color: #337eff;
-      }
+      margin-left: 4px;
     }
   }
 

--- a/apps/doc/src/app/components/table/examples/table-filter-example/table-filter-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-filter-example/table-filter-example.component.less
@@ -9,6 +9,7 @@
 
   .filter {
     margin-left: auto;
+    width: 24px;
 
     &__category {
       margin-left: 4px;

--- a/apps/doc/src/app/components/table/examples/table-sort-example/table-sort-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-sort-example/table-sort-example.component.html
@@ -5,10 +5,10 @@
   <table class="table" [columns]="columns" [sort]="initSortOptions" prizmTable>
     <thead>
       <tr prizmThGroup>
-        <th *prizmHead="'code'" [sorter]="sorter" [resizable]="true" rowspan="2" prizmTh>Код</th>
+        <th *prizmHead="'code'" [sorter]="sorter" [resizable]="true" rowspan="3" prizmTh>Код</th>
         <th *prizmHead="'name'" [resizable]="true" prizmTh>Наименование</th>
-        <th *prizmHead="'category'" [sorter]="sorter" rowspan="2" prizmTh>Категория</th>
-        <th *prizmHead="'count'" [sorter]="sorter" rowspan="2" prizmTh>Количество</th>
+        <th *prizmHead="'category'" [sorter]="sorter" rowspan="3" prizmTh>Категория</th>
+        <th *prizmHead="'count'" [sorter]="sorter" rowspan="3" prizmTh>Количество</th>
       </tr>
       <tr prizmThGroup>
         <th class="extra-border search-cell" [resizable]="true" prizmTh>
@@ -17,6 +17,16 @@
             [interactive]="true"
             (click)="search(input.value, 'name')"
             prizmInputIconButton="sort-zoom-in"
+          ></button>
+        </th>
+      </tr>
+      <tr prizmThGroup>
+        <th class="extra-border search-cell" [resizable]="true" prizmTh>
+          <input #inputExtra (enter)="doSomething($event, 'name')" prizmInput placeholder="Введите текст" />
+          <button
+            [interactive]="true"
+            (click)="doSomething(inputExtra.value, 'name')"
+            prizmInputIconButton="date-access-alarm"
           ></button>
         </th>
       </tr>

--- a/apps/doc/src/app/components/table/examples/table-sort-example/table-sort-example.component.ts
+++ b/apps/doc/src/app/components/table/examples/table-sort-example/table-sort-example.component.ts
@@ -108,4 +108,8 @@ export class TableSortExampleComponent {
       (product[key] as string).toLowerCase().includes(this.searchString as string)
     );
   }
+
+  public doSomething<T extends keyof ITableProduct>(value: string, key: T): void {
+    console.log(value, key);
+  }
 }

--- a/apps/doc/src/app/components/table/examples/table-track-by-example/table-track-by-example.component.less
+++ b/apps/doc/src/app/components/table/examples/table-track-by-example/table-track-by-example.component.less
@@ -8,10 +8,6 @@
     }
   }
 
-  tr {
-    height: 100px;
-  }
-
   .overlay-tpl {
     width: 200px;
     height: 200px;

--- a/apps/doc/src/app/components/table/table-example.component.html
+++ b/apps/doc/src/app/components/table/table-example.component.html
@@ -62,11 +62,7 @@
       <prizm-table-server-sort-example></prizm-table-server-sort-example>
     </prizm-doc-example>
 
-    <prizm-doc-example
-      id="datasource"
-      [content]="exampleDataSourceTable"
-      heading="Sort, Pagination, Filtering"
-    >
+    <prizm-doc-example id="datasource" [content]="exampleDataSourceTable" heading="Sort, Search, Pagination">
       <prizm-table-data-source-example></prizm-table-data-source-example>
     </prizm-doc-example>
 

--- a/apps/doc/src/app/components/table/table-example.component.ts
+++ b/apps/doc/src/app/components/table/table-example.component.ts
@@ -14,7 +14,7 @@ export class TableExampleComponent {
   public products: ITableProduct[] = TABLE_EXAMPLE_DATA_1;
   public prizmTableRowOddBackground: string | null = null;
   public prizmTableRowBackground: string | null = null;
-  public prizmTableRowCursor = 'pointer';
+  public prizmTableRowCursor = 'default';
   public prizmTableRowHoverBackground: string | null = null;
   public prizmTableActiveRowMarkerColor: string | null = null;
   public columns: string[] = ['code', 'name', 'category', 'count'];

--- a/libs/components/src/lib/components/table/table.module.ts
+++ b/libs/components/src/lib/components/table/table.module.ts
@@ -26,6 +26,7 @@ import { PrizmTableLoadingDirective } from './directives/loading.directive';
 import { PrizmTableEmptyDirective } from './directives/empty.directive';
 import { PrizmTableRowInitDirective } from './directives/row-init.directive';
 import { PrizmTrDirective } from './tr/tr.directive';
+import { PrizmButtonComponent } from '../button';
 
 @NgModule({
   imports: [
@@ -35,6 +36,7 @@ import { PrizmTrDirective } from './tr/tr.directive';
     PrizmMapperPipeModule,
     PolymorphModule,
     PrizmIconModule,
+    PrizmButtonComponent,
   ],
   declarations: [
     PrizmTableTreeLoadingDirective,

--- a/libs/components/src/lib/components/table/tbody/tbody.component.less
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.less
@@ -43,6 +43,10 @@
       &_expanded {
         transform: rotate(90deg);
       }
+
+      &:hover {
+        color: var(--prizm-v3-button-primary-solid-hover);
+      }
     }
 
     &__content {

--- a/libs/components/src/lib/components/table/th/th.component.html
+++ b/libs/components/src/lib/components/table/th/th.component.html
@@ -5,7 +5,14 @@
     <span class="sorter__number" [style.visibility]="count > 1 && num ? 'visible' : 'hidden'">{{
       num ?? '0'
     }}</span>
-    <prizm-icon class="sorter__icon" [iconClass]="$any(icon$ | async)"></prizm-icon>
+    <button
+      class="sorter__icon"
+      [icon]="$any(icon$ | async)"
+      [appearance]="isCurrent ? 'primary' : 'secondary'"
+      prizmIconButton
+      appearanceType="ghost"
+      size="s"
+    ></button>
   </span>
 </button>
 <ng-template #content>

--- a/libs/components/src/lib/components/table/th/th.component.html
+++ b/libs/components/src/lib/components/table/th/th.component.html
@@ -1,7 +1,7 @@
-<button class="sorter" *ngIf="isSortable && table; else content" type="button">
+<div class="sorter" *ngIf="isSortable && table; else content" type="button">
   <ng-container [ngTemplateOutlet]="content"></ng-container>
   {{ table.change$ | async }}
-  <span class="sort__block" [class.sort__block_active]="isCurrent" (click)="updateSorter($event)">
+  <span class="sort__block" [class.sort__block_active]="isCurrent">
     <span class="sorter__number" [style.visibility]="count > 1 && num ? 'visible' : 'hidden'">{{
       num ?? '0'
     }}</span>
@@ -9,12 +9,13 @@
       class="sorter__icon"
       [icon]="$any(icon$ | async)"
       [appearance]="isCurrent ? 'primary' : 'secondary'"
+      (click)="updateSorter($event)"
       prizmIconButton
       appearanceType="ghost"
       size="s"
     ></button>
   </span>
-</button>
+</div>
 <ng-template #content>
   <div class="cell"><ng-content></ng-content></div>
 </ng-template>

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -1,9 +1,9 @@
-@height: 32px;
-@rows: 5;
+@height-s: 24px;
+@height-m: 32px;
+@height-l: 40px;
 
 :host {
   padding: 0 8px;
-  height: @height;
 
   border: 1px solid var(--prizm-v3-table-stroke-cell-default);
   background: var(--prizm-v3-table-fill-header-default);
@@ -25,15 +25,6 @@
   &:not(:first-child) {
     border-left: none;
   }
-  // TODO: for 4.0
-  // &:has([prizmInput]:hover) {
-  //   box-shadow: 0 0 0 1px var(--prizm-v3-table-stroke-cell-hover) inset;
-  // }
-
-  // &:has([prizmInput]:focus) {
-  //   background-color: var(--prizm-v3-background-fill-primary);
-  //   box-shadow: 0 0 0 1px var(--prizm-v3-table-stroke-cell-active) inset;
-  // }
 
   .resize-bar {
     height: 100%;
@@ -91,12 +82,71 @@
   border-top: none;
 }
 
-.tr-position-top(@n) when (@n <= @rows) {
-  :host-context(table thead tr:nth-child(@{n})) {
-    top: @height * (@n - 1);
-  }
-
-  .tr-position-top(@n + 1);
+:host-context([data-size='s']),
+:host-context([data-size='xs']) {
+  height: @height-s;
 }
 
-.tr-position-top(2);
+:host-context([data-size='m']) {
+  height: @height-m;
+}
+
+:host-context([data-size='l']) {
+  height: @height-l;
+}
+
+:host-context(tr:not(:first-child)) {
+  border-top: none;
+}
+
+:host-context(table[data-size='s'] thead tr:nth-child(2)),
+:host-context(table[data-size='xs'] thead tr:nth-child(2)) {
+  top: @height-s;
+}
+
+:host-context(table[data-size='m'] thead tr:nth-child(2)) {
+  top: @height-m;
+}
+
+:host-context(table[data-size='l'] thead tr:nth-child(2)) {
+  top: @height-l;
+}
+
+:host-context(table[data-size='s'] thead tr:nth-child(3)),
+:host-context(table[data-size='xs'] thead tr:nth-child(3)) {
+  top: @height-s * 2;
+}
+
+:host-context(table[data-size='m'] thead tr:nth-child(3)) {
+  top: @height-m * 2;
+}
+
+:host-context(table[data-size='l'] thead tr:nth-child(3)) {
+  top: @height-l * 2;
+}
+
+:host-context(table[data-size='s'] thead tr:nth-child(4)),
+:host-context(table[data-size='xs'] thead tr:nth-child(4)) {
+  top: @height-s * 3;
+}
+
+:host-context(table[data-size='m'] thead tr:nth-child(4)) {
+  top: @height-m * 3;
+}
+
+:host-context(table[data-size='l'] thead tr:nth-child(4)) {
+  top: @height-l * 3;
+}
+
+:host-context(table[data-size='s'] thead tr:nth-child(5)),
+:host-context(table[data-size='xs'] thead tr:nth-child(5)) {
+  top: @height-s * 4;
+}
+
+:host-context(table[data-size='m'] thead tr:nth-child(5)) {
+  top: @height-m * 4;
+}
+
+:host-context(table[data-size='l'] thead tr:nth-child(5)) {
+  top: @height-l * 4;
+}

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -83,3 +83,7 @@
     }
   }
 }
+
+:host-context(tr:not(:first-child)) {
+  border-top: none;
+}

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -80,8 +80,13 @@
       justify-content: center;
 
       &_active {
-        color: var(--prizm-v3-button-primary-solid-active);
+        color: var(--prizm-v3-button-primary-solid-default);
       }
+    }
+
+    &__number {
+      min-width: 16px;
+      text-align: end;
     }
   }
 }

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -66,10 +66,6 @@
     font-weight: 600;
     color: var(--prizm-v3-text-icon-tertiary);
 
-    border: none;
-    outline: none;
-    background: transparent;
-
     .sort__block {
       margin-left: 4px;
       display: flex;

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -1,6 +1,9 @@
+@height: 32px;
+@rows: 5;
+
 :host {
   padding: 0 8px;
-  height: 32px;
+  height: @height;
 
   border: 1px solid var(--prizm-v3-table-stroke-cell-default);
   background: var(--prizm-v3-table-fill-header-default);
@@ -87,3 +90,13 @@
 :host-context(tr:not(:first-child)) {
   border-top: none;
 }
+
+.tr-position-top(@n) when (@n <= @rows) {
+  :host-context(table thead tr:nth-child(@{n})) {
+    top: @height * (@n - 1);
+  }
+
+  .tr-position-top(@n + 1);
+}
+
+.tr-position-top(2);

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -1,9 +1,6 @@
-@height-s: 24px;
-@height-m: 32px;
-@height-l: 40px;
-
 :host {
   padding: 0 8px;
+  height: 32px;
 
   border: 1px solid var(--prizm-v3-table-stroke-cell-default);
   background: var(--prizm-v3-table-fill-header-default);
@@ -85,34 +82,4 @@
       text-align: end;
     }
   }
-}
-
-:host-context([data-size='s']),
-:host-context([data-size='xs']) {
-  height: @height-s;
-}
-
-:host-context([data-size='m']) {
-  height: @height-m;
-}
-
-:host-context([data-size='l']) {
-  height: @height-l;
-}
-
-:host-context(tr:not(:first-child)) {
-  border-top: none;
-}
-
-:host-context(table[data-size='s'] thead tr:nth-child(2)),
-:host-context(table[data-size='xs'] thead tr:nth-child(2)) {
-  top: @height-s;
-}
-
-:host-context(table[data-size='m'] thead tr:nth-child(2)) {
-  top: @height-m;
-}
-
-:host-context(table[data-size='l'] thead tr:nth-child(2)) {
-  top: @height-l;
 }

--- a/libs/components/src/lib/components/table/tr/tr.component.less
+++ b/libs/components/src/lib/components/table/tr/tr.component.less
@@ -1,6 +1,5 @@
 [prizmTbody] tr[prizmTr] {
-  cursor: var(--prizm-table-row-cursor, pointer);
-
+  cursor: var(--prizm-table-row-cursor, default);
   color: var(--prizm-v3-text-icon-secondary);
 
   background: var(--prizm-table-row-background, var(--prizm-v3-background-fill-primary));

--- a/libs/components/src/lib/components/tree-button/tree-button.component.less
+++ b/libs/components/src/lib/components/tree-button/tree-button.component.less
@@ -1,5 +1,9 @@
 :host {
   display: inline-flex;
+
+  &:hover {
+    color: var(--prizm-button-primary-solid-hover);
+  }
 }
 
 .hide {

--- a/libs/components/src/lib/components/tree-button/tree-button.component.less
+++ b/libs/components/src/lib/components/tree-button/tree-button.component.less
@@ -2,7 +2,7 @@
   display: inline-flex;
 
   &:hover {
-    color: var(--prizm-button-primary-solid-hover);
+    color: var(--prizm-v3-button-primary-solid-hover);
   }
 }
 


### PR DESCRIPTION
feat(components/table): add five lines support for table head 
fix(component/table): sort icon replaced with button. https://github.com/zyfra/Prizm/issues/1486
fix(component/table): header width doesn't change when sorted https://github.com/zyfra/Prizm/issues/1561
fix(documentation/table): filter and edit action buttons in examples replaced with buttons. https://github.com/zyfra/Prizm/issues/1486
fix(documentation/table): table track by and sort-pagination examples improvement https://github.com/zyfra/Prizm/issues/1655


resolved https://github.com/zyfra/Prizm/issues/1486 https://github.com/zyfra/Prizm/issues/1561
resolved #1655 