### PR TITLE
fix(components/input-date-range): added corrector if from is more than to #1628

### DIFF
--- a/libs/components/src/lib/@core/date-time/day.ts
+++ b/libs/components/src/lib/@core/date-time/day.ts
@@ -388,6 +388,14 @@ export class PrizmDay extends PrizmMonth {
     return new Date(this.year, this.month, this.day);
   }
 
+  public getTime(): number {
+    return this.toLocalNativeDate().getTime();
+  }
+
+  public copy(): PrizmDay {
+    return PrizmDay.fromLocalNativeDate(this.toLocalNativeDate());
+  }
+
   /**
    * Returns native {@link Date} based on UTC
    */


### PR DESCRIPTION
fix(components/input-date-range): added corrector if from is more than to #1628


**Release Notes**

### Версия 

**Компонент**: InputLayoutDateRange

**Описание изменения**:
В данной версии был исправлен баг, связанный с вводом диапазона дат вручную. Теперь, если дата начала больше даты окончания, автоматически применяется корректировка, предотвращающая ввод некорректных данных. Это улучшение гарантирует, что при ручном вводе дат диапазон всегда будет корректен, как и при использовании календаря. 

**Исправление**:
- Исправлена возможность ввода даты начала, превышающей дату окончания при ручном вводе (fix(components/input-date-range): added corrector if from is more than to #1628).
