### PR TITLE
fix(components/dropdown-host): overlay undefined error occures on destroy #1889

### DIFF
--- a/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
+++ b/libs/components/src/lib/components/dropdowns/dropdown-host/dropdown-host.component.ts
@@ -198,7 +198,7 @@ export class PrizmDropdownHostComponent extends PrizmAbstractTestId implements A
   }
 
   public ngOnDestroy() {
-    this.overlay.destroy();
+    this.overlay?.destroy();
   }
 
   public updateWidth(): void {


### PR DESCRIPTION
fix(components/dropdown-host): overlay undefined error occures on destroy #1889

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

dropdown host

### Задача

resolved #1889 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

поведение дропдаун хоста, ошибки в консоли

### Release Notes
Исправили ошибку, возникающую при вызове метода destroy у компонента overlay.
