### PR TITLE
fix(components/panel): set default border radius as 0px to panel #1767

### DIFF
--- a/libs/components/src/lib/components/panel/panel.component.less
+++ b/libs/components/src/lib/components/panel/panel.component.less
@@ -11,7 +11,7 @@
     height: var(--prizm-panel-height, 48px);
     display: flex;
     border-bottom: 1px solid var(--prizm-panel-border-bottom, var(--prizm-v3-background-stroke));
-    border-radius: var(--prizm-panel-border-radius, 2px);
+    border-radius: var(--prizm-panel-border-radius, 0px);
     background: var(--prizm-panel-background, var(--prizm-v3-background-fill-panel));
 
     .back-btn-wrapper {


### PR DESCRIPTION
fix(components/panel): set default border radius as 0px to panel https://github.com/zyfra/Prizm/issues/1767

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Panle

### Задача

#1767 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью
Panel, встроенная в разные компоненты

### Release Notes
исправили дефолтный border radius у панели согласно макетам. 