### PR TITLE
fix(components/file-upload): emit events for clear files fix #1848

### DIFF
--- a/libs/components/src/lib/components/file-upload/file-upload.component.ts
+++ b/libs/components/src/lib/components/file-upload/file-upload.component.ts
@@ -209,7 +209,7 @@ export class PrizmFileUploadComponent
     }
 
     for (const file of this.filesMap.keys()) {
-      this.removeFile(file);
+      this.removeFile(file, { emitEvent: options.emitEvent });
     }
 
     if (options.emitEvent) {


### PR DESCRIPTION
fix(components/file-upload): emit events for clear files fix #1848

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

FileUpload

### Задача

resolved #1858 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание при тестировании

Способ проверки: multiply = false, добавить один файл, затем заменить его другим. Cобытия beforeFilesChange и аilesChange  должно сработать 1 раз, на проде сейчас дублируются из-за ошибки в логике. 

### Release Notes

Исправили ошибку в поведении функции ClearFiles c опцией emitEvent: false
