### PR TITLE
feat: add hint for input clear button #1515

### DIFF
--- a/apps/doc/src/app/components/input/input-carousel/input-carousel-example.component.html
+++ b/apps/doc/src/app/components/input/input-carousel/input-carousel-example.component.html
@@ -42,6 +42,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-carousel
           #carousel
@@ -69,6 +70,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-carousel/input-carousel-example.component.ts
+++ b/apps/doc/src/app/components/input/input-carousel/input-carousel-example.component.ts
@@ -26,6 +26,9 @@ export class PrizmInputCarouselExampleComponent {
   public status: PrizmInputStatus = 'default';
   public statuses: PrizmInputStatus[] = ['default', 'success', 'warning', 'danger'];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   readonly layoutKey = 'PrizmInputLayoutComponent';
   readonly controlKey = 'PrizmInputCarouselComponent';
 

--- a/apps/doc/src/app/components/input/input-layout-date-range/input-layout-date-range.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-range/input-layout-date-range.component.html
@@ -30,6 +30,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-date-range
           #dateElement
@@ -129,6 +130,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-date-range/input-layout-date-range.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-range/input-layout-date-range.component.ts
@@ -1,12 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
-import {
-  PrizmDayRange,
-  PrizmInputPosition,
-  PrizmInputSize,
-  PrizmInputStatus,
-  PrizmTime,
-} from '@prizm-ui/components';
+import { PrizmDayRange, PrizmInputPosition, PrizmInputSize, PrizmInputStatus } from '@prizm-ui/components';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -47,6 +41,9 @@ export class InputLayoutDateRangeComponent {
 
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 

--- a/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.component.html
@@ -18,6 +18,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-date-relative
           #element
@@ -71,6 +72,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.component.ts
@@ -34,6 +34,9 @@ export class InputLayoutDateRelativeRelativeComponent {
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   readonly exampleBase: TuiDocExample = {

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.html
@@ -25,6 +25,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-date-time-range
           #element
@@ -163,6 +164,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/input-layout-date-time-range.component.ts
@@ -46,6 +46,9 @@ export class InputLayoutDateTimeRangeComponent {
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public timeStrict = false;
   public timeModeVariants: ReadonlyArray<PrizmTimeMode> = ['HH:MM', 'HH:MM:SS', 'HH:MM:SS.MSS'];
   public timeMode: PrizmTimeMode = `HH:MM`;

--- a/apps/doc/src/app/components/input/input-layout-date-time/input-layout-date-time.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-time/input-layout-date-time.component.html
@@ -41,6 +41,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-date-time
           #element
@@ -146,6 +147,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-date-time/input-layout-date-time.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time/input-layout-date-time.component.ts
@@ -51,6 +51,9 @@ export class InputLayoutDateTimeTimeComponent {
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public timeModeVariants: ReadonlyArray<PrizmTimeMode> = ['HH:MM', 'HH:MM:SS', 'HH:MM:SS.MSS'];
   public timeMode: PrizmTimeMode = `HH:MM`;
   public testIdPostfix!: string;

--- a/apps/doc/src/app/components/input/input-layout-date/input-layout-date.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date/input-layout-date.component.html
@@ -27,6 +27,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-date
           #dateElement
@@ -119,6 +120,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-date/input-layout-date.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date/input-layout-date.component.ts
@@ -44,6 +44,9 @@ export class InputLayoutDateComponent {
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   readonly exampleBase: TuiDocExample = {

--- a/apps/doc/src/app/components/input/input-layout-month-range/input-layout-month-range.component.html
+++ b/apps/doc/src/app/components/input/input-layout-month-range/input-layout-month-range.component.html
@@ -18,6 +18,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-month-range
           #inputControlElement
@@ -84,6 +85,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-month-range/input-layout-month-range.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-month-range/input-layout-month-range.component.ts
@@ -1,12 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
-import {
-  PrizmDay,
-  PrizmInputPosition,
-  PrizmInputSize,
-  PrizmInputStatus,
-  PrizmTime,
-} from '@prizm-ui/components';
+import { PrizmDay, PrizmInputPosition, PrizmInputSize, PrizmInputStatus } from '@prizm-ui/components';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -18,6 +12,9 @@ import { UntypedFormControl } from '@angular/forms';
 export class InputLayoutMonthRangeRangeComponent {
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
   public readOnly = false;
   val!: PrizmDay;

--- a/apps/doc/src/app/components/input/input-layout-month/input-layout-month.component.html
+++ b/apps/doc/src/app/components/input/input-layout-month/input-layout-month.component.html
@@ -18,6 +18,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-month
           #element
@@ -86,6 +87,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-month/input-layout-month.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-month/input-layout-month.component.ts
@@ -23,6 +23,9 @@ export class InputLayoutMonthComponent {
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   val!: PrizmDay;
   public pseudoInvalid = false;
   public pseudoHovered = false;

--- a/apps/doc/src/app/components/input/input-layout-time/input-layout-time.component.html
+++ b/apps/doc/src/app/components/input/input-layout-time/input-layout-time.component.html
@@ -30,6 +30,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-layout-time
           #element
@@ -119,6 +120,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-layout-time/input-layout-time.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-time/input-layout-time.component.ts
@@ -1,14 +1,9 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RawLoaderContent, TuiDocExample } from '@prizm-ui/doc';
 import {
-  PolymorphContent,
-  PrizmContextWithImplicit,
-  PrizmDay,
   PrizmInputPosition,
   PrizmInputSize,
   PrizmInputStatus,
-  PrizmSizeL,
-  PrizmSizeM,
   PrizmTime,
   PrizmTimeMode,
 } from '@prizm-ui/components';
@@ -36,6 +31,9 @@ export class InputLayoutTimeTimeComponent {
 
   forceClear: boolean | null = null;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
 
   public pseudoInvalid = false;
   public pseudoHovered = false;

--- a/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.html
+++ b/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.html
@@ -44,6 +44,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-multi-select
           #element
@@ -244,6 +245,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.ts
+++ b/apps/doc/src/app/components/input/input-multi-select/input-multi-select.component.ts
@@ -72,6 +72,10 @@ export class InputInputMultiSelectComponent {
   isChipsDeletable = true;
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   forceClear = this.forceClearVariants[0];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   get sizeVariants(): ReadonlyArray<PrizmInputSize> {
     return this.outer ? ['s', 'm', 'l'] : ['m', 'l'];
   }

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.html
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.html
@@ -46,6 +46,7 @@
             [position]="inputPosition"
             [status]="status"
             [forceClear]="forceClear"
+            [hideClearButtonHint]="hideClearButtonHint"
           >
             <input
               #prizmInputNumber
@@ -90,6 +91,7 @@
             [position]="inputPosition"
             [status]="status"
             [forceClear]="forceClear"
+            [hideClearButtonHint]="hideClearButtonHint"
           >
             <button
               [inputNumber]="inputCounter"
@@ -267,6 +269,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-number/input-number-example.component.ts
+++ b/apps/doc/src/app/components/input/input-number/input-number-example.component.ts
@@ -31,6 +31,10 @@ export class InputNumberExampleComponent {
   size = this.sizeVariants[0];
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   forceClear = this.forceClearVariants[0];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   emptyContent = 'Ничего не найдено';
   nullContent = 'Не выбрано';
   minDropdownHeight = 0;

--- a/apps/doc/src/app/components/input/input-select/input-select.component.html
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.html
@@ -76,6 +76,7 @@
         [position]="inputPosition"
         [status]="status"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <prizm-input-select
           #element
@@ -318,6 +319,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-select/input-select.component.ts
+++ b/apps/doc/src/app/components/input/input-select/input-select.component.ts
@@ -67,6 +67,10 @@ export class InputSelectComponent {
   size = this.sizeVariants[0];
   forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   forceClear = this.forceClearVariants[0];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   emptyContent = 'Ничего не найдено';
   nullContent = 'Не выбрано';
   minDropdownHeight = 0;

--- a/apps/doc/src/app/components/input/input-text/input.component.html
+++ b/apps/doc/src/app/components/input/input-text/input.component.html
@@ -176,6 +176,7 @@
         [status]="status"
         [position]="inputPosition"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
         [size]="size"
         [border]="border"
         prizmDocHostElementKey="PrizmInputLayout"
@@ -273,6 +274,16 @@
         documentationPropertyMode="input"
       >
         Force Clear
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/input-text/input.component.ts
+++ b/apps/doc/src/app/components/input/input-text/input.component.ts
@@ -43,6 +43,10 @@ export class InputComponent {
 
   public forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   public forceClear = this.forceClearVariants[0];
+
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public readonly prizmHintDirectionVariants: ReadonlyArray<PrizmHintOptions['direction']> = Object.values(
     PrizmOverlayOutsidePlacement
   );

--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.html
@@ -26,6 +26,7 @@
         [status]="status"
         [position]="inputPosition"
         [forceClear]="forceClear"
+        [hideClearButtonHint]="hideClearButtonHint"
       >
         <textarea
           #element
@@ -49,6 +50,16 @@
         documentationPropertyMode="input"
       >
         Show clear button
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="hideClearButtonHint"
+        [documentationPropertyValues]="hideHintVariants"
+        documentationPropertyName="hideClearButtonHint"
+        documentationPropertyType="boolean | null"
+        documentationPropertyMode="input"
+      >
+        Hide clear button hint
       </ng-template>
 
       <ng-template

--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.ts
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.ts
@@ -52,6 +52,9 @@ export class TextareaExampleComponent {
   public forceClearVariants: ReadonlyArray<boolean | null> = [null, false, true];
   public forceClear = this.forceClearVariants[0];
 
+  public hideClearButtonHint: boolean | null = null;
+  public hideHintVariants: ReadonlyArray<boolean | null> = [null, false, true];
+
   public readonly textareaBasicExample: TuiDocExample = {
     TypeScript: import('./examples/textarea-basic-example/textarea-basic-example.component.ts?raw'),
     HTML: import('./examples/textarea-basic-example/textarea-basic-example.component.html?raw'),

--- a/libs/components/src/lib/components/input/common/input-common.module.ts
+++ b/libs/components/src/lib/components/input/common/input-common.module.ts
@@ -10,7 +10,7 @@ import { PrizmInputLayoutLeftDirective } from './input-layout/input-layout-left.
 import { PrizmInputLayoutInBodyDirective } from './input-layout/input-layout-in-body.directive';
 import { PrizmInputLayoutSubtextDirective } from './input-layout/input-layout-subtext.directive';
 import { PolymorphModule, PrizmZoneEventModule } from '../../../directives';
-import { PrizmLetDirective, PrizmToObservablePipe } from '@prizm-ui/helpers';
+import { PrizmLetDirective, PrizmPluckPipe, PrizmToObservablePipe } from '@prizm-ui/helpers';
 import { PrizmInputHintModule } from './input-hint/input-hint.module';
 import { PrizmInputAllowedSymbolsModule } from './input-allowed-symbols';
 import { PrizmInputCorrectorModule } from './input-corrector';
@@ -28,6 +28,7 @@ import { PrizmInputIconButtonComponent } from './input-icon-button';
     PrizmInputIconButtonComponent,
     PrizmInputAllowedSymbolsModule,
     PrizmInputCorrectorModule,
+    PrizmPluckPipe,
   ],
   declarations: [
     PrizmInputLayoutRightDirective,

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.html
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.html
@@ -6,6 +6,7 @@
     touched: control.touched | prizmToObservable | async,
     invalid: control.invalid | prizmToObservable | async,
     required: control.required | prizmToObservable | async,
+    inputLayout: inputLayout$ | async,
     emptyLabel: emptyLabel
   } as $"
 >
@@ -43,6 +44,9 @@
           [interactive]="true"
           [disabled]="$.disabled"
           [prizmInputIconButton]="$any(clearButton)"
+          [prizmHint]="$.inputLayout | prizmPluck : ['clear']"
+          [prizmHintDirection]="'b'"
+          [prizmHintCanShow]="!hideClearButtonHint"
           (click)="onClearClick($event)"
         ></button>
 
@@ -107,6 +111,9 @@
             [class.alone]="!showStatusButton"
             [disabled]="$.disabled"
             [prizmInputIconButton]="$any(clearButton) ?? 'delete-content'"
+            [prizmHint]="$.inputLayout | prizmPluck : ['clear']"
+            [prizmHintDirection]="'b'"
+            [prizmHintCanShow]="!hideClearButtonHint"
             (click)="onClearClick($event)"
           ></button>
 

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
@@ -7,6 +7,7 @@ import {
   ElementRef,
   EventEmitter,
   HostBinding,
+  Inject,
   Injector,
   Input,
   OnChanges,
@@ -16,7 +17,7 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
-import { BehaviorSubject, EMPTY, merge, Subject, timer } from 'rxjs';
+import { BehaviorSubject, EMPTY, merge, Observable, Subject, timer } from 'rxjs';
 import { PrizmInputControl } from '../base/input-control.class';
 import { PrizmInputStatusTextDirective } from '../input-status-text/input-status-text.directive';
 import { PrizmInputPosition, PrizmInputSize, PrizmInputStatus } from '../models/prizm-input.models';
@@ -24,7 +25,7 @@ import { debounceTime, map, startWith, takeUntil, tap } from 'rxjs/operators';
 import { isPolymorphPrimitive, PolymorphContent } from '../../../../directives/polymorph';
 import { Compare, filterTruthy, PrizmDestroyService, PrizmLetDirective } from '@prizm-ui/helpers';
 import { PrizmAbstractTestId } from '../../../../abstract/interactive';
-import { PrizmI18nService } from '../../../../services';
+import { PrizmI18nService, prizmI18nInitWithKey } from '../../../../services';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import {
   prizmIconsCircleCheckFill,
@@ -33,6 +34,8 @@ import {
   prizmIconsTempChevronsDropdownSmall,
   prizmIconsTriangleExclamationFill,
 } from '@prizm-ui/icons/full/source';
+import { PRIZM_INPUT_LAYOUT } from '../../../../tokens';
+import { PrizmLanguageInputLayout } from '@prizm-ui/i18n';
 
 export type PrizmInputLayoutClearButtonContext = {
   clear: (event: MouseEvent) => void;
@@ -53,7 +56,11 @@ export type PrizmInputLayoutClearButtonContext = {
   host: {
     class: 'prizm-input-layout',
   },
-  providers: [PrizmDestroyService, PrizmI18nService],
+  providers: [
+    PrizmDestroyService,
+    PrizmI18nService,
+    ...prizmI18nInitWithKey(PRIZM_INPUT_LAYOUT, 'inputLayout'),
+  ],
 })
 export class PrizmInputLayoutComponent
   extends PrizmAbstractTestId
@@ -73,6 +80,7 @@ export class PrizmInputLayoutComponent
   @Input() outer = false;
 
   @Input() clearButton: PolymorphContent<PrizmInputLayoutClearButtonContext> = 'delete-content';
+  @Input() hideClearButtonHint: boolean | null = null;
 
   @Input() border = true;
   @Input() position: PrizmInputPosition = 'left';
@@ -156,7 +164,12 @@ export class PrizmInputLayoutComponent
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
 
-  constructor(private readonly injector: Injector, public readonly el: ElementRef<HTMLElement>) {
+  constructor(
+    private readonly injector: Injector,
+    public readonly el: ElementRef<HTMLElement>,
+    @Inject(PRIZM_INPUT_LAYOUT)
+    public readonly inputLayout$: Observable<PrizmLanguageInputLayout['inputLayout']>
+  ) {
     super();
 
     this.iconsFullRegistry.registerIcons(

--- a/libs/components/src/lib/tokens/i18n.ts
+++ b/libs/components/src/lib/tokens/i18n.ts
@@ -6,6 +6,7 @@ import {
   PrizmLanguageCore,
   PrizmLanguageCron,
   PrizmLanguageFileUpload,
+  PrizmLanguageInputLayout,
   PrizmLanguageInputLayoutDateRelative,
   PrizmLanguageInputLayoutDateTime,
   PrizmLanguageKit,
@@ -14,6 +15,10 @@ import {
 
 export const PRIZM_FILE_UPLOAD = new InjectionToken<Observable<PrizmLanguageFileUpload['fileUpload']>>(
   `Localized for file upload component`
+);
+
+export const PRIZM_INPUT_LAYOUT = new InjectionToken<Observable<PrizmLanguageInputLayout['inputLayout']>>(
+  `input layout i18n base texts`
 );
 
 export const PRIZM_INPUT_LAYOUT_DATE_RELATIVE = new InjectionToken<

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -27,6 +27,7 @@ export interface PrizmLanguageInputLayout {
     pattern: string;
     min: string;
     max: string;
+    clear: string;
   };
 }
 

--- a/libs/i18n/src/lib/languages/english/input.ts
+++ b/libs/i18n/src/lib/languages/english/input.ts
@@ -6,5 +6,6 @@ export const PRIZM_ENGLISH_INPUT: PrizmLanguageInputLayout = {
     pattern: 'Wrong format',
     min: 'Value too small',
     max: 'Value too large',
+    clear: 'Clear',
   },
 };

--- a/libs/i18n/src/lib/languages/russian/input.ts
+++ b/libs/i18n/src/lib/languages/russian/input.ts
@@ -6,5 +6,6 @@ export const PRIZM_RUSSIAN_INPUT: PrizmLanguageInputLayout = {
     pattern: 'Неправильный формат',
     min: 'Значение слишком маленькое',
     max: 'Значение слишком большое',
+    clear: 'Очистить',
   },
 };


### PR DESCRIPTION
feat(components/input-layput): add hint for input clear button #1515

Resolved #1515 

Добавлено новое свойство для inputlayout - hideClearButtonHint. Необходимо проверить live demo для всех компонентов с input layout (свойство должно быть добавлено и устанавливаться)