### PR TITLE
fix(components/input-icon-button): disabled button should not fire events #1823 v3

### DIFF
--- a/apps/doc/src/app/components/input/input-text/examples/input-icon-buttons-example/input-icon-buttons-example.component.html
+++ b/apps/doc/src/app/components/input/input-text/examples/input-icon-buttons-example/input-icon-buttons-example.component.html
@@ -4,7 +4,7 @@
   <input prizmInput />
 
   <ng-container prizm-input-right>
-    <button prizmInputIconButton="add-circle"></button>
+    <button [disabled]="disabled" (click)="handleButtonClick()" prizmInputIconButton="add-circle"></button>
   </ng-container>
 </prizm-input-layout>
 
@@ -12,7 +12,11 @@
 
 <prizm-input-layout label="Заголовок">
   <ng-container prizm-input-left>
-    <button prizmInputIconButton="arrows-refresh"></button>
+    <button
+      [disabled]="disabled"
+      (click)="handleButtonClick()"
+      prizmInputIconButton="arrows-refresh"
+    ></button>
   </ng-container>
 
   <input prizmInput />
@@ -22,14 +26,18 @@
 
 <prizm-input-layout label="Заголовок">
   <ng-container prizm-input-left>
-    <button prizmInputIconButton="arrows-refresh"></button>
-    <button prizmInputIconButton="badges-tag"></button>
+    <button
+      [disabled]="disabled"
+      (click)="handleButtonClick()"
+      prizmInputIconButton="arrows-refresh"
+    ></button>
+    <button [disabled]="disabled" (click)="handleButtonClick()" prizmInputIconButton="badges-tag"></button>
   </ng-container>
 
   <input prizmInput />
 
   <ng-container prizm-input-right>
-    <button prizmInputIconButton="add-circle"></button>
+    <button [disabled]="disabled" (click)="handleButtonClick()" prizmInputIconButton="add-circle"></button>
   </ng-container>
 </prizm-input-layout>
 
@@ -37,7 +45,11 @@
 
 <prizm-input-layout label="Заголовок" status="warning">
   <ng-container prizm-input-left>
-    <button prizmInputIconButton="arrows-refresh"></button>
+    <button
+      [disabled]="disabled"
+      (click)="handleButtonClick()"
+      prizmInputIconButton="arrows-refresh"
+    ></button>
   </ng-container>
 
   <input prizmInput />
@@ -45,7 +57,7 @@
   <ng-template prizmInputStatusText>Warning text</ng-template>
 
   <ng-container prizm-input-right>
-    <button prizmInputIconButton="add-circle"></button>
+    <button [disabled]="disabled" (click)="handleButtonClick()" prizmInputIconButton="add-circle"></button>
   </ng-container>
 </prizm-input-layout>
 
@@ -58,3 +70,16 @@
 
   <input prizmInput />
 </prizm-input-layout>
+
+<br />
+<br />
+
+<div>
+  Disable
+  <prizm-toggle
+    [ngModel]="disabled"
+    [ngModelOptions]="{ standalone: true }"
+    (ngModelChange)="disabled = $event"
+    size="m"
+  ></prizm-toggle>
+</div>

--- a/apps/doc/src/app/components/input/input-text/examples/input-icon-buttons-example/input-icon-buttons-example.component.ts
+++ b/apps/doc/src/app/components/input/input-text/examples/input-icon-buttons-example/input-icon-buttons-example.component.ts
@@ -6,4 +6,10 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   styleUrls: ['./input-icon-buttons-example.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class InputIconButtonsExampleComponent {}
+export class InputIconButtonsExampleComponent {
+  public disabled = false;
+
+  public handleButtonClick() {
+    console.log('Button clicked!');
+  }
+}

--- a/apps/doc/src/app/components/input/input-text/input-example.module.ts
+++ b/apps/doc/src/app/components/input/input-text/input-example.module.ts
@@ -6,12 +6,12 @@ import {
   PrizmHintDirective,
   PrizmIconComponent,
   PrizmInputTextModule,
+  PrizmToggleComponent,
 } from '@prizm-ui/components';
 import { PrizmAddonDocModule, prizmDocGenerateRoutes } from '@prizm-ui/doc';
 import { InputIconButtonsExampleComponent } from './examples/input-icon-buttons-example/input-icon-buttons-example.component';
 import { InputComponent } from './input.component';
 import { InputLabelPositionExampleComponent } from './examples/input-label-position-example/input-label-position-example.component';
-
 import { InputSizesExampleComponent } from './examples/input-sizes-example/input-sizes-example.component';
 import { InputStatusesExampleComponent } from './examples/input-statuses-example/input-statuses-example.component';
 import { InputSubtextExampleComponent } from './examples/input-subtext-example/input-subtext-example.component';
@@ -34,6 +34,7 @@ import { InputCustomClearButtonExampleComponent } from './examples/input-custom-
     PrizmButtonModule,
     ReactiveFormsModule,
     FormsModule,
+    PrizmToggleComponent,
   ],
   declarations: [
     InputComponent,

--- a/libs/components/src/lib/components/input/common/input-icon-button/input-icon-button.component.ts
+++ b/libs/components/src/lib/components/input/common/input-icon-button/input-icon-button.component.ts
@@ -19,13 +19,18 @@ export class PrizmInputIconButtonComponent extends PrizmAbstractTestId {
   @Input() prizmInputIconButton!: string;
   @Input() interactive = false;
 
-  @HostBinding('class.disabled')
+  @HostBinding('attr.disabled')
   @Input()
   get disabled() {
-    return this._disabled;
+    return this._disabled || null;
   }
   set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
+  }
+
+  @HostBinding('class.disabled')
+  get classDisabled() {
+    return this._disabled;
   }
   private _disabled = false;
   @Input()


### PR DESCRIPTION
fix(components/input-icon-button): disabled button should not fire events #1823

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

inputIconButton

### Задача

resolved #1823 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

поведение кнопок в инпутах

### Release Notes

исправили ошибку с состоянием disabled для InputIconButton