### PR TITLE
fix(components/chips): dots overflows chip list container #1713

### DIFF
--- a/apps/doc/src/app/components/input/input-multi-select/examples/base/multi-select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-multi-select/examples/base/multi-select-base-example.component.ts
@@ -17,6 +17,7 @@ export class PrizmInputMultiSelectBaseExampleComponent implements OnInit {
   value = true;
   readonly valueControl = new UntypedFormControl([]);
   readonly items = [
+    'Very long text with a lot of characters and spaces',
     'One',
     'Two',
     'Three',

--- a/libs/components/src/lib/components/chips/chips.component.html
+++ b/libs/components/src/lib/components/chips/chips.component.html
@@ -1,38 +1,40 @@
-<div
-  class="chips-list"
-  #prizmElementReady="prizmElementReady"
-  #parent
-  *ngIf="!!(chipsList$ | async)?.length"
-  [class.hidden]="singleLine"
-  [checker]="ready"
-  prizmElementReady
->
-  <ng-container *ngIf="prizmElementReady.ready$ | async">
-    <ng-container
-      *ngFor="let item of chipsList$ | async; let i = index; trackBy: trackByIdx"
-      [ngTemplateOutlet]="buttonTemplate"
-      [ngTemplateOutletContext]="{
-        item: item,
-        idx: i,
-        allChipsCount: (chipsList$ | async)?.length ?? 0,
-        parent: parent,
-        singleLine: singleLine
-      }"
-    >
-    </ng-container>
-
-    <ng-container *ngIf="overflowedChipsList$ | async as chipsOverflowedList">
-      <div
-        class="more-item"
-        *ngIf="chipsOverflowedList.size"
-        [prizmHint]="getOverflowedChipsListHint()"
-        [prizmHintDirection]="hintDirection"
+<ng-container *prizmLet="chipsList$ | async as chipsList">
+  <div
+    class="chips-list"
+    #prizmElementReady="prizmElementReady"
+    #parent
+    *ngIf="!!chipsList?.length"
+    [class.hidden]="singleLine"
+    [checker]="ready"
+    prizmElementReady
+  >
+    <ng-container *ngIf="prizmElementReady.ready$ | async">
+      <ng-container
+        *ngFor="let item of chipsList; let i = index; trackBy: trackByIdx"
+        [ngTemplateOutlet]="buttonTemplate"
+        [ngTemplateOutletContext]="{
+          item: item,
+          idx: i,
+          allChipsCount: chipsList?.length ?? 0,
+          parent: parent,
+          singleLine: singleLine
+        }"
       >
-        ...
-      </div>
+      </ng-container>
+
+      <ng-container *ngIf="overflowedChipsList$ | async as chipsOverflowedList">
+        <div
+          class="more-item"
+          *ngIf="chipsOverflowedList.size"
+          [prizmHint]="getOverflowedChipsListHint()"
+          [prizmHintDirection]="hintDirection"
+        >
+          ...
+        </div>
+      </ng-container>
     </ng-container>
-  </ng-container>
-</div>
+  </div>
+</ng-container>
 
 <ng-template
   #buttonTemplate

--- a/libs/components/src/lib/components/chips/chips.component.less
+++ b/libs/components/src/lib/components/chips/chips.component.less
@@ -35,5 +35,11 @@
       height: var(--prizm-chips-item-heigh, 24px);
       width: 100%;
     }
+
+    &:has(.more-item) {
+      prizm-chips-item.single-line {
+        max-width: calc(100% - 20px);
+      }
+    }
   }
 }

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.less
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.less
@@ -67,6 +67,7 @@
   transition-property: color, transform;
   transition-duration: var(--prizm-duration, 0.3s);
   transition-timing-function: ease-in-out;
+  outline: none;
 
   &.active {
     color: var(--prizm-button-primary-solid-active);

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.less
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.less
@@ -65,7 +65,7 @@
 }
 
 .icon-dropdown {
-  color: #777b92;
+  color: var(--prizm-button-secondary-solid-default);
   cursor: pointer;
   transition-property: transform;
   transition-property: all;
@@ -78,7 +78,7 @@
   }
 
   &.active {
-    color: #337eff;
+    color: var(--prizm-button-primary-solid-active);
   }
 }
 


### PR DESCRIPTION
fix(components/chips): dots overflows chip list container #1713
fix(components/input-multiselect): chevron outline removed
fix(components/input-select): chevron outline removed
refactor(components/chips): move multiply subscriptions to prizmLet

Исправлена ошибка в верстке при переполнении контейнера с чипсами в InputMultiSelect и InputChips singleLine.
Убрали Outline на шевроне, появляющийся при клике в InputMultiSelect.
Заменили статичные цвета на переменные из тем для шеврона в InputSelect. 

Улучшили производительность компонента Chips с помощью оптимизации подписок в шаблоне.   

_Обратить внимание при тестировании_
InputMultiSelect и InputChips, особенно состояние singleLine. Стоит проверить отступы справа внутри указанных компонентов.
Сценарий воспроизведения проблемы: выбрано больше одного чипса, ширина первого из выбранных чипсов превышает ширину контейнера.  Соответствующий пример добавлен в InputMultiSelect, для InputChips доступен для воспроизведения в LiveDemo.


resolved #1713 