### PR TITLE
fix(components/input-date-time): display time 00:00 when a date is selected #1575

### DIFF
--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
@@ -325,7 +325,7 @@ export class PrizmInputLayoutDateTimeComponent
   private updateWithCorrectDateAndTime(value: [PrizmDay | null, PrizmTime | null]): void {
     if (!value) return;
     let [date, time] = value;
-
+    if (date && !time) time = new PrizmTime(0, 0, 0);
     const dateMin = this.min instanceof PrizmDay ? this.min : this.min && this.min[0];
     const dateMax = this.max instanceof PrizmDay ? this.max : this.max && this.max[0];
 


### PR DESCRIPTION
fix(components/input-date-time): display time 00:00 when a date is selected #1575

### Release Notes

#### Исправления

- **Компонент InputLayoutDateTimeComponent:**
  - Исправлена ошибка, при которой при ручном редактировании даты в компоненте `<input-layout-date-time-component>` сбрасывалось время. (#1575)