### PR TITLE
fix(components/hint): update overlay only when changes deps #1719 #716

### DIFF
--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -10,9 +10,10 @@ import {
   OnInit,
   Output,
   Renderer2,
+  SimpleChanges,
   Type,
 } from '@angular/core';
-import { PrizmDestroyService, prizmGenerateId } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmGenerateId, prizmHasChanges } from '@prizm-ui/helpers';
 import { prizmDefaultProp, prizmRequiredSetter } from '@prizm-ui/core';
 import { PolymorphContent } from '../polymorph';
 import { PRIZM_HINT_OPTIONS, PrizmHintContext, PrizmHintOptions } from './hint-options';
@@ -108,7 +109,7 @@ export class PrizmHintDirective<
   protected readonly onHoverActive: boolean = true;
 
   content!: PolymorphContent;
-  overlay!: PrizmOverlayControl;
+  overlay?: PrizmOverlayControl;
   protected readonly containerComponent: Type<unknown> = PrizmHintContainerComponent;
   protected readonly show$ = new Subject<boolean>();
   protected readonly destroyListeners$ = new Subject<void>();
@@ -130,8 +131,13 @@ export class PrizmHintDirective<
     return this.prizmHintHost ?? this.elementRef.nativeElement;
   }
 
-  public ngOnChanges(): void {
-    this.initOverlayController();
+  public ngOnChanges(changes?: SimpleChanges): void {
+    this.show_ = false;
+    if (
+      prizmHasChanges(changes, ['prizmHintHost', 'prizmHint', 'prizmHintCanShow', 'prizmHintContext'], false)
+    ) {
+      this.initOverlayController();
+    }
   }
 
   public ngOnInit(): void {
@@ -152,7 +158,7 @@ export class PrizmHintDirective<
   }
 
   public ngOnDestroy(): void {
-    if (this.overlay) this.overlay.close();
+    this.overlay?.close();
   }
 
   public toggle(open: boolean): void {
@@ -167,7 +173,7 @@ export class PrizmHintDirective<
     if (!this.prizmHintCanShow || this.content === '') return;
     this.show_ = true;
     this.renderer.addClass(this.elementRef.nativeElement, HINT_HOVERED_CLASS);
-    this.overlay.open();
+    this.overlay?.open();
     this.prizmHoveredChange$$.next(!this.show_);
   }
 

--- a/libs/helpers/src/lib/util/directive.spec.ts
+++ b/libs/helpers/src/lib/util/directive.spec.ts
@@ -1,0 +1,73 @@
+import { SimpleChanges } from '@angular/core';
+import { prizmHasChanges } from './directive';
+
+describe('prizmHasChanges', () => {
+  // Тест 1: Функция возвращает false, если объект changes не определен
+  test('should return false if changes are undefined', () => {
+    expect(prizmHasChanges(undefined, 'propertyName')).toBe(false);
+  });
+
+  // Тест 2: Функция возвращает true, если свойство изменилось и не игнорируется первое изменение
+  test('should return true if property has changed and first change is not ignored', () => {
+    const changes: SimpleChanges = {
+      propertyName: {
+        currentValue: 'new value',
+        previousValue: 'old value',
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+    };
+    expect(prizmHasChanges(changes, 'propertyName')).toBe(true);
+  });
+
+  // Тест 3: Функция возвращает false, если свойство изменилось, но это первое изменение и оно игнорируется
+  test('should return false if property has changed but it is the first change and ignored', () => {
+    const changes: SimpleChanges = {
+      propertyName: {
+        currentValue: 'value',
+        previousValue: null,
+        firstChange: true,
+        isFirstChange: () => true,
+      },
+    };
+    expect(prizmHasChanges(changes, 'propertyName', true)).toBe(false);
+  });
+
+  // Тест 4: Функция возвращает true, если хотя бы одно из указанных свойств изменилось
+  test('should return true if at least one of the specified properties has changed', () => {
+    const changes: SimpleChanges = {
+      firstProperty: {
+        currentValue: 'new value',
+        previousValue: 'old value',
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+      secondProperty: {
+        currentValue: 'new value',
+        previousValue: 'old value',
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+    };
+    expect(prizmHasChanges(changes, ['firstProperty', 'secondProperty'])).toBe(true);
+  });
+
+  // Тест 5: Функция возвращает false, если ни одно из указанных свойств не изменилось
+  test('should return false if none of the specified properties have changed', () => {
+    const changes: SimpleChanges = {
+      firstProperty: {
+        currentValue: 'value',
+        previousValue: 'value',
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+      secondProperty: {
+        currentValue: 'value',
+        previousValue: 'value',
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+    };
+    expect(prizmHasChanges(changes, ['firstProperty', 'secondProperty'])).toBe(false);
+  });
+});

--- a/libs/helpers/src/lib/util/directive.ts
+++ b/libs/helpers/src/lib/util/directive.ts
@@ -1,0 +1,29 @@
+import { SimpleChanges } from '@angular/core';
+
+export function prizmHasChanges(
+  changes: SimpleChanges | undefined,
+  name: string,
+  ignoreFirstChange?: boolean
+): boolean;
+export function prizmHasChanges(
+  changes: SimpleChanges | undefined,
+  names: string[],
+  ignoreFirstChange?: boolean
+): boolean;
+export function prizmHasChanges(
+  changes: SimpleChanges | undefined,
+  names: string | string[],
+  ignoreFirstChange = false
+): boolean {
+  if (!changes) return false;
+
+  const nameArray = Array.isArray(names) ? names : [names];
+
+  return nameArray.some(name => {
+    return (
+      name in changes &&
+      !(ignoreFirstChange && changes[name].isFirstChange()) &&
+      changes[name].previousValue !== changes[name].currentValue
+    );
+  });
+}

--- a/libs/helpers/src/lib/util/index.ts
+++ b/libs/helpers/src/lib/util/index.ts
@@ -6,3 +6,4 @@ export * from './decorators';
 export * from './uuid';
 export * from './style';
 export * from './number';
+export * from './directive';


### PR DESCRIPTION
fix(components/hint): safe update overlay only when changes dependencies and moved method prizmHasChanges #1719 #716
feat(helpers): added prizmHasChanged  helper.




### Release Notes

#### Исправления

- **Компонент PrizmHint:**
  - Исправлена ошибка, при которой хинты отображались инверсивно после переключения локализации. Теперь хинты корректно появляются при наведении курсора на иконку и исчезают при его уводе. (#1719, #716)
  - Устранена проблема с задержкой отображения подсказок при переключении направления сплиттера с горизонтального на вертикальное. Теперь подсказки появляются и исчезают своевременно в зависимости от вычисляемого текста ([prizmHint]="..."). (#1719, #716)
  - Добавлен метод prizmHasChanged из v4 для проверки изменений ngOnChanges
