### PR TITLE
fix(doc): version detection on doc.zyfra or prizm.site #1133

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/prepare_release_for_3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prepare_release_for_3.md
@@ -24,6 +24,8 @@
 
 ### Checklist:
 
+- [ ] Изменить версии в соответствующем массиве на ветке MAIN
+  - apps/doc/src/app/version-manager/versions.constants.ts
 - [ ] Замените NEW_VERSION на новую версию в этом PR
 - [ ] Замените CURRENT_DATE на текущую дату в этом PR
 - [ ] Добавить в каждый тип ваши изменения в этом PR
@@ -87,3 +89,6 @@
   - [ ] libs/theme/package.json.ng15
   - [ ] libs/theme/package.json.ng16
 - [ ] Составить readMe файл с описанием изменений на русском
+- [ ] Выпуск тега для v1
+- [ ] Выпуск тега для v2
+- [ ] Выпуск тега для v3

--- a/apps/doc/src/app/version-manager/util.ts
+++ b/apps/doc/src/app/version-manager/util.ts
@@ -1,5 +1,7 @@
 export function isInnerDoc() {
-  return window.location.host.includes('doc.prizm.site');
+  return (
+    window.location.host.includes('doc.prizm.site') || window.location.host.includes('doc.prizm.zyfra.com')
+  );
 }
 
 export function getDocSite(innerSite: string, tempSite: string) {

--- a/apps/doc/src/app/version-manager/util.ts
+++ b/apps/doc/src/app/version-manager/util.ts
@@ -1,0 +1,7 @@
+export function isInnerDoc() {
+  return window.location.host.includes('doc.prizm.site');
+}
+
+export function getDocSite(innerSite: string, tempSite: string) {
+  return new URL(isInnerDoc() ? innerSite : tempSite);
+}

--- a/apps/doc/src/app/version-manager/version-manager.component.ts
+++ b/apps/doc/src/app/version-manager/version-manager.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { LOCATION } from '@ng-web-apis/common';
 
@@ -33,7 +33,7 @@ export class VersionManagerComponent {
     if (this.locationRef.hostname !== 'localhost') {
       this.initialVersion =
         this.versions.find(version =>
-          [version.link, ...version.otherLinks].find(
+          [version.link(), ...version.otherLinks].find(
             i => this.locationRef.hostname === i.hostname || version.cb?.(this.locationRef.hostname, version)
           )
         ) ?? null;
@@ -44,7 +44,7 @@ export class VersionManagerComponent {
     if (version.baseHref) {
       return `${this.locationRef.origin}/${version.baseHref}${this.router.url}${this.locationRef.search}`;
     } else {
-      return version.link?.href;
+      return version.link?.().href;
     }
   }
 }

--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -1,6 +1,8 @@
+import { getDocSite } from './util';
+
 export interface PrizmVersionMeta {
   label: string;
-  link: URL;
+  link: () => URL;
   stackblitz: string | null;
   otherLinks: URL[];
   version?: string;
@@ -10,10 +12,20 @@ export interface PrizmVersionMeta {
 
 export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
   {
+    label: '4.3.2 (ng17)',
+    version: '4.3.2',
+    stackblitz: 'https://stackblitz.com/edit/prizm-v4-demo',
+    link: getDocSite.bind(null, 'http://doc.prizm.site', 'http://prizm.site'),
+    otherLinks: [new URL('https://prizm-v3.web.app')],
+    cb: (hostName: string, current: PrizmVersionMeta) => {
+      return hostName.startsWith('prizm-v4--');
+    },
+  },
+  {
     label: '3.13.2 (ng16)',
     version: '3.13.2',
     stackblitz: 'https://stackblitz.com/edit/prizm-v3-demo',
-    link: new URL('http://prizm.site'),
+    link: getDocSite.bind(null, 'http://3.12.0.doc.prizm.site', 'https://prizm-v3.web.app'),
     otherLinks: [new URL('https://prizm-v3.web.app')],
     cb: (hostName: string, current: PrizmVersionMeta) => {
       return hostName.startsWith('prizm-v3--');
@@ -23,7 +35,7 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     label: '2.14.2 (ng15)',
     version: '2.14.2',
     stackblitz: 'https://stackblitz.com/edit/prizm-v2-demo',
-    link: new URL('https://prizm-v2.web.app'),
+    link: getDocSite.bind(null, 'http://2.14.2.doc.prizm.site', 'https://prizm-v2.web.app'),
     otherLinks: [],
     cb: (hostName: string, current: PrizmVersionMeta) => {
       return hostName.startsWith('prizm-v2--');
@@ -33,52 +45,10 @@ export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
     label: '1.17.2 (ng14)',
     version: '1.17.2',
     stackblitz: 'https://stackblitz.com/edit/prizm-v1-demo',
-    link: new URL('https://prizm-v1.web.app'),
+    link: getDocSite.bind(null, 'http://1.17.2.doc.prizm.site', 'https://prizm-v1.web.app'),
     otherLinks: [],
     cb: (hostName: string, current: PrizmVersionMeta) => {
       return hostName.startsWith('prizm-v1--');
     },
-  },
-  {
-    label: '3.13.2-next (ng16)',
-    version: '3.13.2-next',
-    stackblitz: 'https://stackblitz.com/edit/prizm-v3-next-demo',
-    link: new URL('https://prizm-v3-next.web.app'),
-    otherLinks: [],
-  },
-  {
-    label: '2.14.2-next (ng15)',
-    stackblitz: 'https://stackblitz.com/edit/prizm-v2-next-demo',
-    version: '2.14.2-next',
-    link: new URL('https://prizm-v2-next.web.app'),
-    otherLinks: [],
-  },
-  {
-    label: '1.17.2-next (ng14)',
-    version: '1.17.2-next',
-    stackblitz: 'https://stackblitz.com/edit/prizm-v1-next-demo',
-    link: new URL('https://prizm-v1-next.web.app'),
-    otherLinks: [],
-  },
-  {
-    label: '3.13.2-beta (ng16)',
-    version: '3.13.2-beta',
-    stackblitz: 'https://stackblitz.com/edit/prizm-v3-beta-demo',
-    link: new URL('https://prizm-v3-beta.web.app'),
-    otherLinks: [],
-  },
-  {
-    label: '2.14.2-beta (ng15)',
-    version: '2.14.2-beta',
-    stackblitz: 'https://stackblitz.com/edit/prizm-v2-beta-demo',
-    link: new URL('https://prizm-v2-beta.web.app'),
-    otherLinks: [],
-  },
-  {
-    label: '1.17.2-beta (ng14)',
-    version: '1.17.2-beta',
-    stackblitz: 'https://stackblitz.com/edit/prizm-v1-beta-demo',
-    link: new URL('https://prizm-v1-beta.web.app'),
-    otherLinks: [],
   },
 ];


### PR DESCRIPTION
fix(doc): version detection on doc.zyfra or prizm.site #1133

### Release Notes

**Сайт документации**

#### Исправления

  - Исправлена ошибка, при которой ссылки на документацию всегда указывали на prizm.site. Теперь ссылки корректно указывают на текущий хост (doc.zyfra или prizm.site), в зависимости от того, где находится пользователь. (#1133)
