### PR TITLE
fix(components/button): correct outline buttons height #1399 v5

### DIFF
--- a/libs/components/src/lib/components/button/button.component.less
+++ b/libs/components/src/lib/components/button/button.component.less
@@ -28,7 +28,7 @@
     min-height: inherit;
   }
 
-  .addSize(@size, @height, @width, @padding) {
+  .addSize(@size, @height, @width, @padding, @outline-padding) {
     &[data-size='@{size}'] {
       min-height: @height;
 
@@ -43,13 +43,17 @@
       .z-wrapper {
         padding: @padding;
       }
+
+      .z-wrapper[data-appearance-type='outline'] {
+        padding: @outline-padding;
+      }
     }
   }
-  .addSize('xl', 44px, 44px, 14px 16px 14px 16px);
-  .addSize('l', 40px, 40px, 12px 16px 12px 16px);
-  .addSize('xm', 36px, 36px, 10px 16px 10px 16px);
-  .addSize('m', 32px, 32px, 8px 16px 8px 16px);
-  .addSize('s', 24px, 24px, 4px 8px 4px 8px);
+  .addSize('xl', 44px, 44px, 14px 16px 14px 16px, 12px 16px 12px 16px);
+  .addSize('l', 40px, 40px, 12px 16px 12px 16px, 10px 16px 10px 16px);
+  .addSize('xm', 36px, 36px, 10px 16px 10px 16px, 8px 16px 8px 16px );
+  .addSize('m', 32px, 32px, 8px 16px 8px 16px, 6px 16px 6px 16px);
+  .addSize('s', 24px, 24px, 4px 8px 4px 8px, 2px 16px 2px 16px);
 }
 
 .z-loader {


### PR DESCRIPTION
fix(components/button): correct outline buttons height #1399

fix(components/button): correct outline buttons height #1399

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Button

### Задача


resolved #1399

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes

Исправили высоту outline кнопок


