### PR TITLE
Fix/navigation tree item height-1964

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - fix(components/input-number): bug where empty state was not toggled when clearing https://github.com/zyfra/Prizm/issues/1684
 - fix(components/input-text): incorrect behavior occurring in PrizmInputComponent when NgxMaskDirective is applied and the value changes from an empty state. https://github.com/zyfra/Prizm/issues/1190
 - fix(components/tab): add correct icon name to registry for right arrow #1860
+- fix(components/tree): incorrect markup fix #1742 Note: markup is update can affect tree component in project
 
 ### Refactor
 

--- a/apps/doc/src/app/components/tree/tree.component.html
+++ b/apps/doc/src/app/components/tree/tree.component.html
@@ -76,7 +76,7 @@
                 >Red Delicious</prizm-tree-item
               >
             </prizm-tree-item>
-            <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">>Oranges</prizm-tree-item>
+            <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">Oranges</prizm-tree-item>
           </prizm-tree-item>
           <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">
             Animals

--- a/apps/doc/src/app/components/tree/tree.component.html
+++ b/apps/doc/src/app/components/tree/tree.component.html
@@ -65,19 +65,23 @@
           #treeControllerElement="prizmTreeController"
           [prizmTreeController]="prizmTreeController"
         >
-          <prizm-tree-item #element="prizmTreeItem">
+          <prizm-tree-item #element="prizmTreeItem" [style.--prizm-tree-item-height]="treeItemHeight">
             Fruits
-            <prizm-tree-item>
+            <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">
               Apples
-              <prizm-tree-item>Granny Smith</prizm-tree-item>
-              <prizm-tree-item>Red Delicious</prizm-tree-item>
+              <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight"
+                >Granny Smith</prizm-tree-item
+              >
+              <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight"
+                >Red Delicious</prizm-tree-item
+              >
             </prizm-tree-item>
-            <prizm-tree-item>Oranges</prizm-tree-item>
+            <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">>Oranges</prizm-tree-item>
           </prizm-tree-item>
-          <prizm-tree-item>
+          <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">
             Animals
-            <prizm-tree-item>Cats</prizm-tree-item>
-            <prizm-tree-item>Dogs</prizm-tree-item>
+            <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">Cats</prizm-tree-item>
+            <prizm-tree-item [style.--prizm-tree-item-height]="treeItemHeight">Dogs</prizm-tree-item>
           </prizm-tree-item>
         </ng-container>
       </div>
@@ -88,6 +92,14 @@
       heading="PrizmTreeItemControllerDirective"
       hostComponentKey="PrizmTreeItemControllerDirective"
     >
+      <ng-template
+        [(documentationPropertyValue)]="treeItemHeight"
+        documentationPropertyName="prizm-tree-item-height"
+        documentationPropertyType="string"
+        documentationPropertyMode="css-var"
+      >
+        Tree Item Height (default 32px)
+      </ng-template>
       <ng-template
         [(documentationPropertyValue)]="prizmTreeController"
         documentationPropertyName="prizmTreeController"

--- a/apps/doc/src/app/components/tree/tree.component.ts
+++ b/apps/doc/src/app/components/tree/tree.component.ts
@@ -21,6 +21,7 @@ export class TreeComponent {
   ];
 
   public treeController = true;
+  public treeItemHeight = '32px';
 
   public readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.less
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.less
@@ -1,7 +1,7 @@
 .prizm-navigation-menu {
   --prizm-navigation-menu__item-padding: 8px 16px;
   --prizm-navigation-menu__item-height: 40px;
-  --prizm-tree-item-height: 40px;
+  --prizm-tree-item-height: var(--prizm-navigation-menu__item-height);
 
   display: grid;
   grid-template-rows: min-content;

--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.less
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu/prizm-navigation-menu.component.less
@@ -1,6 +1,7 @@
 .prizm-navigation-menu {
   --prizm-navigation-menu__item-padding: 8px 16px;
   --prizm-navigation-menu__item-height: 40px;
+  --prizm-tree-item-height: 40px;
 
   display: grid;
   grid-template-rows: min-content;

--- a/libs/components/src/lib/components/tree/components/tree-item-content/tree-item-content.component.less
+++ b/libs/components/src/lib/components/tree/components/tree-item-content/tree-item-content.component.less
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   &:not(:empty) {
-    height: 32px;
+    height: var(--prizm-tree-item-height, 32px);
   }
 
   :host-context(prizm-tree-item._expandable):not(._expandable) {


### PR DESCRIPTION
feat(components/tree): added css variable for tree item height
fix(components/navigation-menu): fix navigation item height #1964
fix(doc): missing fix #1742 info added to 4.3.6 version in changelog
 

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Navigation Menu
Tree Item

### Задача

resolved #1964

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [x] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью и тестровании

Tree Item и компоненты, его содержащие
