### PR TITLE
fix(components/input): refactor select, multi-select and fixed with update value  V3 #1190

### DIFF
--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
@@ -39,6 +39,7 @@
           <prizm-input-layout label="Заголовок" size="l" status="default">
             <input
               [disabled]="control.disabled"
+              [formControl]="controlText"
               (enter)="onEnter($event)"
               prizmInput
               placeholder="Введите название"
@@ -124,7 +125,7 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
-      [control]="control"
+      [control]="controlText"
       [hasTestId]="true"
       heading="PrizmChipsComponent"
       hostComponentKey="PrizmChipsComponent"

--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.ts
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.ts
@@ -26,7 +26,7 @@ export class InputChipsExampleComponent {
   public inputPositions: PrizmInputPosition[] = ['left', 'center'];
   public outer!: false;
   public readonly control = new UntypedFormControl([]);
-  public readonly control2 = new UntypedFormControl([]);
+  public readonly controlText = new UntypedFormControl('');
   public size: PrizmInputSize = 'l';
   public sizesOuter: PrizmInputSize[] = ['l', 'm', 's'];
   public sizesInner: PrizmInputSize[] = ['l', 'm'];

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
@@ -21,6 +21,7 @@
     [placeholder]="placeholder"
     [ngModelOptions]="{ standalone: true }"
     [ngModel]="($any(value) | prizmCallFunc : stringify) ?? ''"
+    (blur)="onTouch()"
     prizmInput
   />
 
@@ -30,6 +31,7 @@
       *prizmLet="{ filteredItems: filteredItems$ | async } as $"
       [scroll]="dropdownScroll"
       [style.--prizm-data-list-border]="0"
+      (prizmOnDestroy)="onTouch()"
     >
       <div class="list-search-item" *ngIf="searchable">
         <!-- TODO remove default text value in 4.0, bc #dr -->

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
@@ -367,7 +367,6 @@ export class PrizmInputMultiSelectComponent<T> extends PrizmInputNgControl<T[]> 
   public select(item: PrizmMultiSelectItemWithChecked<T>): void {
     const newItemState = !item.checked;
     let values: T[];
-    this.markAsTouched();
     if (this.isSelectAllItem(item)) {
       values = newItemState ? [...this.items] : [];
     } else {

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -46,6 +46,7 @@
             [prizmHintCanShow]="prizmHintCanShow"
             [ngModelOptions]="{ standalone: true }"
             [ngModel]="text ?? ''"
+            (blur)="onTouch()"
             (focus)="focused$$.next(true)"
             (blur)="focused$$.next(false)"
             prizmInput
@@ -96,12 +97,12 @@
     </ng-template>
 
     <ng-template #dropdown>
-      <ng-container> </ng-container>
       <prizm-data-list
         class="block"
         *prizmLet="(filteredItems$ | async) ?? [] as items"
         [scroll]="customItemDataList ? 'none' : dropdownScroll"
         [style.--prizm-data-list-border]="0"
+        (prizmOnDestroy)="onTouch()"
       >
         <div class="list-search-item" *ngIf="searchable">
           <!-- TODO remove default text value in 4.0, bc #dr -->

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.ts
@@ -20,7 +20,7 @@ import {
   PrizmLetDirective,
   PrizmToObservablePipe,
 } from '@prizm-ui/helpers';
-import { FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import {
   isPolymorphPrimitive,
   PolymorphContent,
@@ -134,7 +134,10 @@ import { prizmI18nInitWithKey } from '../../../services';
   ],
   exportAs: 'prizmSelectInput',
 })
-export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> implements OnInit {
+export class PrizmSelectInputComponent<T>
+  extends PrizmInputNgControl<T>
+  implements OnInit, ControlValueAccessor
+{
   @ViewChild('focusableElementRef', { read: ElementRef })
   public override readonly focusableElement?: ElementRef<HTMLInputElement>;
 
@@ -349,7 +352,6 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
   }
 
   public select(item: T): void {
-    this.markAsTouched();
     const selectedValue = item && this.transformer(item);
     if (!this.identityMatcher(selectedValue, this.value)) {
       this.updateValue(selectedValue);
@@ -367,7 +369,9 @@ export class PrizmSelectInputComponent<T> extends PrizmInputNgControl<T> impleme
 
   public override updateValue(value: T) {
     super.updateValue(value);
-
+    console.log('#mz updateValue', {
+      value,
+    });
     // set touched on change value
     this.ngControl.control?.markAsTouched();
   }

--- a/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
+++ b/libs/components/src/lib/components/input/common/base/input-ng-control.class.ts
@@ -20,8 +20,7 @@ export abstract class PrizmInputNgControl<T>
   readonly layoutComponent?: PrizmInputLayoutComponent | null;
   private previousInternalValue$$ = new BehaviorSubject<T | null>(null);
   onChange: (val: T) => void = PRIZM_EMPTY_FUNCTION;
-  onTouch: (val: T) => void = PRIZM_EMPTY_FUNCTION;
-  onTouched = PRIZM_EMPTY_FUNCTION;
+  onTouch: () => void = PRIZM_EMPTY_FUNCTION;
   protected readonly focusableElement?: ElementRef<HTMLInputElement> | any;
 
   get value(): T {
@@ -122,14 +121,13 @@ export abstract class PrizmInputNgControl<T>
     if (this.disabled || this.valueIdenticalComparator(this.value, value)) {
       return;
     }
-
+    this.onChange(value);
     this.previousInternalValue$$.next(value);
     this.controlSetValue(value);
   }
 
   public clear(ev: MouseEvent) {
     this.updateValue(null as any);
-    this.markAsDirty();
   }
 
   public setDisabledState(isDisabled: boolean) {
@@ -137,16 +135,14 @@ export abstract class PrizmInputNgControl<T>
     this.stateChanges.next();
   }
 
-  public registerOnChange(onChange: any): void {
+  public registerOnChange(onChange: (v: T) => void): void {
     this.onChange = (componentValue: T): void => {
-      onChange(this.toControlValue(componentValue));
+      onChange(this.toControlValue(componentValue) as T);
     };
   }
 
-  public registerOnTouched(fn: any) {
-    this.onTouch = () => {
-      fn();
-    };
+  public registerOnTouched(fn: () => void) {
+    this.onTouch = fn;
   }
 
   public writeValue(value: T): void {
@@ -172,7 +168,7 @@ export abstract class PrizmInputNgControl<T>
   }
 
   protected controlMarkAsTouched(): void {
-    this.onTouched();
+    this.onTouch();
     this.checkControlUpdate();
   }
 
@@ -211,10 +207,6 @@ export abstract class PrizmInputNgControl<T>
   }
 
   public markAsTouched(): void {
-    this.ngControl.control?.markAsTouched();
-  }
-
-  public markAsDirty(): void {
-    this.ngControl.control?.markAsDirty();
+    this.onTouch();
   }
 }

--- a/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
+++ b/libs/components/src/lib/components/input/input-date-relative/input-layout-date-relative.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   forwardRef,
+  inject,
   Inject,
   Injector,
   Input,
@@ -31,13 +32,27 @@ import { PrizmDateButton } from '../../../types';
 import { prizmI18nInitWithKey } from '../../../services';
 import { prizmIsNativeFocusedIn } from '../../../util';
 import { CommonModule } from '@angular/common';
-import { PolymorphOutletDirective, PrizmLifecycleModule } from '../../../directives';
+import { PolymorphOutletDirective, PrizmLifecycleDirective } from '../../../directives';
 import { PrizmInputTextModule } from '../input-text';
-import { PrizmIconComponent } from '../../icon';
 import { PrizmDropdownHostComponent } from '../../dropdowns/dropdown-host';
 import { PrizmInputLayoutDateRelativeDirective } from './input-layout-date-relative.directive';
 import { PrizmDataListComponent } from '../../data-list';
 import { PrizmListingItemComponent } from '../../listing-item';
+import { PrizmIconsComponent } from '@prizm-ui/icons';
+import { PrizmIconsFullRegistry, PrizmIconsRegistry } from '@prizm-ui/icons/core';
+import {
+  prizmIconsLetterTime,
+  prizmIconsCirclePlus,
+  prizmIconsMinusCircle,
+  prizmIconsLetterYear,
+  prizmIconsLetterMonth,
+  prizmIconsLetterDay,
+  prizmIconsLetterHour,
+  prizmIconsLetterMinute,
+  prizmIconsLetterSecond,
+  prizmIconsSymbolAsterisk,
+} from '@prizm-ui/icons/base/source';
+import { prizmIconsClockRotateRight } from '@prizm-ui/icons/full/source';
 
 const MenuItems: RelativeDateMenuItems = getDefaultRelativeDateMenuItems();
 
@@ -60,16 +75,16 @@ const MenuItems: RelativeDateMenuItems = getDefaultRelativeDateMenuItems();
   imports: [
     CommonModule,
     PolymorphOutletDirective,
-    PrizmLifecycleModule,
+    PrizmLifecycleDirective,
     FormsModule,
     PrizmInputTextModule,
     PrizmPluckPipe,
-    PrizmIconComponent,
     ReactiveFormsModule,
     PrizmInputLayoutDateRelativeDirective,
     PrizmDropdownHostComponent,
     PrizmDataListComponent,
     PrizmListingItemComponent,
+    PrizmIconsComponent,
   ],
 })
 export class PrizmInputLayoutDateRelativeComponent
@@ -78,6 +93,8 @@ export class PrizmInputLayoutDateRelativeComponent
 {
   readonly nativeElementType = 'input-layout-date-relative';
   readonly hasClearButton = true;
+  readonly iconsRegistry = inject(PrizmIconsRegistry);
+  private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
 
   @ViewChild(PrizmInputStatusTextDirective, { static: true })
   override statusText!: PrizmInputStatusTextDirective;
@@ -120,11 +137,23 @@ export class PrizmInputLayoutDateRelativeComponent
     public readonly dictionary$: Observable<PrizmLanguageInputLayoutDateRelative['inputLayoutDateRelative']>
   ) {
     super(injector);
+
+    this.iconsRegistry.registerIcons(
+      prizmIconsSymbolAsterisk,
+      prizmIconsLetterTime,
+      prizmIconsCirclePlus,
+      prizmIconsMinusCircle,
+      prizmIconsLetterYear,
+      prizmIconsLetterMonth,
+      prizmIconsLetterDay,
+      prizmIconsLetterHour,
+      prizmIconsLetterMinute,
+      prizmIconsLetterSecond
+    );
+
+    this.iconsFullRegistry.registerIcons(prizmIconsClockRotateRight);
   }
 
-  // public override isEmpty(value: any): boolean {
-  //   return !value && !this.nativeFocusableElement?.value;
-  // }
   public override ngOnInit(): void {
     super.ngOnInit();
     this.rightButtons$ = this.extraButtonInjector.get(PRIZM_DATE_RIGHT_BUTTONS);

--- a/libs/components/src/lib/components/input/input-password/input-password-auxiliary-control.component.ts
+++ b/libs/components/src/lib/components/input/input-password/input-password-auxiliary-control.component.ts
@@ -12,7 +12,7 @@ import { PrizmInputPasswordDirective } from './input-password.directive';
     [interactive]="true"
     [disabled]="
       (inputPassword?.prizmInputText?.ngControl?.statusChanges &&
-        inputPassword.prizmInputText.ngControl.statusChanges | async) &&
+        inputPassword.prizmInputText.ngControl!.statusChanges | async) &&
       inputPassword?.prizmInputText?.ngControl?.disabled
     "
     (click)="toggle()"

--- a/libs/components/src/lib/components/input/input-text/input-block.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-block.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, Optional, Self } from '@angular/core';
+import { Component, Optional, Self } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmInputControl } from '../common/base/input-control.class';
@@ -39,13 +39,8 @@ export class PrizmInputBlockComponent extends PrizmInputTextComponent implements
     this.onTouched = fn;
   }
 
-  constructor(
-    @Optional() @Self() public readonly ngControl_: NgControl,
-    public readonly elementRef_: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
-    private readonly destroy_: PrizmDestroyService,
-    private readonly cdr_: ChangeDetectorRef
-  ) {
-    super(ngControl_, elementRef_, destroy_, cdr_);
+  constructor(@Optional() @Self() public readonly ngControl_: NgControl) {
+    super();
 
     if (this.ngControl != null) {
       this.ngControl.valueAccessor = this;

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng14
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng14
@@ -23,7 +23,7 @@ import { MaskDirective } from 'ngx-mask';
 
 @Component({
   selector:
-    // eslint-disable-next-line @angular-eslint/component-selector
+  // eslint-disable-next-line @angular-eslint/component-selector
     'input[prizmInput]:not([type=number]), textarea[prizmInput], input[prizmInputPassword]',
   template: '',
   // eslint-disable-next-line @angular-eslint/no-host-metadata-property

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng15
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng15
@@ -19,11 +19,11 @@ import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
 import { PrizmInputHintDirective, PrizmInputLayoutComponent } from '../common';
-import { NgxMaskDirective } from 'ngx-mask';
+import { MaskDirective } from 'ngx-mask';
 
 @Component({
   selector:
-    // eslint-disable-next-line @angular-eslint/component-selector
+  // eslint-disable-next-line @angular-eslint/component-selector
     'input[prizmInput]:not([type=number]), textarea[prizmInput], input[prizmInputPassword]',
   template: '',
   // eslint-disable-next-line @angular-eslint/no-host-metadata-property
@@ -130,9 +130,10 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   @HostBinding('class.empty')
   public empty!: boolean;
 
-  readonly maybeMask = inject(NgxMaskDirective, {
+  readonly maybeMask = inject(MaskDirective, {
     optional: true,
   });
+
   readonly parentLayout = inject(PrizmInputLayoutComponent, {
     optional: true,
   });

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng16
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts.ng16
@@ -12,6 +12,7 @@ import {
   OnInit,
   Optional,
   Output,
+  Renderer2,
   Self,
 } from '@angular/core';
 import { NgControl, NgModel, UntypedFormControl, Validators } from '@angular/forms';
@@ -110,16 +111,17 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   set value(value: VALUE) {
     if (this.ngControl && this.ngControl.value !== value) {
       queueMicrotask(() => {
-        this.ngControl.control?.patchValue(value);
+        this.ngControl?.control?.patchValue(value);
       });
     } else {
-      this._inputValue.value = value as string;
+      this.updateValue(value);
       this.updateEmptyState();
       this.stateChanges.next();
     }
 
     this.valueChanged.next(this.value);
   }
+
   private get _inputValue() {
     return this.elementRef.nativeElement as HTMLInputElement;
   }
@@ -171,7 +173,8 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     @Optional() @Self() public readonly ngControl: NgControl,
     public readonly elementRef: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
     private readonly destroy: PrizmDestroyService,
-    private readonly cdr: ChangeDetectorRef
+    private readonly cdr: ChangeDetectorRef,
+    private readonly renderer2_: Renderer2,
   ) {
     super();
     this.nativeElementType = elementRef.nativeElement.type;
@@ -203,14 +206,6 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
 
   ngOnDestroy(): void {
     this.stateChanges.complete();
-  }
-
-  @HostListener('input', ['$event'])
-  private onInput(): void {
-    this.updateEmptyState();
-    this.stateChanges.next();
-    this.updateValue(this.value);
-    this.valueChanged.next(this.value);
   }
 
   @HostListener('focus', ['$event'])
@@ -262,11 +257,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   private updateEmptyState(): void {
-    this.empty = !(
-      (this.elementRef.nativeElement.value && this.elementRef.nativeElement.value.length) ||
-      (this.ngControl && this.ngControl.value) ||
-      (this.ngControl instanceof NgModel && this.ngControl.model)
-    );
+    this.empty = !(this.elementRef.nativeElement.value && this.elementRef.nativeElement.value.length);
   }
 
   private updateErrorState(): void {
@@ -274,8 +265,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   private updateValue(value: VALUE): void {
-    if (value !== this.ngControl?.value) this.ngControl?.control?.setValue(value);
-    if (value !== this.value) this._inputValue.value = value as string;
+    if (value !== this.value) this.renderer2_.setProperty(this._inputValue, 'value', value);
     this.inputHint?.updateHint();
   }
 
@@ -283,7 +273,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
     if (this.disabled) return;
 
     this.updateValue(null as VALUE);
-
+    this.ngControl?.control?.setValue('');
     this.updateEmptyState();
     this.updateErrorState();
 
@@ -306,13 +296,21 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   public markControl(options: { touched?: boolean; dirty?: boolean }): void {
     const { touched, dirty } = options;
 
-    if (touched) {
+    if (typeof touched === 'boolean') {
       this._touched = true;
-      this.ngControl?.control?.markAsTouched();
+      if (touched) {
+        this.ngControl?.control?.markAsTouched();
+      } else {
+        this.ngControl?.control?.markAsUntouched();
+      }
     }
 
-    if (dirty) {
-      this.ngControl?.control?.markAsDirty();
+    if (typeof dirty === 'boolean') {
+      if (dirty) {
+        this.ngControl?.control?.markAsDirty();
+      } else {
+        this.ngControl?.control?.markAsPristine();
+      }
     }
 
     this.stateChanges.next();


### PR DESCRIPTION
fix(components/input-select): sync touched state https://github.com/zyfra/Prizm/issues/1694
fix(components/input-multi-select): sync touched state
fix(components/hint): a bug where the tooltip would not disappear in some cases
fix(components/input-number): bug where empty state was not toggled when clearing https://github.com/zyfra/Prizm/issues/1684
fix(components/input-text): incorrect behavior occurring in PrizmInputComponent when NgxMaskDirective is applied and the value changes from an empty state. https://github.com/zyfra/Prizm/issues/1190

continued closed https://github.com/zyfra/Prizm/pull/1797