### PR TITLE
feat(components/mask): remove deprecated function prizmCreateDateMask

### DIFF
--- a/libs/components/src/lib/@core/mask/create-date-mask.ts
+++ b/libs/components/src/lib/@core/mask/create-date-mask.ts
@@ -1,27 +1,4 @@
-import { PRIZM_DIGIT_REGEXP } from '../../constants';
 import { PrizmDateMode } from '../../types/date-mode';
-import { PrizmTextMaskList } from './text-mask-list';
-import { prizmAssert } from '@prizm-ui/core';
-
-const TWO_DIGITS = new Array(2).fill(PRIZM_DIGIT_REGEXP);
-const FOUR_DIGITS = new Array(4).fill(PRIZM_DIGIT_REGEXP);
-
-/**
- * @deprecated
- * use prizmCreateDateNgxMask
- * */
-export function prizmCreateDateMask(mode: PrizmDateMode, separator: string): PrizmTextMaskList {
-  prizmAssert.assert(separator.length === 1, `Separator should consist of only 1 symbol`);
-
-  switch (mode) {
-    case `YMD`:
-      return [...FOUR_DIGITS, separator, ...TWO_DIGITS, separator, ...TWO_DIGITS];
-    case `MDY`:
-    case `DMY`:
-    default:
-      return [...TWO_DIGITS, separator, ...TWO_DIGITS, separator, ...FOUR_DIGITS];
-  }
-}
 
 export function prizmCreateDateNgxMask(mode: PrizmDateMode, separator: string): any {
   console.assert(separator.length === 1, `Separator should consist of only 1 symbol`);


### PR DESCRIPTION
feat(components): remove deprecated function prizmCreateDateMask  BREACKING CHANGE

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

prizmCreateDateMask


### Изменения

- [x] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [ ] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes

Удалена функиция prizmCreateDateMask