### PR TITLE
fix(components/chips): dots overflows chip list container #1713 v3

### DIFF
--- a/apps/doc/src/app/components/input/input-multi-select/examples/base/multi-select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-multi-select/examples/base/multi-select-base-example.component.ts
@@ -17,6 +17,7 @@ export class PrizmInputMultiSelectBaseExampleComponent implements OnInit {
   value = true;
   readonly valueControl = new UntypedFormControl([]);
   readonly items = [
+    'Very long text with a lot of characters and spaces',
     'One',
     'Two',
     'Three',

--- a/libs/components/src/lib/components/chips/chips.component.html
+++ b/libs/components/src/lib/components/chips/chips.component.html
@@ -1,38 +1,40 @@
-<div
-  class="chips-list"
-  #prizmElementReady="prizmElementReady"
-  #parent
-  *ngIf="!!(chipsList$ | async)?.length"
-  [class.hidden]="singleLine"
-  [checker]="ready"
-  prizmElementReady
->
-  <ng-container *ngIf="prizmElementReady.ready$ | async">
-    <ng-container
-      *ngFor="let item of chipsList$ | async; let i = index; trackBy: trackByIdx"
-      [ngTemplateOutlet]="buttonTemplate"
-      [ngTemplateOutletContext]="{
-        item: item,
-        idx: i,
-        allChipsCount: (chipsList$ | async)?.length ?? 0,
-        parent: parent,
-        singleLine: singleLine
-      }"
-    >
-    </ng-container>
-
-    <ng-container *ngIf="overflowedChipsList$ | async as chipsOverflowedList">
-      <div
-        class="more-item"
-        *ngIf="chipsOverflowedList.size"
-        [prizmHint]="getOverflowedChipsListHint()"
-        [prizmHintDirection]="hintDirection"
+<ng-container *prizmLet="chipsList$ | async as chipsList">
+  <div
+    class="chips-list"
+    #prizmElementReady="prizmElementReady"
+    #parent
+    *ngIf="!!chipsList?.length"
+    [class.hidden]="singleLine"
+    [checker]="ready"
+    prizmElementReady
+  >
+    <ng-container *ngIf="prizmElementReady.ready$ | async">
+      <ng-container
+        *ngFor="let item of chipsList; let i = index; trackBy: trackByIdx"
+        [ngTemplateOutlet]="buttonTemplate"
+        [ngTemplateOutletContext]="{
+          item: item,
+          idx: i,
+          allChipsCount: chipsList?.length ?? 0,
+          parent: parent,
+          singleLine: singleLine
+        }"
       >
-        ...
-      </div>
+      </ng-container>
+
+      <ng-container *ngIf="overflowedChipsList$ | async as chipsOverflowedList">
+        <div
+          class="more-item"
+          *ngIf="chipsOverflowedList.size"
+          [prizmHint]="getOverflowedChipsListHint()"
+          [prizmHintDirection]="hintDirection"
+        >
+          ...
+        </div>
+      </ng-container>
     </ng-container>
-  </ng-container>
-</div>
+  </div>
+</ng-container>
 
 <ng-template
   #buttonTemplate

--- a/libs/components/src/lib/components/chips/chips.component.less
+++ b/libs/components/src/lib/components/chips/chips.component.less
@@ -31,5 +31,11 @@
       height: 18px;
       width: 100%;
     }
+
+    &:has(.more-item) {
+      prizm-chips-item.single-line {
+        max-width: calc(100% - 20px);
+      }
+    }
   }
 }


### PR DESCRIPTION
fix(components/chips): dots overflows chip list container https://github.com/zyfra/Prizm/issues/1713
refactor(components/chips): move multiply subscriptions to prizmLet


Исправлена ошибка в верстке при переполнении контейнера с чипсами в InputMultiSelect и InputChips singleLine.
Улучшили производительность компонента Chips с помощью оптимизации подписок в шаблоне.

_Обратить внимание при тестировании_
InputMultiSelect и InputChips, особенно состояние singleLine. Стоит проверить отступы справа внутри указанных компонентов.
Сценарий воспроизведения проблемы: выбрано больше одного чипса, ширина первого из выбранных чипсов превышает ширину контейнера. Соответствующий пример добавлен в InputMultiSelect, для InputChips доступен для воспроизведения в LiveDemo.

resolved https://github.com/zyfra/Prizm/issues/1713