### PR TITLE
fix(components/hint): re-draw after change context #000

### DIFF
--- a/apps/doc/src/app/components/hint/examples/base/hint-base-example.component.html
+++ b/apps/doc/src/app/components/hint/examples/base/hint-base-example.component.html
@@ -2,6 +2,7 @@
   [prizmHintShowDelay]="500"
   [prizmHintHideDelay]="5000"
   [prizmHint]="hintText"
+  (click)="amount = amount + 1"
   type="button"
   prizmButton
 >

--- a/libs/components/src/lib/directives/hint/hint-container.component.ts
+++ b/libs/components/src/lib/directives/hint/hint-container.component.ts
@@ -47,8 +47,13 @@ export class PrizmHintContainerComponent<CONTEXT extends Record<string, unknown>
   content!: () => PolymorphContent;
 
   @Input()
-  @prizmDefaultProp()
-  context: CONTEXT = {} as CONTEXT;
+  set context(context) {
+    this.context_ = context;
+  }
+  get context() {
+    return this.context_;
+  }
+  context_: CONTEXT = {} as CONTEXT;
 
   @Input()
   set hintTheme(theme: PrizmTheme) {

--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -182,7 +182,7 @@ export class PrizmHintDirective<
         .subscribe();
   }
   private initPropsSyncer() {
-    combineLatest([this.content$$])
+    this.content$$
       .pipe(
         tap(([content]) => {
           this.overlay?.updateProps<PrizmHintContainerComponent>({

--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -155,7 +155,6 @@ export class PrizmHintDirective<
       this.prizmHintTheme$$.pipe(distinctUntilChanged()),
     ])
       .pipe(
-        distinctUntilChanged(),
         tap(() => this.drawHint()),
         takeUntil(this.destroy$)
       )

--- a/libs/components/src/lib/directives/hint/hint.directive.ts
+++ b/libs/components/src/lib/directives/hint/hint.directive.ts
@@ -183,7 +183,7 @@ export class PrizmHintDirective<
   private initPropsSyncer() {
     this.content$$
       .pipe(
-        tap(([content]) => {
+        tap(content => {
           this.overlay?.updateProps<PrizmHintContainerComponent>({
             content: () => content,
           });

--- a/libs/components/src/lib/directives/polymorph/directives/outlet.ts
+++ b/libs/components/src/lib/directives/polymorph/directives/outlet.ts
@@ -33,7 +33,13 @@ export class PolymorphOutletDirective<C extends object> implements OnChanges, Do
   content: PolymorphContent<C> = '';
 
   @Input('polymorphOutletContext')
-  context!: C;
+  get context() {
+    return this.context_;
+  }
+  set context(ctx) {
+    this.context_ = ctx;
+  }
+  private context_!: C;
 
   @Input('polymorphOutletInjector')
   injector: Injector = this.currentInjector;

--- a/libs/components/src/lib/modules/overlay/overlay-control.ts
+++ b/libs/components/src/lib/modules/overlay/overlay-control.ts
@@ -177,6 +177,10 @@ export class PrizmOverlayControl {
     EventBus.send(this.zid, 'z_dynpos');
   }
 
+  /**
+   * @preview
+   * method for update props for passed component
+   * */
   public updateProps<T>(props: Partial<T>) {
     if (!this.compRef) return;
     this.compRef.setInput('content', {

--- a/libs/components/src/lib/modules/overlay/overlay-control.ts
+++ b/libs/components/src/lib/modules/overlay/overlay-control.ts
@@ -177,6 +177,17 @@ export class PrizmOverlayControl {
     EventBus.send(this.zid, 'z_dynpos');
   }
 
+  public updateProps<T>(props: Partial<T>) {
+    if (!this.compRef) return;
+    this.compRef.setInput('content', {
+      ...this.content,
+      props: {
+        ...this.content.props,
+        ...props,
+      },
+    });
+  }
+
   private isNotHostElement(el: HTMLElement): boolean {
     const wrapperEl = this.viewEl?.querySelector('.z-overlay-wrapper');
     return el !== wrapperEl && !wrapperEl?.contains(el);

--- a/libs/components/src/lib/modules/overlay/overlay.component.ts
+++ b/libs/components/src/lib/modules/overlay/overlay.component.ts
@@ -7,6 +7,7 @@ import {
   ElementRef,
   HostBinding,
   Injector,
+  Input,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -32,6 +33,7 @@ import { CommonModule } from '@angular/common';
 })
 export class PrizmOverlayComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('compOutlet', { read: ViewContainerRef }) compOutlet!: ViewContainerRef;
+  @Input()
   content: PrizmOverlayContent = {
     type: PrizmOverlayContentType.STRING,
     data: '',


### PR DESCRIPTION
fix(components/hint): fixed a bug with hiding the hint after changing the context or content

Исправлена ​​ошибка со скрытием hint после смены контекста или содержимого