### PR TITLE
fix(components/input): refactor select, multi-select and fixed with update value #1190

### DIFF
--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
@@ -42,6 +42,7 @@
           <prizm-input-layout label="Заголовок" size="l" status="default">
             <input
               [disabled]="control.disabled"
+              [formControl]="controlText"
               (enter)="onEnter($event)"
               prizmInput
               placeholder="Введите название"
@@ -150,7 +151,7 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
-      [control]="control"
+      [control]="controlText"
       [hasTestId]="true"
       heading="PrizmChipsComponent"
       hostComponentKey="PrizmChipsComponent"

--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
@@ -41,7 +41,6 @@
         <div>
           <prizm-input-layout label="Заголовок" size="l" status="default">
             <input
-              [disabled]="control.disabled"
               [formControl]="controlText"
               (enter)="onEnter($event)"
               prizmInput

--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.ts
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.ts
@@ -30,7 +30,7 @@ export class InputChipsExampleComponent {
   public inputPositions: PrizmInputPosition[] = ['left', 'center'];
   public outer!: false;
   public readonly control = new UntypedFormControl([]);
-  public readonly control2 = new UntypedFormControl([]);
+  public readonly controlText = new UntypedFormControl('');
   public size: PrizmInputSize = 'l';
   public sizesOuter: PrizmInputSize[] = ['l', 'm', 's'];
   public sizesInner: PrizmInputSize[] = ['l', 'm'];

--- a/apps/doc/src/app/components/input/input-text/input.component.html
+++ b/apps/doc/src/app/components/input/input-text/input.component.html
@@ -190,7 +190,6 @@
           [prizmHintDirection]="prizmHintDirection"
           [prizmHintCanShow]="prizmHintCanShow"
           [required]="required"
-          [value]="value"
           prizmInput
           prizmDocHostElementKey="PrizmInput"
         />

--- a/apps/doc/src/app/components/input/input-text/input.component.ts
+++ b/apps/doc/src/app/components/input/input-text/input.component.ts
@@ -20,13 +20,13 @@ import { default as d } from './examples/input-phone-example/input-phone-example
 export class InputComponent {
   public disabled = false;
   public testIdPostfix!: string;
-  public control = new UntypedFormControl();
   public required = false;
   public hidden = false;
   public label = 'Заголовок';
 
   value = 'some text';
   placeholder = '';
+  public control = new UntypedFormControl(this.value);
 
   public border = false;
   public inputPosition: PrizmInputPosition = 'left';

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
@@ -22,6 +22,7 @@
     [placeholder]="placeholder"
     [ngModelOptions]="{ standalone: true }"
     [ngModel]="($any(value) | prizmCallFunc : stringify) ?? ''"
+    (blur)="onTouch()"
     prizmInput
   />
 
@@ -31,6 +32,7 @@
       *prizmLet="{ filteredItems: filteredItems$ | async } as $"
       [scroll]="dropdownScroll"
       [style.--prizm-data-list-border]="0"
+      (prizmOnDestroy)="onTouch()"
     >
       <div class="list-search-item" *ngIf="searchable">
         <prizm-input-layout [label]="searchLabelTranslation$ | async" size="m">

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
@@ -377,7 +377,6 @@ export class PrizmInputMultiSelectComponent<T> extends PrizmInputNgControl<T[]> 
   public select(item: PrizmMultiSelectItemWithChecked<T>): void {
     const newItemState = !item.checked;
     let values: T[];
-    this.markAsTouched();
     if (this.isSelectAllItem(item)) {
       values = newItemState ? [...this.items] : [];
     } else {

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -46,6 +46,7 @@
             [prizmHintCanShow]="prizmHintCanShow"
             [ngModelOptions]="{ standalone: true }"
             [ngModel]="text ?? ''"
+            (blur)="onTouch()"
             (focus)="focused$$.next(true)"
             (blur)="focused$$.next(false)"
             prizmInput
@@ -96,12 +97,12 @@
     </ng-template>
 
     <ng-template #dropdown>
-      <ng-container> </ng-container>
       <prizm-data-list
         class="block"
         *prizmLet="(filteredItems$ | async) ?? [] as items"
         [scroll]="customItemDataList ? 'none' : dropdownScroll"
         [style.--prizm-data-list-border]="0"
+        (prizmOnDestroy)="onTouch()"
       >
         <div class="list-search-item" *ngIf="searchable">
           <prizm-input-layout [label]="searchLabelTranslation$ | async">

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -376,9 +376,6 @@ export class PrizmSelectInputComponent<T>
 
   public override updateValue(value: T) {
     super.updateValue(value);
-    console.log('#mz updateValue', {
-      value,
-    });
     // set touched on change value
     this.ngControl.control?.markAsTouched();
   }

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -20,7 +20,7 @@ import {
   PrizmLetDirective,
   PrizmToObservablePipe,
 } from '@prizm-ui/helpers';
-import { FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import {
   isPolymorphPrimitive,
   PolymorphContent,
@@ -138,7 +138,10 @@ import { prizmIconsMagnifyingGlass, prizmIconsTriangleDown } from '@prizm-ui/ico
   ],
   exportAs: 'prizmSelectInput',
 })
-export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> implements OnInit {
+export class PrizmSelectInputComponent<T>
+  extends PrizmInputNgControl<T>
+  implements OnInit, ControlValueAccessor
+{
   @ViewChild('focusableElementRef', { read: ElementRef })
   public override readonly focusableElement?: ElementRef<HTMLInputElement>;
 
@@ -356,7 +359,6 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   }
 
   public select(item: T): void {
-    this.markAsTouched();
     const selectedValue = item && this.transformer(item);
     if (!this.identityMatcher(selectedValue, this.value)) {
       this.updateValue(selectedValue);
@@ -374,7 +376,9 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
 
   public override updateValue(value: T) {
     super.updateValue(value);
-
+    console.log('#mz updateValue', {
+      value,
+    });
     // set touched on change value
     this.ngControl.control?.markAsTouched();
   }

--- a/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
+++ b/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
@@ -20,8 +20,7 @@ export abstract class PrizmInputNgControl<T>
   readonly layoutComponent?: PrizmInputLayoutComponent | null;
   private previousInternalValue$$ = new BehaviorSubject<T | null>(null);
   onChange: (val: T) => void = PRIZM_EMPTY_FUNCTION;
-  onTouch: (val: T) => void = PRIZM_EMPTY_FUNCTION;
-  onTouched = PRIZM_EMPTY_FUNCTION;
+  onTouch: () => void = PRIZM_EMPTY_FUNCTION;
   protected readonly focusableElement?: ElementRef<HTMLInputElement> | any;
 
   get value(): T {
@@ -122,14 +121,13 @@ export abstract class PrizmInputNgControl<T>
     if (this.disabled || this.valueIdenticalComparator(this.value, value)) {
       return;
     }
-
+    this.onChange(value);
     this.previousInternalValue$$.next(value);
     this.controlSetValue(value);
   }
 
   public clear(ev: MouseEvent) {
     this.updateValue(null as any);
-    this.markAsDirty();
   }
 
   public setDisabledState(isDisabled: boolean) {
@@ -137,16 +135,14 @@ export abstract class PrizmInputNgControl<T>
     this.stateChanges.next();
   }
 
-  public registerOnChange(onChange: any): void {
+  public registerOnChange(onChange: (v: T) => void): void {
     this.onChange = (componentValue: T): void => {
-      onChange(this.toControlValue(componentValue));
+      onChange(this.toControlValue(componentValue) as T);
     };
   }
 
-  public registerOnTouched(fn: any) {
-    this.onTouch = () => {
-      fn();
-    };
+  public registerOnTouched(fn: () => void) {
+    this.onTouch = fn;
   }
 
   public writeValue(value: T): void {
@@ -172,7 +168,7 @@ export abstract class PrizmInputNgControl<T>
   }
 
   protected controlMarkAsTouched(): void {
-    this.onTouched();
+    this.onTouch();
     this.checkControlUpdate();
   }
 
@@ -211,10 +207,6 @@ export abstract class PrizmInputNgControl<T>
   }
 
   public markAsTouched(): void {
-    this.ngControl.control?.markAsTouched();
-  }
-
-  public markAsDirty(): void {
-    this.ngControl.control?.markAsDirty();
+    this.onTouch();
   }
 }

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.html
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.html
@@ -47,7 +47,7 @@
           [prizmHint]="$.inputLayout | prizmPluck : ['clear']"
           [prizmHintDirection]="'b'"
           [prizmHintCanShow]="!hideClearButtonHint"
-          (click)="onClearClick($event)"
+          (mousedown)="onClearClick($event)"
         ></button>
 
         <div class="prizm-input-label-clear-btn clear-icon" *ngSwitchDefault>
@@ -114,7 +114,7 @@
             [prizmHint]="$.inputLayout | prizmPluck : ['clear']"
             [prizmHintDirection]="'b'"
             [prizmHintCanShow]="!hideClearButtonHint"
-            (click)="onClearClick($event)"
+            (mousedown)="onClearClick($event)"
           ></button>
 
           <div class="prizm-input-button-default clear-icon" *ngSwitchDefault>

--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
@@ -16,6 +16,7 @@ import {
   SimpleChanges,
   ViewChild,
   inject,
+  HostListener,
 } from '@angular/core';
 import { BehaviorSubject, EMPTY, merge, Observable, Subject, timer } from 'rxjs';
 import { PrizmInputControl } from '../base/input-control.class';
@@ -103,7 +104,6 @@ export class PrizmInputLayoutComponent
   @HostBinding('class.has-textarea') get hasTextarea() {
     return this.control.nativeElementType === 'textarea';
   }
-
   override testId_ = 'ui_input_layout';
   protected readonly isPolymorphPrimitive = isPolymorphPrimitive;
 

--- a/libs/components/src/lib/components/input/input-number/input-number.component.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.component.ts
@@ -139,6 +139,8 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
     this.ngControl.control?.setValue(null);
     this.markAsTouched();
     this.onClear.emit(ev);
+    this.detectSymbols(false);
+    this.stateChanges.next();
   }
 
   private markAsTouched(): void {

--- a/libs/components/src/lib/components/input/input-password/input-password-auxiliary-control.component.ts
+++ b/libs/components/src/lib/components/input/input-password/input-password-auxiliary-control.component.ts
@@ -14,7 +14,7 @@ import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
     [interactive]="true"
     [disabled]="
       (inputPassword?.prizmInputText?.ngControl?.statusChanges &&
-        inputPassword.prizmInputText.ngControl.statusChanges | async) &&
+        inputPassword.prizmInputText.ngControl!.statusChanges | async) &&
       inputPassword?.prizmInputText?.ngControl?.disabled
     "
     (click)="toggle()"

--- a/libs/components/src/lib/components/input/input-text/input-block.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-block.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, Optional, Self } from '@angular/core';
+import { Component, Optional, Self } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmInputControl } from '../common/base/input-control.class';
@@ -39,13 +39,8 @@ export class PrizmInputBlockComponent extends PrizmInputTextComponent implements
     this.onTouched = fn;
   }
 
-  constructor(
-    @Optional() @Self() public readonly ngControl_: NgControl,
-    public readonly elementRef_: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
-    private readonly destroy_: PrizmDestroyService,
-    private readonly cdr_: ChangeDetectorRef
-  ) {
-    super(ngControl_, elementRef_, destroy_, cdr_);
+  constructor(@Optional() @Self() public readonly ngControl_: NgControl) {
+    super();
 
     if (this.ngControl != null) {
       this.ngControl.valueAccessor = this;

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -1,4 +1,5 @@
 import {
+  afterRender,
   ChangeDetectorRef,
   Component,
   DoCheck,
@@ -7,14 +8,16 @@ import {
   HostBinding,
   HostListener,
   inject,
+  Injector,
   Input,
   OnDestroy,
   OnInit,
   Optional,
   Output,
+  Renderer2,
   Self,
 } from '@angular/core';
-import { NgControl, NgModel, Validators } from '@angular/forms';
+import { NgControl, Validators } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
@@ -109,10 +112,10 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   set value(value: VALUE) {
     if (this.ngControl && this.ngControl.value !== value) {
       queueMicrotask(() => {
-        this.ngControl.control?.patchValue(value);
+        this.ngControl?.control?.patchValue(value);
       });
     } else {
-      this._inputValue.value = value as string;
+      this.updateValue(value);
       this.updateEmptyState();
       this.stateChanges.next();
     }
@@ -163,17 +166,31 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     host: true,
   });
 
+  private readonly renderer2_ = inject(Renderer2);
+
+  public readonly ngControl = inject(NgControl, {
+    self: true,
+    optional: true,
+  });
+  public readonly elementRef: ElementRef<HTMLInputElement | HTMLTextAreaElement> = inject(ElementRef);
+  private readonly destroy = inject(PrizmDestroyService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
   /**
    * Create instance
    */
-  constructor(
-    @Optional() @Self() public readonly ngControl: NgControl,
-    public readonly elementRef: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
-    private readonly destroy: PrizmDestroyService,
-    private readonly cdr: ChangeDetectorRef
-  ) {
+  constructor() {
     super();
-    this.nativeElementType = elementRef.nativeElement.type;
+    this.nativeElementType = this.elementRef.nativeElement.type;
+
+    afterRender(
+      () => {
+        this.updateEmptyState();
+      },
+      {
+        injector: inject(Injector),
+      }
+    );
   }
 
   public ngOnInit(): void {
@@ -194,19 +211,12 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
       .subscribe();
   }
 
-  public override ngDoCheck(): void {
-    super.ngDoCheck();
-    this.updateEmptyState();
-    this.updateErrorState();
-  }
-
   ngOnDestroy(): void {
     this.stateChanges.complete();
   }
 
   @HostListener('input', ['$event'])
   private onInput(): void {
-    this.updateEmptyState();
     this.stateChanges.next();
     this.updateValue(this.value);
     this.valueChanged.next(this.value);
@@ -222,6 +232,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   private onBlur(): void {
     this.focused = false;
     this._touched = true;
+    console.log('#mz blur');
     this.stateChanges.next();
   }
 
@@ -233,8 +244,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   private initControlListener(): void {
     this.ngControl?.statusChanges
       ?.pipe(
-        tap(result => {
-          this.updateEmptyState();
+        tap(() => {
           this.updateErrorState();
           this.cdr.markForCheck();
         }),
@@ -248,7 +258,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     this.ngControl?.valueChanges
       ?.pipe(
         tap(value => {
-          this.updateEmptyState();
           this.updateErrorState();
           this.updateValue(value);
         }),
@@ -261,11 +270,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   private updateEmptyState(): void {
-    this.empty = !(
-      (this.elementRef.nativeElement.value && this.elementRef.nativeElement.value.length) ||
-      (this.ngControl && this.ngControl.value) ||
-      (this.ngControl instanceof NgModel && this.ngControl.model)
-    );
+    this.empty = !(this.elementRef.nativeElement.value && this.elementRef.nativeElement.value.length);
   }
 
   private updateErrorState(): void {
@@ -273,8 +278,8 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   private updateValue(value: VALUE): void {
-    if (value !== this.ngControl?.value) this.ngControl?.control?.setValue(value);
-    if (value !== this.value) this._inputValue.value = value as string;
+    // if (value !== this.ngControl?.value) this.ngControl?.control?.setValue(value);
+    if (value !== this.value) this.renderer2_.setProperty(this._inputValue, 'value', value);
     this.inputHint?.updateHint();
   }
 
@@ -305,13 +310,25 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   public markControl(options: { touched?: boolean; dirty?: boolean }): void {
     const { touched, dirty } = options;
 
-    if (touched) {
+    if (typeof touched === 'boolean') {
       this._touched = true;
-      this.ngControl?.control?.markAsTouched();
+      if (touched) {
+        this.ngControl?.control?.markAsTouched();
+      } else {
+        this.ngControl?.control?.markAsUntouched();
+      }
     }
 
-    if (dirty) {
-      this.ngControl?.control?.markAsDirty();
+    console.log('#mz markControl', {
+      options,
+    });
+
+    if (typeof dirty === 'boolean') {
+      if (dirty) {
+        this.ngControl?.control?.markAsDirty();
+      } else {
+        this.ngControl?.control?.markAsPristine();
+      }
     }
 
     this.stateChanges.next();

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -232,7 +232,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   private onBlur(): void {
     this.focused = false;
     this._touched = true;
-    console.log('#mz blur');
     this.stateChanges.next();
   }
 
@@ -318,10 +317,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
         this.ngControl?.control?.markAsUntouched();
       }
     }
-
-    console.log('#mz markControl', {
-      options,
-    });
 
     if (typeof dirty === 'boolean') {
       if (dirty) {

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -17,7 +17,7 @@ import {
   Renderer2,
   Self,
 } from '@angular/core';
-import { NgControl, Validators } from '@angular/forms';
+import { FormControl, NgControl, Validators } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
@@ -215,13 +215,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     this.stateChanges.complete();
   }
 
-  @HostListener('input', ['$event'])
-  private onInput(): void {
-    this.stateChanges.next();
-    this.updateValue(this.value);
-    this.valueChanged.next(this.value);
-  }
-
   @HostListener('focus', ['$event'])
   private onFocus(): void {
     this.focused = true;
@@ -285,7 +278,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     if (this.disabled) return;
 
     this.updateValue(null as VALUE);
-
+    this.ngControl?.control?.setValue('');
     this.updateEmptyState();
     this.updateErrorState();
 

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -277,7 +277,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   private updateValue(value: VALUE): void {
-    // if (value !== this.ngControl?.value) this.ngControl?.control?.setValue(value);
     if (value !== this.value) this.renderer2_.setProperty(this._inputValue, 'value', value);
     this.inputHint?.updateHint();
   }

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup.directive.ts
@@ -61,8 +61,14 @@ export class PrizmConfirmPopupDirective<
   public size = this.options.size;
 
   @Input('prizmConfirmPopupHost')
-  @prizmDefaultProp()
-  override prizmHintHost: HTMLElement | null = null;
+  override set prizmHintHost(host: HTMLElement | null) {
+    this.prizmHintHost_ = host;
+  }
+  override get prizmHintHost(): HTMLElement | null {
+    return this.prizmHintHost_;
+  }
+
+  private prizmHintHost_: HTMLElement | null = null;
 
   @Output()
   @prizmDefaultProp()

--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -22,7 +22,7 @@ import {
   PrizmOverlayRelativePosition,
   PrizmOverlayService,
 } from '../../modules/overlay';
-import { combineLatest, merge, of, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, of, Subject } from 'rxjs';
 import { PrizmHoveredService } from '../../services';
 import { delay, distinctUntilChanged, finalize, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PrizmHintContainerComponent } from './hint-container.component';
@@ -70,8 +70,12 @@ export class PrizmHintDirective<
   prizmHintHideDelay: PrizmHintOptions['hideDelay'] = this.options.hideDelay;
 
   @Input()
-  @prizmDefaultProp()
-  prizmHintHost: HTMLElement | null = null;
+  set prizmHintHost(host: HTMLElement | null) {
+    this.hintHost$$.next(host);
+  }
+  get prizmHintHost() {
+    return this.hintHost$$.value;
+  }
 
   @Input()
   @prizmDefaultProp()
@@ -120,7 +124,7 @@ export class PrizmHintDirective<
   public readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly destroy$: PrizmDestroyService = inject(PrizmDestroyService);
   private readonly hoveredService: PrizmHoveredService = inject(PrizmHoveredService);
-
+  readonly hintHost$$ = new BehaviorSubject<HTMLElement | null>(this.elementRef.nativeElement);
   private readonly hintService: PrizmHintService = inject(PrizmHintService);
 
   get id(): string | null {
@@ -143,6 +147,27 @@ export class PrizmHintDirective<
   public ngOnInit(): void {
     this.initVisibleController();
     this.initShowedChangeListener();
+
+    if (this.onHoverActive)
+      this.hintHost$$
+        .pipe(
+          distinctUntilChanged(),
+          switchMap(() => {
+            return combineLatest([
+              this.hoveredService.createHovered$(this.host),
+              this.hintService.childHovered(this.id as string),
+            ]);
+          }),
+          map(([thisHovered, containerHovered]) => {
+            return thisHovered || containerHovered;
+          }),
+          tap(hovered => this.show$.next(hovered)),
+          finalize(() => {
+            this.overlay?.destroy();
+          }),
+          takeUntil(this.destroy$)
+        )
+        .subscribe();
   }
 
   protected initShowedChangeListener() {
@@ -228,24 +253,6 @@ export class PrizmHintDirective<
       .create({
         parentInjector: this.injector,
       });
-
-    if (this.onHoverActive) {
-      combineLatest([
-        this.hoveredService.createHovered$(this.host),
-        this.hintService.childHovered(this.id as string),
-      ])
-        .pipe(
-          map(([thisHovered, containerHovered]) => {
-            return thisHovered || containerHovered;
-          }),
-          tap(hovered => this.show$.next(hovered)),
-          finalize(() => {
-            this.overlay?.destroy();
-          }),
-          takeUntil(merge(this.destroyListeners$, this.destroy$))
-        )
-        .subscribe();
-    }
   }
 
   protected getContext(): CONTEXT {


### PR DESCRIPTION
fix(components/input-select): sync touched state #1694
fix(components/input-multi-select): sync touched state 
fix(components/hint): a bug where the tooltip would not disappear in some cases
fix(components/input-number): bug where empty state was not toggled when clearing #1684 
fix(components/input-text): incorrect behavior occurring in PrizmInputComponent when NgxMaskDirective is applied and the value changes from an empty state. #1190

continued closed #1797