### PR TITLE
fix(components/tabs): view not updated for activeTabindexChage when tabs overflows #1863

### DIFF
--- a/apps/doc/src/app/components/tabs/tabs-example.component.html
+++ b/apps/doc/src/app/components/tabs/tabs-example.component.html
@@ -76,6 +76,17 @@
             content="Big Tab 2"
           >
           </prizm-tab>
+          <prizm-tab
+            *ngFor="let item of simpleTabs"
+            [icon]="icon"
+            [closable]="closable"
+            [type]="type"
+            [closeIcon]="$any(closeIcon)"
+            [disabled]="disabled"
+            [style.--prizm-tab-button-max-width]="prizmTabButtonMaxWidth"
+            [content]="item.title ?? ''"
+          >
+          </prizm-tab>
         </prizm-tabs>
       </div>
     </prizm-doc-demo>

--- a/apps/doc/src/app/components/tabs/tabs-example.component.ts
+++ b/apps/doc/src/app/components/tabs/tabs-example.component.ts
@@ -4,6 +4,7 @@ import {
   PrizmTabCanOpen,
   PrizmTabComponent,
   PrizmTabCounterOptions,
+  PrizmTabItem,
   PrizmTabSize,
   PrizmTabType,
 } from '@prizm-ui/components';
@@ -64,6 +65,33 @@ export class TabsExampleComponent {
     {
       status: 'warning',
       disabled: true,
+    },
+  ];
+
+  public simpleTabs: PrizmTabItem[] = [
+    {
+      title: 'Вкладка 3',
+    },
+    {
+      title: 'Вкладка 4',
+    },
+    {
+      title: 'Вкладка 5',
+    },
+    {
+      title: 'Вкладка 6',
+    },
+    {
+      title: 'Вкладка 7',
+    },
+    {
+      title: 'Вкладка 8',
+    },
+    {
+      title: 'Вкладка 9',
+    },
+    {
+      title: 'Вкладка 10',
     },
   ];
 

--- a/libs/components/src/lib/components/listing-item/listing-item.component.less
+++ b/libs/components/src/lib/components/listing-item/listing-item.component.less
@@ -1,5 +1,10 @@
 :host {
   background-color: var(--prizm-background-fill-overlay);
+
+  &.disabled {
+    pointer-events: none;
+  }
+
   .item-container {
     display: flex;
     align-items: center;

--- a/libs/components/src/lib/components/listing-item/listing-item.component.ts
+++ b/libs/components/src/lib/components/listing-item/listing-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
 import { PolymorphOutletDirective } from '../../directives';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
@@ -13,6 +13,7 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule, PolymorphOutletDirective],
 })
 export class PrizmListingItemComponent extends PrizmAbstractTestId {
+  @HostBinding('class.disabled')
   @Input()
   get disabled() {
     return this._disabled;
@@ -29,6 +30,7 @@ export class PrizmListingItemComponent extends PrizmAbstractTestId {
   set selected(value: BooleanInput) {
     this._selected = coerceBooleanProperty(value);
   }
+
   private _selected = false;
 
   override readonly testId_ = 'ui_listing_item';

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -82,6 +82,7 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
     this.activeTabIndexLastChanged = idx;
     if (idx === this.tabsService.activeTabIdx) return;
     this.tabsService.updateActiveTab(idx);
+    this.focusTabByIdx(idx);
   }
   get activeTabIndex(): number {
     return this.tabsService.activeTabIdx;

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -151,7 +151,7 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
 
     this.subscription.add(
       this.mutationDetector$
-        .pipe(debounceTime(200), observeOn(animationFrameScheduler))
+        .pipe(debounceTime(300), observeOn(animationFrameScheduler))
         .subscribe(() => this.overflowChecker())
     );
   }


### PR DESCRIPTION
fix(components/tabs): view not updated for activeTabindexChage when tabs overflows #1863
fix(components/tabs): tabindex should recalculate on close from dropdown #1948
fix(components/listing-item): disabled items should not fire mouse events #1947

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

_Название компонента или группы компонентов_

### Задача

resolved #1863 
resolved #1948
resolved #1947

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились


### Release Notes

Исправлена проблема с отстуствием прокрутки к выбранному скрытому табу при установке черезщ  activeTabIndex
Исправлена проблема с пересчетом activeTabIndex при закрытии через дропдаун
