### PR TITLE
fix(components/panel): rename panel component to name with prefix #1665

### DIFF
--- a/apps/doc/src/app/components/panel/examples/setup-module.md
+++ b/apps/doc/src/app/components/panel/examples/setup-module.md
@@ -1,13 +1,13 @@
 ```ts
 import { NgModule } from '@angular/core';
-import { PrizmPanelModule } from '@prizm-ui/components';
+import { PrizmPanelComponent } from '@prizm-ui/components';
 
 // ...
 
 @NgModule({
   imports: [
     // ...
-    PrizmPanelModule,
+    PrizmPanelComponent,
   ],
 })
 export class MyModule {}

--- a/apps/doc/src/app/components/panel/panel-example.module.ts
+++ b/apps/doc/src/app/components/panel/panel-example.module.ts
@@ -7,7 +7,7 @@ import { RouterModule } from '@angular/router';
 import {
   PrizmBreadcrumbsModule,
   PrizmButtonModule,
-  PrizmPanelModule,
+  PrizmPanelComponent,
   PrizmTabsModule,
   PrizmToggleComponent,
 } from '@prizm-ui/components';
@@ -34,7 +34,7 @@ import { FormsModule } from '@angular/forms';
     CommonModule,
     PrizmAddonDocModule,
     RouterModule.forChild(prizmDocGenerateRoutes(PanelExampleComponent)),
-    PrizmPanelModule,
+    PrizmPanelComponent,
     PrizmButtonModule,
     FormsModule,
     PrizmToggleComponent,

--- a/libs/components/src/lib/components/panel/panel.component.ts
+++ b/libs/components/src/lib/components/panel/panel.component.ts
@@ -1,22 +1,26 @@
 import {
-  Component,
   ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  inject,
   Input,
   Output,
-  EventEmitter,
   ViewChild,
-  ElementRef,
-  inject,
 } from '@angular/core';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsArrowLeft } from '@prizm-ui/icons/full/source';
+import { CommonModule } from '@angular/common';
+import { PrizmButtonComponent } from '../button';
 
 @Component({
   selector: 'prizm-panel',
   templateUrl: './panel.component.html',
   styleUrls: ['./panel.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [CommonModule, PrizmButtonComponent],
 })
 export class PanelComponent extends PrizmAbstractTestId {
   @Input() withBackButton = false;
@@ -39,3 +43,5 @@ export class PanelComponent extends PrizmAbstractTestId {
     this.backClick.emit();
   }
 }
+
+export const PrizmPanelComponent = PanelComponent;

--- a/libs/components/src/lib/components/panel/panel.module.ts
+++ b/libs/components/src/lib/components/panel/panel.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { PanelComponent } from './panel.component';
-import { PrizmButtonComponent } from '../button';
+import { PrizmPanelComponent } from './panel.component';
 
+/**
+ * @deprecated
+ * use standalone
+ * */
 @NgModule({
-  declarations: [PanelComponent],
-  imports: [CommonModule, PrizmButtonComponent],
-  exports: [PanelComponent],
+  imports: [PrizmPanelComponent],
+  exports: [PrizmPanelComponent],
 })
 export class PrizmPanelModule {}


### PR DESCRIPTION
- fix(components/panel): add prefix prizm to panel component #1665
- fix(components/panel): converted panelcomponent to standalone #1665

### Release Notes

#### Исправления

- **Компоненты**: Исправлен экспорт `PanelComponent` без префикса `Prizm` в библиотеке `@prizm-ui/components`. Теперь компонент экспортируется как `PrizmPanelComponent`. Также компонент был переведен в режим standalone. (#1665)






