### PR TITLE
fix(components/inputs): fix markup for input icon button #1529

### DIFF
--- a/libs/components/src/lib/components/input/common/input-icon-button/input-icon-button.component.less
+++ b/libs/components/src/lib/components/input/common/input-icon-button/input-icon-button.component.less
@@ -3,6 +3,7 @@
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   border: 0;
   padding: 0;


### PR DESCRIPTION
fix(components/inputs): fix markup for input icon button #1529, #1672

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

_Название компонента или группы компонентов_

### Задача

resolved #1672
resolved #1529

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Нужно проверить отступы для внутренних кнопок у всех компонентов - иконки внутри кнопок должны иметь равные отступы справа и слева. проверить сочетания кнопок и статусных иконок.

### Release Notes

 Исправили некорректные отступы для кнопок внутри компонента Carousel и остальных контролов.
