### PR TITLE
fix(components/chips): hint appears in multiselect after deletion #1815

### DIFF
--- a/libs/components/src/lib/components/chips/chips-item/chips-item.component.html
+++ b/libs/components/src/lib/components/chips/chips-item/chips-item.component.html
@@ -6,7 +6,9 @@
     [prizmHintHost]="el.nativeElement"
     [prizmHintDirection]="hintDirection"
     [prizmHintCanShow]="
-      $any(!!hintText && (div | prizmCallFunc : prizmIsTextOverflow$ : hintCanShow : null | async))
+      $any(
+        !!hintText && (div | prizmCallFunc : prizmIsTextOverflow$ : hintCanShow : false : hintText | async)
+      )
     "
   >
     <ng-content></ng-content>

--- a/libs/components/src/lib/components/chips/chips-item/chips-item.component.ts
+++ b/libs/components/src/lib/components/chips/chips-item/chips-item.component.ts
@@ -3,9 +3,9 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  inject,
   Input,
   Output,
-  inject,
 } from '@angular/core';
 import { PrizmOverlayOutsidePlacement } from '../../../modules';
 import { Observable, of } from 'rxjs';
@@ -67,7 +67,9 @@ export class PrizmChipsItemComponent extends PrizmAbstractTestId {
   readonly prizmIsTextOverflow$ = (
     elem: HTMLElement,
     hintCanShow: boolean,
-    forceShowHint: boolean
+    forceShowHint: boolean,
+    // for clear memory
+    ..._: unknown[]
   ): Observable<boolean> => {
     return of(forceShowHint).pipe(
       switchMap(val => {


### PR DESCRIPTION
fix(components/chips): hint appears in multiselect after deletion #1815

Хинт всегда появляется после удаление чипса с хинтом для следующих элементов