### PR TITLE
fix(components/tab): add correct icon name to registry for right arrow #1860

### DIFF
--- a/libs/components/src/lib/components/tabs/components/tab.component.html
+++ b/libs/components/src/lib/components/tabs/components/tab.component.html
@@ -6,7 +6,6 @@
 >
   <div class="page__icon" *ngIf="icon">
     <ng-container *polymorphOutlet="icon; context: $any({ idx: idx$ | async, tab: this })">
-      <!--      <prizm-icon class="icon icon__mark" [size]="16" [iconClass]="$any(icon)"> </prizm-icon>-->
       <prizm-icons-full class="icon icon__mark" [size]="16" [name]="$any(icon)"> </prizm-icons-full>
     </ng-container>
   </div>

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -46,7 +46,7 @@ import { PrizmIconsFullComponent } from '@prizm-ui/icons';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import {
   prizmIconsAngleLeft,
-  prizmIconsAngleLeftRight,
+  prizmIconsAngleRight,
   prizmIconsEllipsisV,
   prizmIconsXmark,
 } from '@prizm-ui/icons/full/source';
@@ -132,7 +132,7 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
       prizmIconsXmark,
       prizmIconsEllipsisV,
       prizmIconsAngleLeft,
-      prizmIconsAngleLeftRight
+      prizmIconsAngleRight
     );
   }
 


### PR DESCRIPTION
fix(components/tab): add correct icon name to registry for right arrow #1860

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Tabs

resolved #1860 

- Ссылка на issue(если есть)

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Иконки в табах, проверить, что ничего не потерялось

### Release Notes

Исправили имя для иконки прокрутки вправо
