### PR TITLE
fix(components/input-date-range): added corrector if from is more than to in v3 #1628

### DIFF
--- a/libs/components/src/lib/@core/date-time/day.ts
+++ b/libs/components/src/lib/@core/date-time/day.ts
@@ -388,6 +388,14 @@ export class PrizmDay extends PrizmMonth {
     return new Date(this.year, this.month, this.day);
   }
 
+  public getTime(): number {
+    return this.toLocalNativeDate().getTime();
+  }
+
+  public copy(): PrizmDay {
+    return PrizmDay.fromLocalNativeDate(this.toLocalNativeDate());
+  }
+
   /**
    * Returns native {@link Date} based on UTC
    */

--- a/libs/components/src/lib/components/input/input-date-range/input-layout-date-range.component.ts
+++ b/libs/components/src/lib/components/input/input-date-range/input-layout-date-range.component.ts
@@ -217,29 +217,58 @@ export class PrizmInputLayoutDateRangeComponent extends PrizmInputNgControl<Priz
   }
 
   public onValueFromChange(value: string, isFromValue: boolean): void {
-    // clear from mask
+    // Clear from mask
     value = value.replace(/[_]/g, '');
 
-    if (isFromValue && value === this.fromValue) return;
-    if (!isFromValue && value === this.toValue) return;
-    this.nativeValue$$.next(
-      isFromValue ? [value, this.nativeValue$$.value[1]] : [this.nativeValue$$.value[0], value]
-    );
+    const currentValue = isFromValue ? this.fromValue : this.toValue;
+    if (value === currentValue) return;
+
+    const otherValue = isFromValue ? this.nativeValue$$.value[1] : this.nativeValue$$.value[0];
+    this.nativeValue$$.next(isFromValue ? [value, otherValue] : [otherValue, value]);
+
     if (value == null) {
       this.onOpenChange(true);
     }
 
     if (!value || value.length !== this.computedSingleMask.length) {
-      if (!value && isFromValue && !this.value?.to && !isFromValue && !this.value?.from)
+      if (!value && isFromValue && !this.value?.to && !isFromValue && !this.value?.from) {
         this.updateValue(null);
+      }
       return;
     }
 
     const parsedValue = PrizmDay.normalizeParse(value, this.dateFormat);
-    this.updateWithCorrectDateAndTime(
-      isFromValue ? parsedValue : (this.value?.from as any),
-      isFromValue ? this.value?.to : (parsedValue as any)
+    const [parsedFromValue, parsedToValue] = this.ensureCorrectDateOrder(
+      isFromValue,
+      isFromValue ? parsedValue : this.value?.from,
+      isFromValue ? this.value?.to : parsedValue
     );
+
+    this.updateWithCorrectDateAndTime(parsedFromValue ?? null, parsedToValue ?? null);
+  }
+
+  /**
+   * Ensures that the date range is valid by adjusting the fromValue and toValue if necessary.
+   * If the fromValue is later than the toValue, it corrects the order based on the isFromValue flag.
+   *
+   * @param isFromValue - A boolean indicating if the change was made to the fromValue.
+   * @param fromValue - The starting date of the range.
+   * @param toValue - The ending date of the range.
+   * @returns A tuple containing the corrected fromValue and toValue.
+   */
+  private ensureCorrectDateOrder(
+    isFromValue: boolean,
+    fromValue?: PrizmDay,
+    toValue?: PrizmDay
+  ): [typeof fromValue, typeof toValue] {
+    if (fromValue && toValue && fromValue.getTime() > toValue.getTime()) {
+      if (isFromValue) {
+        fromValue = toValue.copy();
+      } else {
+        toValue = fromValue.copy();
+      }
+    }
+    return [fromValue, toValue];
   }
 
   public onRangeChange(range: PrizmDayRange | null): void {


### PR DESCRIPTION
fix(components/input-date-range): added corrector if from is more than to #1628

**Release Notes**

### Версия

**Компонент**: InputLayoutDateRange

**Описание изменения**:
В данной версии был исправлен баг, связанный с вводом диапазона дат вручную. Теперь, если дата начала больше даты окончания, автоматически применяется корректировка, предотвращающая ввод некорректных данных. Это улучшение гарантирует, что при ручном вводе дат диапазон всегда будет корректен, как и при использовании календаря. 

**Исправление**:
- Исправлена возможность ввода даты начала, превышающей дату окончания при ручном вводе (fix(components/input-date-range): added corrector if from is more than to #1628).
