### PR TITLE
fix(components/file-upload): newly uploaded files should not overwrte existing files array #1662

### DIFF
--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.html
@@ -1,8 +1,8 @@
 <prizm-file-upload
   [multiple]="true"
-  [accept]="'image/*'"
+  [accept]="acceptedTypes"
   [progress]="$any(progress$$ | async)"
-  [maxFilesCount]="3"
+  [maxFilesCount]="maxFiles"
   [maxFileSize]="1000000"
   [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
@@ -11,7 +11,9 @@
   (retry)="retry($event)"
 >
   <ng-container *prizmIfLang="'russian'; else eng">
-    Максимум три изображения размером не более 1МБ
+    Загружено {{ files.length }}/{{ maxFiles }}. {{ acceptedTypes }} размером не более 1МБ.
   </ng-container>
-  <ng-template #eng> Maximum of three images up to 1MB in size </ng-template>
+  <ng-template #eng>
+    Uploaded {{ files.length }}/{{ maxFiles }}. {{ acceptedTypes }} up to 1MB in size
+  </ng-template>
 </prizm-file-upload>

--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
@@ -13,6 +13,8 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
   progress$$ = new BehaviorSubject<PrizmFilesProgress>({});
   files: Array<File> = [];
   disabled = false;
+  acceptedTypes = 'image/*';
+  maxFiles = 3;
 
   public onFilesChange(files: Array<File>): void {
     this.files = files;

--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
@@ -17,8 +17,10 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
   maxFiles = 3;
 
   public onFilesChange(files: Array<File>): void {
-    if (files.length > 0) {
-      this.send(files.slice(this.files.length));
+    const filesToUpload = files.filter(file => !this.files.some(el => el === file));
+
+    if (filesToUpload.length > 0) {
+      this.send(filesToUpload);
     }
 
     this.files = files;

--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
@@ -45,7 +45,7 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
   public send(files: File[]): void {
     this.disabled = true;
     const formData = new FormData();
-    for (const file of this.files) {
+    for (const file of files) {
       formData.append(file.name, file);
     }
 

--- a/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/auto-upload/auto-upload.component.ts
@@ -17,10 +17,11 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
   maxFiles = 3;
 
   public onFilesChange(files: Array<File>): void {
-    this.files = files;
-    if (this.files.length > 0) {
-      this.send();
+    if (files.length > 0) {
+      this.send(files.slice(this.files.length));
     }
+
+    this.files = files;
   }
 
   public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {
@@ -41,7 +42,7 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
     });
   }
 
-  public send(): void {
+  public send(files: File[]): void {
     this.disabled = true;
     const formData = new FormData();
     for (const file of this.files) {
@@ -62,14 +63,14 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
               this.disabled = false;
 
               if (event.status >= 200 && event.status < 300) {
-                for (const file of this.files) {
+                for (const file of files) {
                   this.progress$$.next({
                     ...this.progress$$.value,
                     [file.name]: { progress: 100, error: false },
                   });
                 }
               } else {
-                for (const file of this.files) {
+                for (const file of files) {
                   this.progress$$.next({
                     ...this.progress$$.value,
                     [file.name]: { error: true },
@@ -80,7 +81,7 @@ export class PrizmFileAutoUploadExampleComponent implements OnDestroy {
               break;
             }
             case HttpEventType.UploadProgress: {
-              for (const file of this.files) {
+              for (const file of files) {
                 this.progress$$.next({
                   ...this.progress$$.value,
                   [file.name]: {

--- a/apps/doc/src/app/components/file-upload/examples/basic/basic.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/basic/basic.component.html
@@ -1,8 +1,8 @@
 <prizm-file-upload
   [multiple]="true"
-  [accept]="'image/*'"
+  [accept]="acceptedTypes"
   [progress]="$any(progress$$ | async)"
-  [maxFilesCount]="3"
+  [maxFilesCount]="maxFiles"
   [maxFileSize]="1000000"
   [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
@@ -11,9 +11,11 @@
   (retry)="retry($event)"
 >
   <ng-container *prizmIfLang="'russian'; else eng">
-    Максимум три изображения размером не более 1МБ
+    Загружено {{ files.length }}/{{ maxFiles }}. {{ acceptedTypes }} размером не более 1МБ.
   </ng-container>
-  <ng-template #eng> Maximum of three images up to 1MB in size </ng-template>
+  <ng-template #eng>
+    Uploaded {{ files.length }}/{{ maxFiles }}. {{ acceptedTypes }} up to 1MB in size
+  </ng-template>
 </prizm-file-upload>
 
 <button
@@ -24,5 +26,6 @@
   appearance="primary"
   size="m"
 >
-  Отправить
+  <ng-container *prizmIfLang="'russian'; else engBtn"> Отправить </ng-container>
+  <ng-template #engBtn> Upload </ng-template>
 </button>

--- a/apps/doc/src/app/components/file-upload/examples/basic/basic.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/basic/basic.component.ts
@@ -13,6 +13,8 @@ export class PrizmFileUploadBasicExampleComponent implements OnDestroy {
   progress$$ = new BehaviorSubject<PrizmFilesProgress>({});
   files: Array<File> = [];
   disabled = false;
+  acceptedTypes = 'image/*';
+  maxFiles = 3;
 
   public onFilesChange(files: Array<File>): void {
     console.log('fileschange');

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.html
@@ -1,8 +1,8 @@
 <prizm-file-upload
   [multiple]="true"
-  [accept]="'image/*'"
+  [accept]="acceptedTypes"
   [progress]="$any(progress$$ | async)"
-  [maxFilesCount]="3"
+  [maxFilesCount]="maxFiles"
   [maxFileSize]="1000000"
   [disabled]="disabled"
   (filesChange)="onFilesChange($event)"
@@ -11,7 +11,9 @@
   (retry)="retry($event)"
 >
   <ng-container *prizmIfLang="'russian'; else eng">
-    Максимум три изображения размером не более 1МБ
+    Загружено {{ files.length }}/{{ maxFiles }}. {{ acceptedTypes }} размером не более 1МБ.
   </ng-container>
-  <ng-template #eng> Maximum of three images up to 1MB in size </ng-template>
+  <ng-template #eng>
+    Uploaded {{ files.length }}/{{ maxFiles }}. {{ acceptedTypes }} up to 1MB in size
+  </ng-template>
 </prizm-file-upload>

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -15,10 +15,13 @@ export class PrizmFileUploadI18nExampleComponent {
   maxFiles = 3;
 
   public onFilesChange(files: Array<File>): void {
-    this.files = files;
-    if (files.length > 0) {
-      this.send(files.slice(files.length));
+    const filesToUpload = files.filter(file => !this.files.some(el => el === file));
+
+    if (filesToUpload.length > 0) {
+      this.send(filesToUpload);
     }
+
+    this.files = files;
   }
 
   public onfilesValidationErrors(errors: { [key: string]: PrizmFileValidationErrors }): void {

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -11,6 +11,8 @@ export class PrizmFileUploadI18nExampleComponent {
   progress$$ = new BehaviorSubject<PrizmFilesProgress>({});
   files: Array<File> = [];
   disabled = false;
+  acceptedTypes = 'image/*';
+  maxFiles = 3;
 
   public onFilesChange(files: Array<File>): void {
     this.files = files;

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -17,7 +17,7 @@ export class PrizmFileUploadI18nExampleComponent {
   public onFilesChange(files: Array<File>): void {
     this.files = files;
     if (this.files.length > 0) {
-      this.send();
+      this.send(files.slice(this.files.length));
     }
   }
 
@@ -39,10 +39,10 @@ export class PrizmFileUploadI18nExampleComponent {
     });
   }
 
-  public send(): void {
+  public send(files: File[]): void {
     this.disabled = true;
     const formData = new FormData();
-    for (const file of this.files) {
+    for (const file of files) {
       formData.append(file.name, file);
     }
 
@@ -60,14 +60,14 @@ export class PrizmFileUploadI18nExampleComponent {
               this.disabled = false;
 
               if (event.status >= 200 && event.status < 300) {
-                for (const file of this.files) {
+                for (const file of files) {
                   this.progress$$.next({
                     ...this.progress$$.value,
                     [file.name]: { progress: 100, error: false },
                   });
                 }
               } else {
-                for (const file of this.files) {
+                for (const file of files) {
                   this.progress$$.next({
                     ...this.progress$$.value,
                     [file.name]: { error: true },
@@ -78,7 +78,7 @@ export class PrizmFileUploadI18nExampleComponent {
               break;
             }
             case HttpEventType.UploadProgress: {
-              for (const file of this.files) {
+              for (const file of files) {
                 this.progress$$.next({
                   ...this.progress$$.value,
                   [file.name]: {

--- a/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/examples/i18n/file-upload-i18n-example.component.ts
@@ -16,8 +16,8 @@ export class PrizmFileUploadI18nExampleComponent {
 
   public onFilesChange(files: Array<File>): void {
     this.files = files;
-    if (this.files.length > 0) {
-      this.send(files.slice(this.files.length));
+    if (files.length > 0) {
+      this.send(files.slice(files.length));
     }
   }
 

--- a/apps/doc/src/app/components/file-upload/file-upload-example.component.ts
+++ b/apps/doc/src/app/components/file-upload/file-upload-example.component.ts
@@ -47,6 +47,8 @@ export class PrizmFileUploadExampleComponent implements OnDestroy {
   files: Array<File> = [];
   disabled = false;
 
+  constructor(private readonly toastService: PrizmToastService, private http: HttpClient) {}
+
   public onFilesChange(files: Array<File>): void {
     this.files = files;
   }
@@ -179,8 +181,6 @@ export class PrizmFileUploadExampleComponent implements OnDestroy {
         }
       );
   }
-
-  constructor(private readonly toastService: PrizmToastService, private http: HttpClient) {}
 
   public ngOnDestroy(): void {
     this.progress$$.complete();

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -21,7 +21,7 @@
 
     <button
       class="dropzone__file-select"
-      [disabled]="disabled || files.length >= maxFilesCount"
+      [disabled]="disabled || files.length >= calculatedMaxFilesCount"
       (click)="inputFile.click()"
       type="button"
       prizmButton

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -21,7 +21,7 @@
 
     <button
       class="dropzone__file-select"
-      [disabled]="disabled || files.length >= calculatedMaxFilesCount"
+      [disabled]="disabled || (multiple && files.length >= calculatedMaxFilesCount)"
       (click)="inputFile.click()"
       type="button"
       prizmButton

--- a/libs/components/src/lib/components/file-upload/file-upload.component.html
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.html
@@ -21,7 +21,7 @@
 
     <button
       class="dropzone__file-select"
-      [disabled]="disabled"
+      [disabled]="disabled || files.length >= maxFilesCount"
       (click)="inputFile.click()"
       type="button"
       prizmButton

--- a/libs/components/src/lib/components/file-upload/file-upload.component.less
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.less
@@ -119,6 +119,7 @@
     font-size: 10px;
     line-height: 12px;
     color: var(--prizm-text-icon-tertiary);
+    white-space: nowrap;
   }
 
   &__stage {

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -271,9 +271,11 @@ export class PrizmFileUploadComponent
     }
 
     this.beforeFilesChange.next();
-    if (filteredFiles.length > this.calculatedMaxFilesCount) {
-      this.filesCountError.next(filteredFiles.slice(this.calculatedMaxFilesCount).map(file => file.name));
-      filteredFiles.length = this.calculatedMaxFilesCount;
+
+    const filesCountDelta = this.calculatedMaxFilesCount - this.files.length;
+    if (filteredFiles.length + this.files.length > this.calculatedMaxFilesCount) {
+      this.filesCountError.next(filteredFiles.slice(filesCountDelta).map(file => file.name));
+      filteredFiles.length = filesCountDelta;
     }
 
     this.emitValidationErrors();

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -152,7 +152,7 @@ export class PrizmFileUploadComponent
       this.calculatedMaxFilesCount = this.multiple ? this._maxFilesCount : 1;
     }
 
-    if (this.files.length > this.calculatedMaxFilesCount && this.multiple) {
+    if (this.files.length > this.calculatedMaxFilesCount) {
       this.filesCountError.next(this.files.slice(this.calculatedMaxFilesCount).map(file => file.name));
     }
   }
@@ -272,17 +272,25 @@ export class PrizmFileUploadComponent
 
     this.beforeFilesChange.next();
 
-    const filesCountDelta = this.calculatedMaxFilesCount - this.files.length;
-    if (filteredFiles.length + this.files.length > this.calculatedMaxFilesCount && this.multiple) {
-      this.filesCountError.next(filteredFiles.slice(filesCountDelta).map(file => file.name));
-      filteredFiles.length = filesCountDelta;
+    if (this.multiple) {
+      const filesCountDelta = this.calculatedMaxFilesCount - this.files.length;
+
+      if (filteredFiles.length + this.files.length > this.calculatedMaxFilesCount) {
+        this.filesCountError.next(filteredFiles.slice(filesCountDelta).map(file => file.name));
+        filteredFiles.length = filesCountDelta;
+      }
+    }
+
+    if (!this.multiple) {
+      if (filteredFiles.length > 1) {
+        this.filesCountError.next(filteredFiles.slice(1).map(file => file.name));
+        filteredFiles.length = 1;
+      }
+
+      this.clearFiles({ emitEvent: false });
     }
 
     this.emitValidationErrors();
-
-    if (!this.multiple) {
-      this.clearFiles({ emitEvent: false });
-    }
 
     for (const file of filteredFiles) {
       this.filesMap.set(file.name, {

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -6,10 +6,12 @@ import {
   EventEmitter,
   Inject,
   Input,
+  OnChanges,
   OnDestroy,
   Optional,
   Output,
   Renderer2,
+  SimpleChanges,
   ViewChild,
   inject,
 } from '@angular/core';
@@ -72,12 +74,16 @@ import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
   standalone: true,
   providers: [PrizmDestroyService, ...prizmI18nInitWithKey(PRIZM_FILE_UPLOAD, 'fileUpload')],
 })
-export class PrizmFileUploadComponent extends PrizmAbstractTestId implements AfterViewInit, OnDestroy {
+export class PrizmFileUploadComponent
+  extends PrizmAbstractTestId
+  implements OnChanges, AfterViewInit, OnDestroy
+{
   @ViewChild('dropzone') dropzoneElementRef!: ElementRef<HTMLDivElement>;
 
   override readonly testId_ = 'ui_file_upload';
   readonly icon = prizmIconsFileEmpty;
   readonly prizmIsTextOverflow = prizmIsTextOverflow;
+  public calculatedMaxFilesCount = Number.MAX_SAFE_INTEGER;
 
   options: PrizmFileUploadOptions = { ...prizmFileUploadDefaultOptions };
 
@@ -102,10 +108,15 @@ export class PrizmFileUploadComponent extends PrizmAbstractTestId implements Aft
 
   private validationErrors: { [filename: string]: PrizmFileValidationErrors } = {};
 
+  private _maxFilesCount = Number.MAX_SAFE_INTEGER;
+
   @Input() accept = '';
   @Input() multiple = false;
   @Input() maxFileSize = Number.MAX_SAFE_INTEGER;
-  @Input() maxFilesCount = Number.MAX_SAFE_INTEGER;
+  @Input() set maxFilesCount(value: number) {
+    this._maxFilesCount = value ?? Number.MAX_SAFE_INTEGER;
+    this.calculatedMaxFilesCount = this.multiple ? this._maxFilesCount : 1;
+  }
 
   @Input()
   get disabled() {
@@ -134,6 +145,16 @@ export class PrizmFileUploadComponent extends PrizmAbstractTestId implements Aft
 
   get files(): Array<File> {
     return [...this.filesMap.entries()].map(([_, { file }]) => file);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.multiple || changes.maxFilesCount) {
+      this.calculatedMaxFilesCount = this.multiple ? this._maxFilesCount : 1;
+    }
+
+    if (this.files.length > this.calculatedMaxFilesCount) {
+      this.filesCountError.next(this.files.slice(this.calculatedMaxFilesCount).map(file => file.name));
+    }
   }
 
   public ngAfterViewInit(): void {
@@ -250,10 +271,9 @@ export class PrizmFileUploadComponent extends PrizmAbstractTestId implements Aft
     }
 
     this.beforeFilesChange.next();
-
-    if (filteredFiles.length > this.maxFilesCount) {
-      this.filesCountError.next(filteredFiles.slice(this.maxFilesCount).map(file => file.name));
-      filteredFiles.length = this.maxFilesCount;
+    if (filteredFiles.length > this.calculatedMaxFilesCount) {
+      this.filesCountError.next(filteredFiles.slice(this.calculatedMaxFilesCount).map(file => file.name));
+      filteredFiles.length = this.calculatedMaxFilesCount;
     }
 
     this.emitValidationErrors();

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -258,7 +258,9 @@ export class PrizmFileUploadComponent extends PrizmAbstractTestId implements Aft
 
     this.emitValidationErrors();
 
-    this.clearFiles({ emitEvent: false });
+    if (!this.multiple) {
+      this.clearFiles({ emitEvent: false });
+    }
 
     for (const file of filteredFiles) {
       this.filesMap.set(file.name, {

--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -152,7 +152,7 @@ export class PrizmFileUploadComponent
       this.calculatedMaxFilesCount = this.multiple ? this._maxFilesCount : 1;
     }
 
-    if (this.files.length > this.calculatedMaxFilesCount) {
+    if (this.files.length > this.calculatedMaxFilesCount && this.multiple) {
       this.filesCountError.next(this.files.slice(this.calculatedMaxFilesCount).map(file => file.name));
     }
   }
@@ -273,7 +273,7 @@ export class PrizmFileUploadComponent
     this.beforeFilesChange.next();
 
     const filesCountDelta = this.calculatedMaxFilesCount - this.files.length;
-    if (filteredFiles.length + this.files.length > this.calculatedMaxFilesCount) {
+    if (filteredFiles.length + this.files.length > this.calculatedMaxFilesCount && this.multiple) {
       this.filesCountError.next(filteredFiles.slice(filesCountDelta).map(file => file.name));
       filteredFiles.length = filesCountDelta;
     }

--- a/libs/components/src/lib/components/file-upload/pipes/file-size.pipe.ts
+++ b/libs/components/src/lib/components/file-upload/pipes/file-size.pipe.ts
@@ -4,11 +4,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class PrizmFileSizePipe implements PipeTransform {
   public transform(size: number): string {
     if (size < 1024) {
-      return size + 'bytes';
+      return size + ' byte/bytes';
     } else if (size > 1024 && size < 1048576) {
-      return (size / 1024).toFixed(1) + 'KB';
+      return (size / 1024).toFixed(1) + ' KB';
     } else if (size > 1048576) {
-      return (size / 1048576).toFixed(1) + 'MB';
+      return (size / 1048576).toFixed(1) + ' MB';
     }
 
     return '';

--- a/libs/components/src/lib/components/file-upload/pipes/file-size.pipe.ts
+++ b/libs/components/src/lib/components/file-upload/pipes/file-size.pipe.ts
@@ -5,9 +5,9 @@ export class PrizmFileSizePipe implements PipeTransform {
   public transform(size: number): string {
     if (size < 1024) {
       return size + ' byte/bytes';
-    } else if (size > 1024 && size < 1048576) {
+    } else if (size >= 1024 && size < 1048576) {
       return (size / 1024).toFixed(1) + ' KB';
-    } else if (size > 1048576) {
+    } else if (size >= 1048576) {
       return (size / 1048576).toFixed(1) + ' MB';
     }
 


### PR DESCRIPTION
fix(components/file-upload): newly uploaded files should not overwrte existing files array #1662
fix(components/file-upload): multiply false paramenter works incorrect with uploading by drop #1770
fix(components/file-upload):  file size text small fixes 

### Библиотека

- [ ] `@prizm-ui/core`
- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/flag-icons`
- [ ] `@prizm-ui/theme`
- [ ] `@prizm-ui/charts`
- [ ] `@prizm-ui/ast`
- [ ] `@prizm-ui/nx-plugin`

### Компонент

file-upload

### Задача

resolved #1662
resolved #1770  

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Работа компонента file upload, компонент отдает все загруженные файлы, событие ошибки на количество файлов отрабатывает корректно для multiply=false

### Описание

Исправлена ошибка с перетиранием ранее добавленных файлов в file upload при значении multiply = true. Так же доработан пример использования компонента при ограничении количества добавляемых файлов: пользовательский текст стал более информативным.
Поправили поведение дроп-зоны при значении multiply false, теперь при добавлении более одного файла компонент отправляет событие ошибки. 
Обновили тексты для описания размера файлов.