### PR TITLE
fix(components/input-layout): add margin bottom for label in outer inputs #1659

### DIFF
--- a/libs/components/src/lib/components/input/common/input-layout/input-layout-hidden-control.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout-hidden-control.component.less
@@ -1,5 +1,5 @@
 :host.has-hidden-control {
-  .label-container {
+  .label-container:not(.label-container-outer) {
     height: 16px;
     margin-bottom: 2px;
 

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.less
@@ -46,6 +46,7 @@
   width: 100%;
   display: flex;
   gap: 4px;
+  margin-bottom: 4px;
 
   &-required {
     color: var(--prizm-status-alarm-primary-default);


### PR DESCRIPTION
fix(components/input-layout): add margin bottom for label in outer inputs #1659

resolved #1659 