### PR TITLE
fix(doc/textarea): missing border property added for textarea livedemo #1803

### DIFF
--- a/apps/doc/src/app/components/input/textarea/textarea-example.component.html
+++ b/apps/doc/src/app/components/input/textarea/textarea-example.component.html
@@ -22,6 +22,7 @@
         [label]="label"
         [size]="size"
         [outer]="outer"
+        [border]="border"
         [ngStyle]="{ width }"
         [status]="status"
         [position]="inputPosition"


### PR DESCRIPTION
fix(doc/textarea): missing border property added for textarea livedemo #1803

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [x] `doc`

### Компонент

Textarea

### Задача

resolved #1803 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes
 В Live demo компонента Textarea добавили пропущенное свойство border. 