### PR TITLE
fix(docs/tab): remove $any from basic example #841

### DIFF
--- a/apps/doc/src/app/components/tabs/examples/tabs-example-basic/tabs-example-basic.component.html
+++ b/apps/doc/src/app/components/tabs/examples/tabs-example-basic/tabs-example-basic.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <prizm-tabs [(activeTabIndex)]="activeTabIndex">
-    <prizm-tab *ngFor="let item of tabs" [content]="$any(item.title)" [type]="'line'"> </prizm-tab>
+    <prizm-tab *ngFor="let item of tabs" [content]="item.title ?? ''" [type]="'line'"> </prizm-tab>
   </prizm-tabs>
 </div>
 


### PR DESCRIPTION
fix(docs/tab): remove $any from basic example #841

### Release Notes

#### @prizm-ui/components

**Компонент:** prizm-tab

- Исправлена ошибка в документации, связанная с примером использования свойства [content] компонента prizm-tab. Теперь пример корректно демонстрирует использование типа PolymorphContent<PrizmTabContext> вместо string | number | undefined, что устраняет проблему несовместимости типов. (#841)