### PR TITLE
fix(components/input-date-relative): active items not updated when value set by formControl #1685

### DIFF
--- a/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.html
@@ -1,3 +1,11 @@
 <prizm-input-layout label="Относительное время">
   <prizm-input-layout-date-relative [formControl]="valueControl"></prizm-input-layout-date-relative>
 </prizm-input-layout>
+
+<br />
+<br />
+
+<button (click)="changeDate()" prizmButton appearance="primary" size="l">
+  <ng-container *prizmIfLang="'russian'; else eng"> Изменить дату</ng-container>
+  <ng-template #eng>Change Date</ng-template>
+</button>

--- a/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -15,4 +15,8 @@ import { UntypedFormControl } from '@angular/forms';
 })
 export class PrizmInputLayoutDateRelativeBaseExampleComponent {
   public readonly valueControl = new UntypedFormControl();
+
+  public changeDate(): void {
+    this.valueControl.setValue('T-5M');
+  }
 }

--- a/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.module.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.module.ts
@@ -3,9 +3,14 @@ import { CommonModule } from '@angular/common';
 import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { InputLayoutDateRelativeRelativeComponent } from './input-layout-date-relative.component';
-import { PolymorphModule, PrizmInputLayoutDateRelativeModule } from '@prizm-ui/components';
+import {
+  PolymorphModule,
+  PrizmButtonComponent,
+  PrizmInputLayoutDateRelativeModule,
+} from '@prizm-ui/components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PrizmInputLayoutDateRelativeBaseExampleComponent } from './examples/base/input-layout-date-relative-base-example.component';
+import { PrizmIfLanguageDirective } from '@prizm-ui/i18n';
 
 @NgModule({
   imports: [
@@ -15,6 +20,8 @@ import { PrizmInputLayoutDateRelativeBaseExampleComponent } from './examples/bas
     ReactiveFormsModule,
     PolymorphModule,
     PrizmInputLayoutDateRelativeModule,
+    PrizmButtonComponent,
+    PrizmIfLanguageDirective,
     RouterModule.forChild(prizmDocGenerateRoutes(InputLayoutDateRelativeRelativeComponent)),
   ],
   declarations: [PrizmInputLayoutDateRelativeBaseExampleComponent, InputLayoutDateRelativeRelativeComponent],

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.html
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.html
@@ -38,7 +38,6 @@
       tabindex="0"
     >
       <ng-container leftBox>
-        <!--        <i class="relative-menu-icon prizm-base-icons{{ item.icon }}"></i>-->
         <prizm-icons class="relative-menu-icon prizm-base-icons" [size]="16" [name]="item.icon"></prizm-icons>
       </ng-container>
       {{ item.label }}


### PR DESCRIPTION
fix(components/input-date-relative): active items not updated when value set by formControl #1685

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

InputDateRelative

### Задача

#1685 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Release notes
Исправлена ошибка с установкой активных элементов в списке опций InputDateRelative при работе через FormControl
