### PR TITLE
fix(components/input-date-relative): active items not updated when va…

### DIFF
--- a/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.html
@@ -1,3 +1,8 @@
 <prizm-input-layout label="Относительное время">
   <prizm-input-layout-date-relative [formControl]="valueControl"></prizm-input-layout-date-relative>
 </prizm-input-layout>
+
+<br />
+<br />
+
+<button (click)="changeDate()" prizmButton appearance="primary" size="l">Изменить дату</button>

--- a/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/examples/base/input-layout-date-relative-base-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({
@@ -15,4 +15,8 @@ import { UntypedFormControl } from '@angular/forms';
 })
 export class PrizmInputLayoutDateRelativeBaseExampleComponent {
   public readonly valueControl = new UntypedFormControl();
+
+  public changeDate(): void {
+    this.valueControl.setValue('T-5M');
+  }
 }

--- a/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.module.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-relative/input-layout-date-relative.module.ts
@@ -3,7 +3,11 @@ import { CommonModule } from '@angular/common';
 import { prizmDocGenerateRoutes, PrizmAddonDocModule } from '@prizm-ui/doc';
 import { RouterModule } from '@angular/router';
 import { InputLayoutDateRelativeRelativeComponent } from './input-layout-date-relative.component';
-import { PolymorphModule, PrizmInputLayoutDateRelativeModule } from '@prizm-ui/components';
+import {
+  PolymorphModule,
+  PrizmButtonComponent,
+  PrizmInputLayoutDateRelativeModule,
+} from '@prizm-ui/components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PrizmInputLayoutDateRelativeBaseExampleComponent } from './examples/base/input-layout-date-relative-base-example.component';
 
@@ -15,6 +19,7 @@ import { PrizmInputLayoutDateRelativeBaseExampleComponent } from './examples/bas
     ReactiveFormsModule,
     PolymorphModule,
     PrizmInputLayoutDateRelativeModule,
+    PrizmButtonComponent,
     RouterModule.forChild(prizmDocGenerateRoutes(InputLayoutDateRelativeRelativeComponent)),
   ],
   declarations: [PrizmInputLayoutDateRelativeBaseExampleComponent, InputLayoutDateRelativeRelativeComponent],

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -6,7 +6,6 @@ import {
   Inject,
   Injector,
   Input,
-  OnDestroy,
   OnInit,
   ViewChild,
 } from '@angular/core';
@@ -14,7 +13,7 @@ import { FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/fo
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { PrizmDestroyService, PrizmPluckPipe } from '@prizm-ui/helpers';
 import { PrizmLanguageInputLayoutDateRelative } from '@prizm-ui/i18n';
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, takeUntil, tap } from 'rxjs';
 
 import {
   getDefaultRelativeDateMenuItems,
@@ -75,7 +74,7 @@ const MenuItems: RelativeDateMenuItems = getDefaultRelativeDateMenuItems();
 })
 export class PrizmInputLayoutDateRelativeComponent
   extends PrizmInputNgControl<string | null>
-  implements OnInit, OnDestroy
+  implements OnInit
 {
   readonly nativeElementType = 'input-layout-date-relative';
   readonly hasClearButton = true;
@@ -113,8 +112,6 @@ export class PrizmInputLayoutDateRelativeComponent
   private activeNumber = '';
   private activeWrongFormat = false;
 
-  private readonly subscriptions = new Subscription();
-
   public rightButtons$!: BehaviorSubject<PrizmDateButton[]>;
 
   constructor(
@@ -131,6 +128,12 @@ export class PrizmInputLayoutDateRelativeComponent
   public override ngOnInit(): void {
     super.ngOnInit();
     this.rightButtons$ = this.extraButtonInjector.get(PRIZM_DATE_RIGHT_BUTTONS);
+    this.ngControl.valueChanges
+      ?.pipe(
+        tap((value: string) => this.valueChange(value)),
+        takeUntil(this.destroy$)
+      )
+      .subscribe();
   }
 
   public valueChange(value: string) {
@@ -144,10 +147,6 @@ export class PrizmInputLayoutDateRelativeComponent
       }
     }
     this.updateTouchedAndValue(value);
-  }
-
-  public ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
   }
 
   public onMenuItemClick(event: MouseEvent, item: RelativeDateMenuItem): void {


### PR DESCRIPTION
fix(components/input-date-relative): active items not updated when value set by formControl #1685

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

InputDateRelative

### Задача

#1685 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Release notes
Исправлена ошибка с установкой активных элементов в списке опций InputDateRelative при работе через FormControl