### PR TITLE
fix(components/hint): update overlay only when changes deps #1719 #716

### DIFF
--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -13,7 +13,7 @@ import {
   SimpleChanges,
   Type,
 } from '@angular/core';
-import { PrizmDestroyService, prizmGenerateId } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmGenerateId, prizmHasChanges } from '@prizm-ui/helpers';
 import { prizmDefaultProp, prizmRequiredSetter } from '@prizm-ui/core';
 import { PolymorphContent } from '../polymorph';
 import { PRIZM_HINT_OPTIONS, PrizmHintContext, PrizmHintOptions } from './hint-options';
@@ -109,7 +109,7 @@ export class PrizmHintDirective<
   public onHoverActive: boolean = true;
 
   content!: PolymorphContent;
-  overlay!: PrizmOverlayControl;
+  overlay?: PrizmOverlayControl;
   public containerComponent: Type<unknown> = PrizmHintContainerComponent;
   public readonly show$ = new Subject<boolean>();
   protected readonly destroyListeners$ = new Subject<void>();
@@ -133,7 +133,11 @@ export class PrizmHintDirective<
 
   public ngOnChanges(changes?: SimpleChanges): void {
     this.show_ = false;
-    this.initOverlayController();
+    if (
+      prizmHasChanges(changes, ['prizmHintHost', 'prizmHint', 'prizmHintCanShow', 'prizmHintContext'], false)
+    ) {
+      this.initOverlayController();
+    }
   }
 
   public ngOnInit(): void {
@@ -154,7 +158,7 @@ export class PrizmHintDirective<
   }
 
   public ngOnDestroy(): void {
-    if (this.overlay) this.overlay.close();
+    this.overlay?.close();
   }
 
   public toggle(open: boolean): void {
@@ -170,7 +174,7 @@ export class PrizmHintDirective<
     if (!this.prizmHintCanShow || this.content === '') return;
     this.show_ = true;
     this.renderer.addClass(this.elementRef.nativeElement, HINT_HOVERED_CLASS);
-    this.overlay.open();
+    this.overlay?.open();
     this.prizmHoveredChange$$.next(this.show_);
   }
 


### PR DESCRIPTION
fix(components/hint): safe update overlay only when changes dependencies #1719 #716




### Release Notes

#### Исправления

- **Компонент PrizmHint:**
  - Исправлена ошибка, при которой хинты отображались инверсивно после переключения локализации. Теперь хинты корректно появляются при наведении курсора на иконку и исчезают при его уводе. (#1719, #716)
  - Устранена проблема с задержкой отображения подсказок при переключении направления сплиттера с горизонтального на вертикальное. Теперь подсказки появляются и исчезают своевременно в зависимости от вычисляемого текста ([prizmHint]="..."). (#1719, #716)
