### PR TITLE
fix(components/input-date-time): default time is set only after focus is removed #1762

### DIFF
--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
@@ -434,6 +434,7 @@ export class PrizmInputLayoutDateTimeComponent
   public onOpenChange(open: boolean): void {
     this.open = open;
     this.changeDetectorRef.markForCheck();
+    if (!open) this.completeDateIfAreNotPending();
   }
 
   public override writeValue(value: [PrizmDay | null, PrizmTime | null] | null): void {


### PR DESCRIPTION
fix(components/input-date-range): default time is set only after focus is removed #1762


Исправлено поведение компонента InputLayoutDateTimeComponent, когда дефолтное время устанавливалось только после потери фокуса. Закрыта задача №1762.