### PR TITLE
feat(components/paginator): update paginator dictionary #1840

### DIFF
--- a/libs/components/src/lib/components/paginator/prizm-paginator.component.html
+++ b/libs/components/src/lib/components/paginator/prizm-paginator.component.html
@@ -1,10 +1,12 @@
-<div class="container">
+<div class="container" *prizmLet="paginator$ | async as language">
   <div class="content">
     <span
       class="rows rows__count"
       *ngIf="!paginatorOptions?.noRowsSelector && !paginatorOptions?.noRowsSelectorLabel"
     >
-      <ng-container *polymorphOutlet="textOnPage as title">
+      <ng-container
+        *polymorphOutlet="textOnPage ? textOnPage : (language | prizmPluck : ['linesOnPage']) as title"
+      >
         {{ title }}
       </ng-container>
     </span>
@@ -24,10 +26,19 @@
 
   <div class="content">
     <span class="rows rows__show" *ngIf="!paginatorOptions?.noInfo" [hidden]="disabled">
-      {{ paginator$ | async | prizmPluck : ['linesShown'] }} {{ (currentPage - 1) * rows + 1 }}-{{
-        currentPage * rows > $any(totalRecords) ? totalRecords : currentPage * rows
-      }}
-      {{ paginator$ | async | prizmPluck : ['fromText'] }} {{ realTotalRecord }}
+      <span data-testid="paginator-i18n-lines-shown">
+        {{ language | prizmPluck : ['linesShown'] }}
+      </span>
+      <span data-testid="paginator-lines-shown"> {{ (currentPage - 1) * rows + 1 }} </span>-
+      <span data-testid="paginator-total-count">
+        {{ currentPage * rows > $any(totalRecords) ? totalRecords : currentPage * rows }}
+      </span>
+      <span data-testid="paginator-i18n-from-text">
+        {{ language | prizmPluck : ['fromText'] }}
+      </span>
+      <span data-testid="paginator-real-total-record">
+        {{ realTotalRecord }}
+      </span>
     </span>
     <div
       class="paginator paginator__finite"
@@ -177,7 +188,7 @@
         appearance="primary"
         size="m"
       >
-        {{ moreButtonLabel }}
+        {{ moreButtonLabel ? moreButtonLabel : (language | prizmPluck : ['moreButtonLabel']) }}
       </button>
     </div>
   </div>

--- a/libs/components/src/lib/components/paginator/prizm-paginator.component.ts
+++ b/libs/components/src/lib/components/paginator/prizm-paginator.component.ts
@@ -50,7 +50,10 @@ import { PrizmButtonModule } from '../button';
 })
 export class PrizmPaginatorComponent extends PrizmAbstractTestId implements OnInit {
   @Input() public paginatorType: PrizmPaginatorType = 'finite';
-  @Input() textOnPage: PolymorphContent = 'Строк на странице';
+  @Input() textOnPage: PolymorphContent;
+  @Input() public leftButtonLabel = '';
+  @Input() public rightButtonLabel = '';
+  @Input() public moreButtonLabel = '';
   /** The length of the total number of items that are being paginated. Defaulted to 0. */
   @Input()
   get totalRecords(): number | null {
@@ -99,10 +102,6 @@ export class PrizmPaginatorComponent extends PrizmAbstractTestId implements OnIn
     noInfo: false,
     noPages: false,
   };
-
-  @Input() public leftButtonLabel = '';
-  @Input() public rightButtonLabel = '';
-  @Input() moreButtonLabel = 'Показать еще';
 
   @Input() public rowsCountOptions: number[] = [];
   @Output() public paginatorChange: EventEmitter<PrizmPaginatorOutput> =

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -65,6 +65,8 @@ export interface PrizmLanguagePaginator {
   paginator: {
     linesShown: string;
     fromText: string;
+    linesOnPage: string;
+    moreButtonLabel: string;
   };
 }
 

--- a/libs/i18n/src/lib/languages/english/paginator.ts
+++ b/libs/i18n/src/lib/languages/english/paginator.ts
@@ -1,0 +1,10 @@
+import { PrizmLanguagePaginator } from '../../interfaces';
+
+export const PRIZM_ENGLISH_PAGINATOR: PrizmLanguagePaginator = {
+  paginator: {
+    linesShown: 'Lines shown:',
+    fromText: 'out of',
+    linesOnPage: 'Lines per page',
+    moreButtonLabel: 'Show more',
+  },
+};

--- a/libs/i18n/src/lib/languages/russian/paginator.ts
+++ b/libs/i18n/src/lib/languages/russian/paginator.ts
@@ -4,5 +4,7 @@ export const PRIZM_RUSSIAN_PAGINATOR: PrizmLanguagePaginator = {
   paginator: {
     linesShown: 'Показано строк:',
     fromText: 'из',
+    linesOnPage: 'Строк на странице',
+    moreButtonLabel: 'Показать ещё',
   },
 };


### PR DESCRIPTION
feat(components/paginator): update paginator dictionary #1840 BREAKING CHANGE in dictionary  - BREAKING CHANGE in dictionaries, why we do this read [here](https://github.com/zyfra/Prizm/discussions/1617)


### Библиотека

- [ ] `@prizm-ui/core`
- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/flag-icons`
- [ ] `@prizm-ui/theme`
- [ ] `@prizm-ui/charts`
- [ ] `@prizm-ui/ast`
- [ ] `@prizm-ui/nx-plugin`

### Компонент
paginator

### Задача
resolved #1840 

### Изменения

- [x] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [ ] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью
 кастомные лейблы в paginator

### Описание

Дополнили локализацию компонента Paginator.