### PR TITLE
fix(components/input-date-range): default time is set only after focus is removed for V4 #1565

### DIFF
--- a/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
@@ -307,6 +307,7 @@ export class PrizmInputLayoutDateTimeRangeComponent
   public onOpenChange(open: boolean): void {
     this.open = open;
     this.changeDetectorRef.markForCheck();
+    if (!open) this.completeDateIfAreNotPending();
   }
 
   private completeDateIfAreNotPending() {


### PR DESCRIPTION
fix(components/input-date-range): default time is set only after focus is removed #1565


Исправлено поведение компонента InputLayoutDateTimeRangeComponent, когда дефолтное время устанавливалось только после потери фокуса. Закрыта задача №1565.