### PR TITLE
fix: add initialization _autoReposition and _placement in input in dropdown#1596 #1681

### DIFF
--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -119,7 +119,8 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
   private destroyReCalc$ = new Subject<void>();
   private _autoReposition = this.options.autoReposition;
   @Input() set autoReposition(state: boolean) {
-    this.position?.updateConfig({ autoReposition: (this._autoReposition = state) });
+    this._autoReposition = state;
+    this.position?.updateConfig({ autoReposition: this._autoReposition});
   }
   get autoReposition(): boolean {
     return this._autoReposition;
@@ -127,6 +128,7 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
 
   private _placement: PrizmOverlayOutsidePlacement = this.options.placement;
   @Input() set placement(place: PrizmOverlayOutsidePlacement) {
+    this._placement = place;
     this.position?.updateConfig({ placement: place });
   }
   get placement(): PrizmOverlayOutsidePlacement {


### PR DESCRIPTION
fix(component/dropdown-host): add initialization _autoReposition and _placement in input in dropdown https://github.com/zyfra/Prizm/issues/1596