### PR TITLE
fix: update native time value for min-max date time limit #1618

### DIFF
--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
@@ -334,10 +334,16 @@ export class PrizmInputLayoutDateTimeComponent
 
     if (date) time = this.limitTime(date, time, dateMin, dateMax);
 
-    this.focusableElement?.updateNativeValues({
-      idx: 0,
-      value: date?.toString() ?? '',
-    });
+    this.focusableElement?.updateNativeValues(
+      {
+        idx: 0,
+        value: date?.toString() ?? '',
+      },
+      {
+        idx: 1,
+        value: time?.toString() ?? '',
+      }
+    );
 
     // force update native value
     this.nativeValue$$.next([


### PR DESCRIPTION
fix(components/input-layout-date-time): incorrect min max work for manual input #1618