### PR TITLE
fix(components/multiselect): usage with transformers should cover case with selectAll option #1919

### DIFF
--- a/apps/doc/src/app/components/input/input-multi-select/examples/with-transformer/multi-select-with-transformer-example.component.html
+++ b/apps/doc/src/app/components/input/input-multi-select/examples/with-transformer/multi-select-with-transformer-example.component.html
@@ -8,6 +8,7 @@
     [identityMatcher]="identityMatcher"
     [stringify]="stringify"
     [searchable]="true"
+    [selectAllItem]="selectAll"
   >
   </prizm-input-multi-select>
 </prizm-input-layout>

--- a/apps/doc/src/app/components/input/input-multi-select/examples/with-transformer/multi-select-with-transformer-example.component.ts
+++ b/apps/doc/src/app/components/input/input-multi-select/examples/with-transformer/multi-select-with-transformer-example.component.ts
@@ -33,6 +33,8 @@ export class PrizmInputMultiSelectWithTransformerExampleComponent {
     { id: 3, name: 'ОАЭ' },
   ];
 
+  readonly selectAll: PrizmItem = { id: 0, name: 'Select all' };
+
   readonly valueControl = new UntypedFormControl([3]);
 
   readonly searchMatcher: PrizmMultiSelectSearchMatcher<PrizmItem> = (search: string, item: PrizmItem) => {

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
@@ -378,7 +378,7 @@ export class PrizmInputMultiSelectComponent<T> extends PrizmInputNgControl<T[]> 
     const newItemState = !item.checked;
     let values: T[];
     if (this.isSelectAllItem(item)) {
-      values = newItemState ? [...this.items] : [];
+      values = newItemState ? this.items.map(item => this.transformer(item)) : [];
     } else {
       const selectedValue = this.transformer(item.obj);
       values = newItemState


### PR DESCRIPTION
fix(components/multiselect): usage with transformers should cover case with selectAll option #1919

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

multiselect

### Задача

resolved #1919 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release notes

Исправили ошибку обработки опции 'Выбарть все'  при использовании трансформера в мультселекте.
