### PR TITLE
fix(components/input-number): fix sync state with input-layout FOR V3 #1645 #1644

### DIFF
--- a/libs/components/src/lib/components/input/input-number/input-number.component.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.component.ts
@@ -32,7 +32,7 @@ import { PrizmHintDirective } from '../../../directives';
 export class PrizmInputNumberComponent extends PrizmInputControl<number> implements OnInit {
   private hasSymbol = false;
 
-  destroy$ = inject(PrizmDestroyService);
+  readonly destroy$ = inject(PrizmDestroyService);
   public get empty() {
     return this.el.nativeElement.value == '' && !this.hasSymbol;
   }
@@ -198,6 +198,7 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
     // this.overrideSetValueMethod();
     this.prizmHint_.ngOnInit();
     this.inputHint?.updateHint();
+    this.initUpdateParentOnChangeStatus();
 
     this.input$$
       .pipe(
@@ -213,6 +214,17 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
   public ngOnDestroy(): void {
     this.stateChanges.complete();
     this.prizmHint_.ngOnDestroy();
+  }
+
+  private initUpdateParentOnChangeStatus() {
+    this.ngControl?.statusChanges
+      ?.pipe(
+        tap(() => {
+          this.stateChanges.next();
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe();
   }
 
   // TODO change overriding later


### PR DESCRIPTION
fix(components/input-number): fix sync state with input-layout #1645 #1644


Исправлена синхронизация состояния компонента input-number с компонентом input-layout при disabled. Теперь кнопка очистки и рамки работают как у input-text
 Закрыты задачи №1645 и №1644.