### PR TITLE
fix(components/panel): rename panel component to name with prefix V3 #1665

### DIFF
--- a/apps/doc/src/app/components/panel/examples/setup-module.md
+++ b/apps/doc/src/app/components/panel/examples/setup-module.md
@@ -1,13 +1,13 @@
 ```ts
 import { NgModule } from '@angular/core';
-import { PrizmPanelModule } from '@prizm-ui/components';
+import { PrizmPanelComponent } from '@prizm-ui/components';
 
 // ...
 
 @NgModule({
   imports: [
     // ...
-    PrizmPanelModule,
+    PrizmPanelComponent,
   ],
 })
 export class MyModule {}

--- a/apps/doc/src/app/components/panel/panel-example.module.ts
+++ b/apps/doc/src/app/components/panel/panel-example.module.ts
@@ -8,7 +8,7 @@ import {
   PrizmBreadcrumbsModule,
   PrizmButtonModule,
   PrizmIconModule,
-  PrizmPanelModule,
+  PrizmPanelComponent,
   PrizmTabsModule,
   PrizmToggleModule,
 } from '@prizm-ui/components';
@@ -35,7 +35,7 @@ import { FormsModule } from '@angular/forms';
     CommonModule,
     PrizmAddonDocModule,
     RouterModule.forChild(prizmDocGenerateRoutes(PanelExampleComponent)),
-    PrizmPanelModule,
+    PrizmPanelComponent,
     PrizmButtonModule,
     PrizmIconModule,
     FormsModule,

--- a/libs/components/src/lib/components/panel/panel.component.ts
+++ b/libs/components/src/lib/components/panel/panel.component.ts
@@ -8,11 +8,16 @@ import {
   ElementRef,
 } from '@angular/core';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
+import { CommonModule } from '@angular/common';
+import { PrizmIconModule } from '../icon';
+import { PrizmButtonModule } from '../button';
 
 @Component({
   selector: 'prizm-panel',
   templateUrl: './panel.component.html',
   styleUrls: ['./panel.component.less'],
+  standalone: true,
+  imports: [CommonModule, PrizmIconModule, PrizmButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PanelComponent extends PrizmAbstractTestId {
@@ -29,3 +34,5 @@ export class PanelComponent extends PrizmAbstractTestId {
     this.backClick.emit();
   }
 }
+
+export const PrizmPanelComponent = PanelComponent;

--- a/libs/components/src/lib/components/panel/panel.module.ts
+++ b/libs/components/src/lib/components/panel/panel.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { PanelComponent } from './panel.component';
-import { PrizmIconModule } from '../icon';
-import { PrizmButtonModule } from '../button';
+import { PrizmPanelComponent } from './panel.component';
 
+/**
+ * @deprecated
+ * use standalone
+ * */
 @NgModule({
-  declarations: [PanelComponent],
-  imports: [CommonModule, PrizmIconModule, PrizmButtonModule],
-  exports: [PanelComponent],
+  imports: [PrizmPanelComponent],
+  exports: [PrizmPanelComponent],
 })
 export class PrizmPanelModule {}


### PR DESCRIPTION
- fix(components/panel): add prefix prizm to panel component #1665
- fix(components/panel): converted panelcomponent to standalone #1665

### Release Notes

#### Исправления

- **Компоненты**: Исправлен экспорт `PanelComponent` без префикса `Prizm` в библиотеке `@prizm-ui/components`. Теперь компонент экспортируется как `PrizmPanelComponent`. Также компонент был переведен в режим standalone. (#1665)






