### PR TITLE
fix(components/calendar): change calendar resrtictions ux #1674

### DIFF
--- a/apps/doc/src/app/components/input/input-layout-date-range/examples/base/input-layout-date-range-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-range/examples/base/input-layout-date-range-base-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { PrizmDay, PrizmDayRange } from '@prizm-ui/components';
 

--- a/libs/components/src/lib/components/calendar/calendar.component.ts
+++ b/libs/components/src/lib/components/calendar/calendar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { PrizmDay } from '../../@core/date-time/day';
 import { PrizmDayRange } from '../../@core/date-time/day-range';
 import { PRIZM_FIRST_DAY, PRIZM_LAST_DAY } from '../../@core/date-time/days.const';
@@ -21,6 +21,7 @@ import { PrizmMapperPipeModule } from '../../pipes';
 import { PrizmPrimitiveYearMonthPaginationComponent } from '../internal/primitive-year-month-pagination/primitive-year-month-pagination.component';
 import { PrizmPrimitiveMonthPickerComponent } from '../internal/primitive-month-picker/primitive-month-picker.component';
 import { PrizmPrimitiveYearPickerComponent } from '../internal/primitive-year-picker/primitive-year-picker.component';
+import { prizmInRange } from '../../util/math/in-range';
 
 @Component({
   selector: `prizm-calendar`,
@@ -38,7 +39,10 @@ import { PrizmPrimitiveYearPickerComponent } from '../internal/primitive-year-pi
     PrizmMapperPipeModule,
   ],
 })
-export class PrizmCalendarComponent extends PrizmAbstractTestId implements PrizmWithOptionalMinMax<PrizmDay> {
+export class PrizmCalendarComponent
+  extends PrizmAbstractTestId
+  implements PrizmWithOptionalMinMax<PrizmDay>, OnInit
+{
   @Input()
   @prizmDefaultProp()
   month: PrizmMonth = PrizmMonth.currentLocal();
@@ -117,6 +121,10 @@ export class PrizmCalendarComponent extends PrizmAbstractTestId implements Prizm
     return this.maxViewedMonth.monthSameOrBefore(this.max) ? this.maxViewedMonth : this.max;
   }
 
+  ngOnInit(): void {
+    this.doMonthCorrection();
+  }
+
   public onPaginationYearClick(year: PrizmYear): void {
     this.year = year;
     this.clickedMonth = null;
@@ -165,5 +173,16 @@ export class PrizmCalendarComponent extends PrizmAbstractTestId implements Prizm
 
     this.hoveredItem = day;
     this.hoveredItemChange.emit(day);
+  }
+
+  private doMonthCorrection(): void {
+    if ((this.min || this.max) && !this.isMonthInRange(this.month, this.min, this.max)) {
+      const monthToDisplay = this.min ?? this.max;
+      this.month = new PrizmMonth(monthToDisplay.year, monthToDisplay.month);
+    }
+  }
+
+  private isMonthInRange(month: PrizmMonth, min: PrizmMonth | PrizmDay, max: PrizmMonth | PrizmDay): boolean {
+    return prizmInRange(month.year, min.year, max.year) && prizmInRange(month.month, min.month, max.month);
   }
 }

--- a/libs/components/src/lib/components/calendar/calendar.component.ts
+++ b/libs/components/src/lib/components/calendar/calendar.component.ts
@@ -183,6 +183,8 @@ export class PrizmCalendarComponent
   }
 
   private isMonthInRange(month: PrizmMonth, min: PrizmMonth | PrizmDay, max: PrizmMonth | PrizmDay): boolean {
-    return prizmInRange(month.year, min.year, max.year) && prizmInRange(month.month, min.month, max.month);
+    return prizmInRange(month.year, min.year, max.year) && min.year === max.year
+      ? prizmInRange(month.month, min.month, max.month)
+      : true;
   }
 }

--- a/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-month-picker/primitive-month-picker.component.ts
@@ -114,10 +114,11 @@ export class PrizmPrimitiveMonthPickerComponent extends PrizmAbstractTestId {
   }
 
   public getItemState(item: number): PrizmInteractiveState | null {
-    const { disabledItemHandler, max, pressedItem, hoveredItem } = this;
+    const { disabledItemHandler, max, min, pressedItem, hoveredItem } = this;
 
     if (
       (max.month < item && max.year <= this.currentYear) ||
+      (min.month > item && min.year >= this.currentYear) ||
       (disabledItemHandler !== PRIZM_ALWAYS_FALSE_HANDLER && disabledItemHandler(item))
     ) {
       return PrizmInteractiveState.Disabled;

--- a/libs/components/src/lib/components/internal/primitive-year-month-pagination/primitive-year-month-pagination.component.html
+++ b/libs/components/src/lib/components/internal/primitive-year-month-pagination/primitive-year-month-pagination.component.html
@@ -1,11 +1,32 @@
 <div class="box">
   <div class="year-month prizm-font-input-text-14px">
-    <div *ngIf="oneMonth; else buttonMonth">
-      {{ value?.month | prizmMonth | async }}
+    <div class="month-box" (click)="onMonthClick($event)">
+      <button
+        class="pagination-btn"
+        [attr.testId]="'prizm-primitive-year-month-pagination__year-button'"
+        [class.active]="monthActive"
+        [prizmFocusable]="true"
+        [disabled]="oneMonth"
+        type="button"
+      >
+        {{ value?.month | prizmMonth | async }}
+
+        <prizm-icons-full *ngIf="!oneMonth" name="triangle-down"></prizm-icons-full>
+      </button>
     </div>
 
-    <div *ngIf="oneYear; else button">
-      {{ value.formattedYear }}
+    <div class="year-box" (click)="onYearClick($event)">
+      <button
+        class="pagination-btn"
+        [attr.data-testid]="'prizm-primitive-year-month-pagination__year-button'"
+        [prizmFocusable]="true"
+        [class.active]="yearActive"
+        [disabled]="oneYear"
+        type="button"
+      >
+        {{ value.formattedYear }}
+        <prizm-icons-full *ngIf="!oneYear" name="triangle-down"></prizm-icons-full>
+      </button>
     </div>
   </div>
   <div>
@@ -20,39 +41,3 @@
     </prizm-primitive-spin-button>
   </div>
 </div>
-
-<ng-template #button>
-  <div class="year-box" (click)="onYearClick($event)">
-    <button
-      class="pagination-btn"
-      [attr.data-testid]="'prizm-primitive-year-month-pagination__year-button'"
-      [prizmFocusable]="true"
-      [class.active]="yearActive"
-      type="button"
-    >
-      {{ value.formattedYear }}
-      <span>
-        <!--        <prizm-icon iconClass="temp-chevrons-dropdown-small"></prizm-icon>-->
-        <prizm-icons-full name="triangle-down"></prizm-icons-full>
-      </span>
-    </button>
-  </div>
-</ng-template>
-
-<ng-template #buttonMonth>
-  <div class="month-box" (click)="onMonthClick($event)">
-    <button
-      class="pagination-btn"
-      [attr.testId]="'prizm-primitive-year-month-pagination__year-button'"
-      [class.active]="monthActive"
-      [prizmFocusable]="true"
-      type="button"
-    >
-      {{ value?.month | prizmMonth | async }}
-      <span>
-        <!--        <prizm-icon iconClass="temp-chevrons-dropdown-small"></prizm-icon>-->
-        <prizm-icons-full name="triangle-down"></prizm-icons-full>
-      </span>
-    </button>
-  </div>
-</ng-template>

--- a/libs/components/src/lib/components/internal/primitive-year-month-pagination/primitive-year-month-pagination.component.html
+++ b/libs/components/src/lib/components/internal/primitive-year-month-pagination/primitive-year-month-pagination.component.html
@@ -1,12 +1,13 @@
 <div class="box">
   <div class="year-month prizm-font-input-text-14px">
-    <div class="month-box" (click)="onMonthClick($event)">
+    <div class="month-box">
       <button
         class="pagination-btn"
         [attr.testId]="'prizm-primitive-year-month-pagination__year-button'"
         [class.active]="monthActive"
         [prizmFocusable]="true"
         [disabled]="oneMonth"
+        (click)="onMonthClick($event)"
         type="button"
       >
         {{ value?.month | prizmMonth | async }}
@@ -15,13 +16,14 @@
       </button>
     </div>
 
-    <div class="year-box" (click)="onYearClick($event)">
+    <div class="year-box">
       <button
         class="pagination-btn"
         [attr.data-testid]="'prizm-primitive-year-month-pagination__year-button'"
         [prizmFocusable]="true"
         [class.active]="yearActive"
         [disabled]="oneYear"
+        (click)="onYearClick($event)"
         type="button"
       >
         {{ value.formattedYear }}

--- a/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
+++ b/libs/components/src/lib/components/internal/primitive-year-picker/primitive-year-picker.component.ts
@@ -19,6 +19,7 @@ import { PrizmLetDirective } from '@prizm-ui/helpers';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 
 const LIMIT = 100;
+const MIN_ROW_COUNT = 5;
 const ITEMS_IN_ROW = 3;
 
 @Component({
@@ -84,7 +85,8 @@ export class PrizmPrimitiveYearPickerComponent extends PrizmAbstractTestId {
   override readonly testId_ = 'ui_primitive_year_picker';
 
   get rows(): number {
-    return Math.ceil((this.calculatedMax - this.calculatedMin) / ITEMS_IN_ROW);
+    const calculatedRows = Math.ceil((this.calculatedMax - this.calculatedMin) / ITEMS_IN_ROW);
+    return calculatedRows < MIN_ROW_COUNT ? MIN_ROW_COUNT : calculatedRows;
   }
 
   get calculatedMin(): number {

--- a/libs/components/src/styles/mixins/mixins.less
+++ b/libs/components/src/styles/mixins/mixins.less
@@ -147,4 +147,9 @@
   &.active {
     color: var(--prizm-button-primary-solid-active);
   }
+
+  &:disabled {
+    pointer-events: none;
+    cursor: default;
+  }
 }

--- a/libs/components/src/styles/mixins/mixins.less
+++ b/libs/components/src/styles/mixins/mixins.less
@@ -138,7 +138,7 @@
 
   color: var(--prizm-text-icon-secondary);
 
-  &:hover:not(.active):not(:active) {
+  &:hover:not(.active):not(:active):not(:disabled) {
     background-color: var(--prizm-button-ghost-hover);
     border-radius: 2px;
   }


### PR DESCRIPTION
fix(components/calendar): change calendar resrtictions ux #1674

Исправили UX календарей: теперь при указанных min/max значениях календарь открывается в доступный период, так же исправлена бага с версткой.

_Обратить внимание при тестировании_
Календари и все компоненты, их использующие. Особенно сценарии с использованием min/max, периодами меньше года, меньше месяца, периоды с указанными min/max, не попадающими в текущую дату.

сценарий, когда выбранная дата, установленная программно, не попадает в период - требует уточнения UX (описания валидации в input) 

resolved #1674 