### PR TITLE
feat(doc/dialog):  add examples how to use custom dialog #1602

### DIFF
--- a/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.html
@@ -32,6 +32,9 @@
     <prizm-doc-example id="result-handling" [content]="exampleResulthandling" heading="Result Handling">
       <prizm-dialog-service-result-handling-example></prizm-dialog-service-result-handling-example>
     </prizm-doc-example>
+    <prizm-doc-example id="custom-service" [content]="exampleCustomService" heading="Custom Service">
+      <prizm-dialog-custom-service-example></prizm-dialog-custom-service-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.ts
@@ -75,6 +75,13 @@ export class DialogExampleComponent {
     TypeScript: import('./examples/base/dialog-base-example.component.ts?raw'),
     HTML: import('./examples/base/dialog-base-example.component.html?raw'),
   };
+
+  public readonly exampleCustomService: TuiDocExample = {
+    TypeScript: import('./examples/custom-service/dialog-custom-service-example.component.ts?raw'),
+    HTML: import('./examples/custom-service/dialog-custom-service-example.component.html?raw'),
+    Service: import('./examples/custom-service/my-custom-service.ts?raw'),
+  };
+
   public readonly exampleWightOuterHeader: TuiDocExample = {
     TypeScript: import('./examples/outher-header/dialog-outher-header-example.component.ts?raw'),
     HTML: import('./examples/outher-header/dialog-outher-header-example.component.html?raw'),

--- a/apps/doc/src/app/components/dialogs/dialog/dialog-example.module.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog-example.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
+import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import {
   PolymorphModule,
@@ -18,6 +18,7 @@ import { PrizmDialogServiceWithButtonsExampleComponent } from './examples/with-b
 import { PrizmDialogServiceWithParentExampleComponent } from './examples/with-parent/dialog-with-parent-example.component';
 import { PrizmDialogServiceResultHandlingExampleComponent } from './examples/result/dialog-result-handling-example.component';
 import { PrizmDialogOuterHeaderExampleComponent } from './examples/outher-header/dialog-outher-header-example.component';
+import { PrizmDialogCustomServiceExampleComponent } from './examples/custom-service/dialog-custom-service-example.component';
 
 @NgModule({
   imports: [
@@ -33,6 +34,7 @@ import { PrizmDialogOuterHeaderExampleComponent } from './examples/outher-header
     RouterModule.forChild(prizmDocGenerateRoutes(DialogExampleComponent)),
     PrizmInputCommonModule,
     PrizmInputSelectModule,
+    PrizmDialogCustomServiceExampleComponent,
   ],
   declarations: [
     PrizmDialogOuterHeaderExampleComponent,

--- a/apps/doc/src/app/components/dialogs/dialog/examples/custom-service/dialog-custom-service-example.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/custom-service/dialog-custom-service-example.component.html
@@ -1,0 +1,1 @@
+<button (click)="show()" type="button" prizmButton>Show Dialog</button>

--- a/apps/doc/src/app/components/dialogs/dialog/examples/custom-service/dialog-custom-service-example.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/custom-service/dialog-custom-service-example.component.ts
@@ -1,0 +1,48 @@
+import { Component, Inject } from '@angular/core';
+import { PrizmButtonComponent, PrizmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
+import { MyDialogService } from './my-custom-service';
+
+@Component({
+  selector: 'prizm-dialog-custom-service-example',
+  templateUrl: './dialog-custom-service-example.component.html',
+  styles: [
+    `
+      .box {
+        display: flex;
+        gap: 1rem;
+      }
+    `,
+  ],
+  standalone: true,
+  imports: [PrizmButtonComponent],
+  providers: [
+    {
+      provide: PrizmDialogService,
+      useClass: MyDialogService,
+    },
+  ],
+})
+export class PrizmDialogCustomServiceExampleComponent {
+  public positionVariants: PrizmOverlayInsidePlacement[] = Object.values(PrizmOverlayInsidePlacement);
+  public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
+  public backdrop = false;
+  public dismissible = true;
+
+  constructor(@Inject(PrizmDialogService) private readonly dialogService: PrizmDialogService) {}
+
+  public show(): void {
+    this.dialogService
+      .open(
+        `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
+        {
+          closeable: true,
+          header: 'Header',
+          width: 500,
+          closeWord: 'Продолжить',
+          position: this.position,
+          dismissible: this.dismissible,
+        }
+      )
+      .subscribe();
+  }
+}

--- a/apps/doc/src/app/components/dialogs/dialog/examples/custom-service/my-custom-service.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/custom-service/my-custom-service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { PRIZM_DIALOG_DEFAULT_OPTIONS, PrizmDialogOptions, PrizmDialogService } from '@prizm-ui/components';
+
+@Injectable()
+export class MyDialogService extends PrizmDialogService {
+  protected override readonly defaultOptions = {
+    ...PRIZM_DIALOG_DEFAULT_OPTIONS,
+    backdrop: true,
+  } as PrizmDialogOptions;
+}

--- a/libs/components/src/lib/abstract/dialog.service.ts
+++ b/libs/components/src/lib/abstract/dialog.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Type } from '@angular/core';
+import { inject, Injectable, Injector, Type } from '@angular/core';
 import { noop, Observable, Observer, Subject } from 'rxjs';
 import { PrizmBaseDialogContext, PrizmDialogBaseOptions } from '../components/dialogs/dialog/dialog.models';
 import { PolymorphContent, PrizmOverscrollService } from '../directives';
@@ -23,12 +23,13 @@ export abstract class AbstractPrizmDialogService<
 > {
   protected abstract readonly component: Type<unknown>;
   protected abstract readonly defaultOptions: T;
-  protected readonly overlayService: PrizmOverlayService;
-  protected readonly overscrollService: PrizmOverscrollService;
-  protected constructor(injector: Injector) {
-    this.overlayService = injector.get(PrizmOverlayService);
-    this.overscrollService = injector.get(PrizmOverscrollService);
-  }
+  protected readonly overlayService: PrizmOverlayService = inject(PrizmOverlayService);
+  protected readonly overscrollService: PrizmOverscrollService = inject(PrizmOverscrollService);
+
+  // protected constructor(injector: Injector) {
+  // this.overlayService = injector.get(PrizmOverlayService);
+  // this.overscrollService = injector.get(PrizmOverscrollService);
+  // }
 
   public open<O = unknown, DATA = unknown>(
     content: PolymorphContent<PrizmBaseDialogContext<O>> | unknown,
@@ -51,6 +52,11 @@ export abstract class AbstractPrizmDialogService<
       };
 
       options = options ?? {};
+
+      console.log('#mz options', {
+        options,
+        defaultOptions: this.defaultOptions,
+      });
 
       const dialog = {
         ...this.defaultOptions,

--- a/libs/components/src/lib/abstract/dialog.service.ts
+++ b/libs/components/src/lib/abstract/dialog.service.ts
@@ -26,11 +26,6 @@ export abstract class AbstractPrizmDialogService<
   protected readonly overlayService: PrizmOverlayService = inject(PrizmOverlayService);
   protected readonly overscrollService: PrizmOverscrollService = inject(PrizmOverscrollService);
 
-  // protected constructor(injector: Injector) {
-  // this.overlayService = injector.get(PrizmOverlayService);
-  // this.overscrollService = injector.get(PrizmOverscrollService);
-  // }
-
   public open<O = unknown, DATA = unknown>(
     content: PolymorphContent<PrizmBaseDialogContext<O>> | unknown,
     options: Partial<T>,

--- a/libs/components/src/lib/abstract/dialog.service.ts
+++ b/libs/components/src/lib/abstract/dialog.service.ts
@@ -48,11 +48,6 @@ export abstract class AbstractPrizmDialogService<
 
       options = options ?? {};
 
-      console.log('#mz options', {
-        options,
-        defaultOptions: this.defaultOptions,
-      });
-
       const dialog = {
         ...this.defaultOptions,
         ...options,

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.service.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.service.ts
@@ -4,7 +4,7 @@ import { PrizmDialogComponent } from './dialog.component';
 import { PrizmOverlayInsidePlacement } from '../../../modules/overlay';
 import { PrizmDialogOptions } from './dialog.models';
 
-const DEFAULT_OPTIONS: PrizmDialogOptions = {
+export const PRIZM_DIALOG_DEFAULT_OPTIONS: PrizmDialogOptions = {
   size: 'm',
   required: false,
   closeable: true,
@@ -21,5 +21,5 @@ const DEFAULT_OPTIONS: PrizmDialogOptions = {
 })
 export class PrizmDialogService extends AbstractPrizmDialogService<PrizmDialogOptions> {
   protected readonly component = PrizmDialogComponent;
-  protected readonly defaultOptions: PrizmDialogOptions = DEFAULT_OPTIONS;
+  protected readonly defaultOptions: PrizmDialogOptions = PRIZM_DIALOG_DEFAULT_OPTIONS;
 }


### PR DESCRIPTION
feat(doc/dialog): add examples how to use custom dialog #1602
refactor(components/dialog): removed injection from constructor and now defaultOptions is exported #1602

Добавлен пример на страницу диалога с использованием пользовательского сервиса