### PR TITLE
fix(components/tree): incorrect markup fix #1742

### DIFF
--- a/apps/doc/src/app/components/tree/examples/component/folder.component.less
+++ b/apps/doc/src/app/components/tree/examples/component/folder.component.less
@@ -23,7 +23,7 @@
   }
 
   &:after {
-    top: -1rem;
+    top: -0.5rem;
     bottom: 1rem;
     border-left: 1px solid var(--prizm-background-stroke);
   }

--- a/libs/components/src/lib/components/tree/components/tree-item-content/tree-item-content.component.less
+++ b/libs/components/src/lib/components/tree/components/tree-item-content/tree-item-content.component.less
@@ -3,6 +3,9 @@
 :host {
   display: flex;
   align-items: center;
+  &:not(:empty) {
+    height: 32px;
+  }
 
   :host-context(prizm-tree-item._expandable):not(._expandable) {
     padding-left: 28px;

--- a/libs/components/src/lib/components/tree/components/tree-item/tree-item.component.less
+++ b/libs/components/src/lib/components/tree/components/tree-item/tree-item.component.less
@@ -16,7 +16,3 @@
   position: relative;
   margin-left: var(--prizm-tree-item-indent, 24px);
 }
-
-.prizm-tree-item__dynamic-content {
-  margin: 4px 0;
-}


### PR DESCRIPTION
fix(components/tree): incorrect markup fix #1742 Note: markup is update can affect tree component in project 

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

tree

### Задача

resolved  #1742

### Изменения

- [x] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

верстка компонента tree, особенно варианты с шаблонами

### Release Notes

Исправлена верстка компонента tree, изменилась высота строки, возможно влияние на верстку в проектах.
