### PR TITLE
#1710 #1704

### DIFF
--- a/apps/doc/src/app/components/tooltip/tooltip-example.component.html
+++ b/apps/doc/src/app/components/tooltip/tooltip-example.component.html
@@ -7,17 +7,17 @@
       <prizm-tooltip-base-example></prizm-tooltip-base-example>
     </prizm-doc-example>
 
-    <!--    <prizm-doc-example id="with-template" [content]="exampleWithTemplate" heading="With Template">-->
-    <!--      <prizm-tooltip-with-template-example></prizm-tooltip-with-template-example>-->
-    <!--    </prizm-doc-example>-->
+    <prizm-doc-example id="with-template" [content]="exampleWithTemplate" heading="With Template">
+      <prizm-tooltip-with-template-example></prizm-tooltip-with-template-example>
+    </prizm-doc-example>
 
-    <!--    <prizm-doc-example id="with-custom-context" [content]="exampleWithContext" heading="With Context">-->
-    <!--      <prizm-tooltip-with-custom-context-example></prizm-tooltip-with-custom-context-example>-->
-    <!--    </prizm-doc-example>-->
+    <prizm-doc-example id="with-custom-context" [content]="exampleWithContext" heading="With Context">
+      <prizm-tooltip-with-custom-context-example></prizm-tooltip-with-custom-context-example>
+    </prizm-doc-example>
 
-    <!--    <prizm-doc-example id="with-component" [content]="exampleWithComponent" heading="With Component">-->
-    <!--      <prizm-tooltip-with-component-example></prizm-tooltip-with-component-example>-->
-    <!--    </prizm-doc-example>-->
+    <prizm-doc-example id="with-component" [content]="exampleWithComponent" heading="With Component">
+      <prizm-tooltip-with-component-example></prizm-tooltip-with-component-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/tooltip/tooltip-example.component.html
+++ b/apps/doc/src/app/components/tooltip/tooltip-example.component.html
@@ -7,17 +7,17 @@
       <prizm-tooltip-base-example></prizm-tooltip-base-example>
     </prizm-doc-example>
 
-    <prizm-doc-example id="with-template" [content]="exampleWithTemplate" heading="With Template">
-      <prizm-tooltip-with-template-example></prizm-tooltip-with-template-example>
-    </prizm-doc-example>
+    <!--    <prizm-doc-example id="with-template" [content]="exampleWithTemplate" heading="With Template">-->
+    <!--      <prizm-tooltip-with-template-example></prizm-tooltip-with-template-example>-->
+    <!--    </prizm-doc-example>-->
 
-    <prizm-doc-example id="with-custom-context" [content]="exampleWithContext" heading="With Context">
-      <prizm-tooltip-with-custom-context-example></prizm-tooltip-with-custom-context-example>
-    </prizm-doc-example>
+    <!--    <prizm-doc-example id="with-custom-context" [content]="exampleWithContext" heading="With Context">-->
+    <!--      <prizm-tooltip-with-custom-context-example></prizm-tooltip-with-custom-context-example>-->
+    <!--    </prizm-doc-example>-->
 
-    <prizm-doc-example id="with-component" [content]="exampleWithComponent" heading="With Component">
-      <prizm-tooltip-with-component-example></prizm-tooltip-with-component-example>
-    </prizm-doc-example>
+    <!--    <prizm-doc-example id="with-component" [content]="exampleWithComponent" heading="With Component">-->
+    <!--      <prizm-tooltip-with-component-example></prizm-tooltip-with-component-example>-->
+    <!--    </prizm-doc-example>-->
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>
@@ -131,7 +131,18 @@
       <ng-template
         [(documentationPropertyValue)]="prizmTooltipTheme"
         [documentationPropertyValues]="prizmTooltipThemeVariants"
+        [documentationPropertyDeprecated]="true"
         documentationPropertyName="prizmHintTheme"
+        documentationPropertyType="PrizmTheme | null"
+        documentationPropertyMode="input"
+      >
+        use prizmTooltipTheme
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="prizmTooltipTheme"
+        [documentationPropertyValues]="prizmTooltipThemeVariants"
+        documentationPropertyName="prizmTooltipTheme"
         documentationPropertyType="PrizmTheme | null"
         documentationPropertyMode="input"
       >

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
@@ -99,8 +99,8 @@ export class PrizmConfirmPopupDirective<
   @Output('prizmConfirmPopupShowed')
   override prizmHintShowed = new EventEmitter<boolean>();
 
-  protected override readonly containerComponent = PrizmConfirmPopupContainerComponent;
-  protected override readonly onHoverActive = false;
+  public override readonly containerComponent = PrizmConfirmPopupContainerComponent;
+  public override readonly onHoverActive = false;
 
   @HostListener('document:click', ['$event.target']) public onClick(target: HTMLElement): void {
     if (this.elementRef.nativeElement.contains(target)) {

--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -106,18 +106,18 @@ export class PrizmHintDirective<
   @Output()
   readonly prizmHintShowed = new EventEmitter<boolean>();
 
-  protected readonly onHoverActive: boolean = true;
+  public onHoverActive: boolean = true;
 
   content!: PolymorphContent;
   overlay!: PrizmOverlayControl;
-  protected readonly containerComponent: Type<unknown> = PrizmHintContainerComponent;
-  protected readonly show$ = new Subject<boolean>();
+  public containerComponent: Type<unknown> = PrizmHintContainerComponent;
+  public readonly show$ = new Subject<boolean>();
   protected readonly destroyListeners$ = new Subject<void>();
 
   private readonly prizmOverlayService: PrizmOverlayService = inject(PrizmOverlayService);
 
   private readonly renderer: Renderer2 = inject(Renderer2);
-  protected readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
+  public readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly destroy$: PrizmDestroyService = inject(PrizmDestroyService);
   private readonly hoveredService: PrizmHoveredService = inject(PrizmHoveredService);
 
@@ -218,6 +218,7 @@ export class PrizmHintDirective<
       .create({
         parentInjector: this.injector,
       });
+
     if (this.onHoverActive) {
       combineLatest([
         this.hoveredService.createHovered$(this.host),

--- a/libs/doc/base/src/lib/components/host/host-element.service.ts
+++ b/libs/doc/base/src/lib/components/host/host-element.service.ts
@@ -75,7 +75,6 @@ export class PrizmDocHostElementService implements OnDestroy {
     selector = componentMetadata.selectors?.[0]?.[0] as string;
 
     const hasHostDirectives = !!componentMetadata.hostDirectives?.length;
-
     // Process collected properties and fill the sets
     this.processProperties(inputKeys, inputValues, componentMetadata.inputs, !hasHostDirectives);
     this.processProperties(outputKeys, outputValues, componentMetadata.outputs, !hasHostDirectives);
@@ -91,9 +90,6 @@ export class PrizmDocHostElementService implements OnDestroy {
         outputValues,
         this.collectProperties(componentMetadata.hostDirectives, 'outputs')
       );
-    } else {
-      this.processProperties(inputKeys, inputValues, componentMetadata.inputs);
-      this.processProperties(outputKeys, outputValues, componentMetadata.outputs);
     }
 
     // Return the collected information
@@ -125,9 +121,15 @@ export class PrizmDocHostElementService implements OnDestroy {
   ) {
     for (const key in properties) {
       if (key in properties) {
-        if (skipByKey && keysSet.has(key)) continue;
-        keysSet.add(key);
-        valuesSet.add(properties[key]);
+        if (skipByKey) {
+          // if extended components > filter parent input and outputs
+          if (keysSet.has(properties[key])) continue;
+          valuesSet.add(key);
+          keysSet.add(properties[key]);
+        } else {
+          keysSet.add(key);
+          valuesSet.add(properties[key]);
+        }
       }
     }
   }
@@ -209,6 +211,7 @@ export class PrizmDocHostElementService implements OnDestroy {
     eventRealKey: string,
     hasNotListener = false
   ): void {
+    if (eventRealKey == null) return;
     if (!el.nativeElement?.[eventRealKey]) {
       console.error(`Prizm component output <${eventRealKey}> does not exists`, {
         name: eventRealKey,

--- a/libs/helpers/src/lib/util/index.ts
+++ b/libs/helpers/src/lib/util/index.ts
@@ -11,3 +11,4 @@ export * from './merge';
 export * from './order-by';
 export * from './difference';
 export * from './directive';
+export * from './invert-object';

--- a/libs/helpers/src/lib/util/invert-object.spec.ts
+++ b/libs/helpers/src/lib/util/invert-object.spec.ts
@@ -1,0 +1,71 @@
+import { prizmInvertObject } from './invert-object';
+
+describe('prizmInvertObject', () => {
+  it('should invert keys and values of a simple object', () => {
+    const originalObject = {
+      a: '1',
+      b: '2',
+      c: '3',
+    };
+    const expectedInvertedObject = {
+      '1': 'a',
+      '2': 'b',
+      '3': 'c',
+    };
+
+    const result = prizmInvertObject(originalObject);
+    expect(result).toEqual(expectedInvertedObject);
+  });
+
+  it('should handle objects with number keys and string values', () => {
+    const originalObject = {
+      1: 'a',
+      2: 'b',
+      3: 'c',
+    };
+    const expectedInvertedObject = {
+      a: '1',
+      b: '2',
+      c: '3',
+    };
+
+    const result = prizmInvertObject(originalObject);
+    expect(result).toEqual(expectedInvertedObject);
+  });
+
+  it('should handle objects with mixed keys and values', () => {
+    const originalObject = {
+      a: 1,
+      b: 2,
+      c: 3,
+    };
+    const expectedInvertedObject = {
+      1: 'a',
+      2: 'b',
+      3: 'c',
+    };
+
+    const result = prizmInvertObject(originalObject);
+    expect(result).toEqual(expectedInvertedObject);
+  });
+
+  it('should throw an error if the values are not primitive types', () => {
+    const originalObject = {
+      a: { nested: 'object' },
+      b: '2',
+      c: '3',
+    };
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(() => prizmInvertObject(originalObject)).toThrow();
+  });
+
+  it('should handle empty objects', () => {
+    const originalObject = {};
+    const expectedInvertedObject = {};
+
+    const result = prizmInvertObject(originalObject);
+    expect(result).toEqual(expectedInvertedObject);
+  });
+});

--- a/libs/helpers/src/lib/util/invert-object.ts
+++ b/libs/helpers/src/lib/util/invert-object.ts
@@ -6,7 +6,7 @@ export function prizmInvertObject<K extends string | number | symbol, V extends 
   for (const key in obj) {
     if (obj[key]) {
       const value = obj[key];
-      if ((value && typeof value === 'object') || typeof value === 'function')
+      if ((value == null && value && typeof value === 'object') || typeof value === 'function')
         throw new Error('Passed to prizmInvertObject values that has not primitive value');
       invertedObj[value] = key as K;
     }

--- a/libs/helpers/src/lib/util/invert-object.ts
+++ b/libs/helpers/src/lib/util/invert-object.ts
@@ -1,0 +1,16 @@
+export function prizmInvertObject<K extends string | number | symbol, V extends string | number | symbol>(
+  obj: Record<K, V>
+): Record<V, K> {
+  const invertedObj = {} as Record<V, K>;
+
+  for (const key in obj) {
+    if (obj[key]) {
+      const value = obj[key];
+      if ((value && typeof value === 'object') || typeof value === 'function')
+        throw new Error('Passed to prizmInvertObject values that has not primitive value');
+      invertedObj[value] = key as K;
+    }
+  }
+
+  return invertedObj;
+}


### PR DESCRIPTION
- feat(doc): add support for get inputs and outputs from hostDirectives #1710
- fix(components/tooltip): tooltip close on click in showed dropdown #1704
- feat(helpers): new method prizmInvertObject to invert keys and values for json object 
- refactor(components/tooltip): migrate to composition api instead of extend
Resolved #1704
Resolvde #1710