### PR TITLE
fix(components/tabs): template usage for tabs listing #1859

### DIFF
--- a/apps/doc/src/app/components/tabs/examples/tabs-example-component/tabs-example-component.component.ts
+++ b/apps/doc/src/app/components/tabs/examples/tabs-example-component/tabs-example-component.component.ts
@@ -24,5 +24,35 @@ export class TabsExampleComponentComponent {
     {
       title: 'Вкладка 4',
     },
+    {
+      title: 'Вкладка 5',
+    },
+    {
+      title: 'Вкладка 6',
+    },
+    {
+      title: 'Вкладка 7',
+    },
+    {
+      title: 'Вкладка 8',
+    },
+    {
+      title: 'Вкладка 9',
+    },
+    {
+      title: 'Вкладка 10',
+    },
+    {
+      title: 'Вкладка 11',
+    },
+    {
+      title: 'Вкладка 12',
+    },
+    {
+      title: 'Вкладка 13',
+    },
+    {
+      title: 'Вкладка 14',
+    },
   ];
 }

--- a/apps/doc/src/app/components/tabs/examples/tabs-example-component/tabs-example-content-component.component.ts
+++ b/apps/doc/src/app/components/tabs/examples/tabs-example-component/tabs-example-content-component.component.ts
@@ -1,9 +1,9 @@
 import { Component, ChangeDetectionStrategy, Inject } from '@angular/core';
-import { POLYMORPH_CONTEXT, PrizmTabContext, PrizmTabItem } from '@prizm-ui/components';
+import { POLYMORPH_CONTEXT, PrizmTabContext } from '@prizm-ui/components';
 
 @Component({
   selector: 'prizm-tabs-example-component-content',
-  template: `{{ context.idx + 1 }}`,
+  template: `{{ context.idx + 1 }} element`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TabsExampleComponentContentComponent {

--- a/libs/components/src/lib/components/tabs/tabs.component.html
+++ b/libs/components/src/lib/components/tabs/tabs.component.html
@@ -81,16 +81,17 @@
                   <div class="icon-placeholder"></div>
                 </ng-template>
               </ng-container>
-
-              <ng-container>
-                <div
-                  class="tab-content"
-                  #elem
-                  [prizmHint]="tab.content"
-                  [prizmHintCanShow]="$any(elem | prizmCallFunc : prizmIsTextOverflow$ | async)"
-                >
-                  {{ tab.content }}
-                </div>
+              <ng-container *ngIf="tab.content as content">
+                <ng-container *polymorphOutlet="content; context: $any({ idx: i, tab: this })">
+                  <div
+                    class="tab-content"
+                    #elem
+                    [prizmHint]="content"
+                    [prizmHintCanShow]="$any(elem | prizmCallFunc : prizmIsTextOverflow$ | async)"
+                  >
+                    {{ content }}
+                  </div>
+                </ng-container>
               </ng-container>
 
               <ng-container rightBox>


### PR DESCRIPTION
fix(components/tabs): template usage for tabs listing #1859

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

_Название компонента или группы компонентов_

### Задача

resolved #1859

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Поведение табов, когда они не помещаются в обалсть и появляется кебаб. Особенно пример с компонентом

### Release Notes
Исправили ошибку с некорректным отображением шаблона в выпадающием списке табов при переполнении.
