### PR TITLE
feat(components/input-date-time): add time restrictions for min max values #1570 v5

### DIFF
--- a/apps/doc/src/app/components/input/input-layout-date-time-range/examples/base/input-layout-date-time-range-base-example.component.html
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/examples/base/input-layout-date-time-range-base-example.component.html
@@ -1,7 +1,13 @@
 <prizm-input-layout label="Выберите период">
-  <prizm-input-layout-date-time-range [formControl]="value"> </prizm-input-layout-date-time-range>
+  <prizm-input-layout-date-time-range [formControl]="value" [min]="min" [max]="max">
+  </prizm-input-layout-date-time-range>
 </prizm-input-layout>
 <h3>
   Value:
   <b>{{ value.value }}</b>
 </h3>
+
+<pre>
+  min: {{ min.toLocalNativeDate() }}
+  max: {{ max.toLocalNativeDate() }}
+</pre>

--- a/apps/doc/src/app/components/input/input-layout-date-time-range/examples/base/input-layout-date-time-range-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-layout-date-time-range/examples/base/input-layout-date-time-range-base-example.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { FormControl, UntypedFormControl } from '@angular/forms';
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { PrizmDateTime, PrizmDateTimeRange, PrizmDay, PrizmDayRange, PrizmTime } from '@prizm-ui/components';
 
 @Component({
@@ -22,4 +22,7 @@ export class PrizmInputLayoutDateTimeRangeBaseExampleComponent {
   readonly value = new FormControl(
     new PrizmDateTimeRange(new PrizmDayRange(new PrizmDay(2018, 2, 10), new PrizmDay(2018, 2, 10)))
   );
+
+  public min: PrizmDateTime = new PrizmDateTime(new PrizmDay(2018, 1, 1), new PrizmTime(10, 0));
+  public max: PrizmDateTime = new PrizmDateTime(new PrizmDay(2025, 10, 10), new PrizmTime(18, 30));
 }

--- a/libs/components/src/lib/@core/date-time/date-time.ts
+++ b/libs/components/src/lib/@core/date-time/date-time.ts
@@ -1,4 +1,3 @@
-import { PRIZM_CHAR_EN_DASH, PRIZM_CHAR_NO_BREAK_SPACE } from '../../constants/unicode-chars';
 import { PrizmTime } from './time';
 import { PrizmDay } from './day';
 
@@ -38,11 +37,11 @@ export const PRIZM_MILLISECONDS_IN_HOUR = PRIZM_MILLISECONDS_IN_MINUTE * PRIZM_M
 export const PRIZM_MILLISECONDS_IN_DAY = PRIZM_MILLISECONDS_IN_HOUR * PRIZM_HOURS_IN_DAY;
 
 export class PrizmDateTime {
+  constructor(public day: PrizmDay, public time: PrizmTime | null = new PrizmTime(0, 0)) {}
+
   public static fromLocalNativeDate(date: Date): PrizmDateTime {
     return new PrizmDateTime(PrizmDay.fromLocalNativeDate(date), PrizmTime.fromLocalNativeDate(date));
   }
-
-  constructor(public day: PrizmDay, public time: PrizmTime | null = new PrizmTime(0, 0)) {}
 
   public toLocalNativeDate(): Date {
     return new Date(

--- a/libs/components/src/lib/components/calendar-range/calendar-range.component.html
+++ b/libs/components/src/lib/components/calendar-range/calendar-range.component.html
@@ -62,10 +62,6 @@
       >
         <div class="btn-content">
           <span>{{ item }}</span>
-          <!--          <prizm-icon-->
-          <!--            [style.visibility]="isItemActive(item) ? '' : 'hidden'"-->
-          <!--            iconClass="selection-check-simple"-->
-          <!--          ></prizm-icon>-->
           <prizm-icons-full
             [style.visibility]="isItemActive(item) ? '' : 'hidden'"
             name="check"

--- a/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.html
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.html
@@ -138,7 +138,7 @@
             [style.--prizm-dropdown-host-width]="'100%'"
             [ngModelOptions]="{ standalone: true }"
             [ngModel]="value?.timeRange?.from"
-            [items]="timeItems"
+            [items]="timeItems | prizmTimeConstraints : $any(value?.dayRange?.from) : min : max"
             [strict]="timeStrict"
             [mode]="timeMode"
             (ngModelChange)="updateTimeFrom($event)"
@@ -154,7 +154,7 @@
             [ngModel]="value?.timeRange?.to"
             [ngModelOptions]="{ standalone: true }"
             [strict]="timeStrict"
-            [items]="timeItems"
+            [items]="timeItems | prizmTimeConstraints : $any(value?.dayRange?.to) : min : max"
             [mode]="timeMode"
             (ngModelChange)="updateTimeTo($event)"
           >

--- a/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time-range/input-layout-date-time-range.component.ts
@@ -65,6 +65,7 @@ import { PrizmDropdownHostComponent } from '../../dropdowns/dropdown-host';
 import { PrizmCalendarRangeComponent } from '../../calendar-range';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsCalendarRange, prizmIconsClock } from '@prizm-ui/icons/full/source';
+import { PrizmTimeConstraintsPipe } from '../../../pipes/time-constraints/time-constraints.pipe';
 
 @Component({
   selector: `prizm-input-layout-date-time-range`,
@@ -101,6 +102,7 @@ import { prizmIconsCalendarRange, prizmIconsClock } from '@prizm-ui/icons/full/s
     PrizmCalendarRangeComponent,
     PrizmValueAccessorDirective,
     FormsModule,
+    PrizmTimeConstraintsPipe,
   ],
 })
 export class PrizmInputLayoutDateTimeRangeComponent

--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.html
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.html
@@ -108,7 +108,7 @@
   >
     <ng-container>
       <prizm-listing-item
-        *ngFor="let item of timeItems; let idx = index"
+        *ngFor="let item of timeItems | prizmTimeConstraints : calendarValue : min : max; let idx = index"
         [selected]="value?.[1] && item.isSameTime($any(value?.[1]))"
         (click)="$event.stopPropagation(); onTimeMenuClick(item, $event)"
       >

--- a/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
+++ b/libs/components/src/lib/components/input/input-date-time/input-layout-date-time.component.ts
@@ -62,6 +62,7 @@ import { PrizmLanguageInputLayoutDateTime } from '@prizm-ui/i18n';
 import { prizmTimeLimitWithinRange } from '../../../@core/date-time/time-limit';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsCalendarBlank, prizmIconsClock } from '@prizm-ui/icons/full/source';
+import { PrizmTimeConstraintsPipe } from '../../../pipes/time-constraints/time-constraints.pipe';
 
 @Component({
   selector: `prizm-input-layout-date-time`,
@@ -107,6 +108,7 @@ import { prizmIconsCalendarBlank, prizmIconsClock } from '@prizm-ui/icons/full/s
     PrizmInputNativeValueDirective,
     PrizmListingItemComponent,
     PrizmPluckPipe,
+    PrizmTimeConstraintsPipe,
   ],
 })
 export class PrizmInputLayoutDateTimeComponent

--- a/libs/components/src/lib/pipes/month/month.pipe.ts
+++ b/libs/components/src/lib/pipes/month/month.pipe.ts
@@ -1,7 +1,6 @@
 import { Inject, Pipe, PipeTransform } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { distinctUntilChanged, map, tap } from 'rxjs/operators';
-import { PrizmMonth } from '../../@core/date-time/month';
+import { map } from 'rxjs/operators';
 import { PRIZM_MONTHS } from '../../tokens/i18n';
 
 @Pipe({ name: `prizmMonth`, standalone: true })

--- a/libs/components/src/lib/pipes/time-constraints/index.ts
+++ b/libs/components/src/lib/pipes/time-constraints/index.ts
@@ -1,0 +1,1 @@
+export * from './time-constraints.pipe';

--- a/libs/components/src/lib/pipes/time-constraints/time-constraints.pipe.ts
+++ b/libs/components/src/lib/pipes/time-constraints/time-constraints.pipe.ts
@@ -1,0 +1,32 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { PrizmDay, PrizmTime } from '../../@core';
+
+@Pipe({ name: 'prizmTimeConstraints', standalone: true })
+export class PrizmTimeConstraintsPipe implements PipeTransform {
+  public transform(
+    timeItems: readonly PrizmTime[],
+    currentDate: PrizmDay | null,
+    min: PrizmDay | [PrizmDay, PrizmTime],
+    max: PrizmDay | [PrizmDay, PrizmTime]
+  ): PrizmTime[] {
+    let items = [...timeItems];
+
+    if (!currentDate || (min instanceof PrizmDay && max instanceof PrizmDay)) {
+      return items;
+    }
+
+    const minDate = min instanceof PrizmDay ? null : min[0];
+    const maxDate = max instanceof PrizmDay ? null : max[0];
+
+    if (minDate && currentDate?.daySame(minDate)) {
+      items = items.filter(el => el.hours >= (min as [PrizmDay, PrizmTime])[1].hours);
+    }
+
+    if (maxDate && currentDate?.daySame(maxDate)) {
+      items = items.filter(el => el.hours <= (max as [PrizmDay, PrizmTime])[1].hours);
+    }
+
+    return items;
+  }
+}

--- a/libs/components/src/lib/pipes/time-constraints/time-constraints.pipe.ts
+++ b/libs/components/src/lib/pipes/time-constraints/time-constraints.pipe.ts
@@ -1,19 +1,28 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { PrizmDay, PrizmTime } from '../../@core';
+import { PrizmDateTime, PrizmDay, PrizmTime } from '../../@core';
+import { PrizmDateTimeMinMax } from '../../components';
 
 @Pipe({ name: 'prizmTimeConstraints', standalone: true })
 export class PrizmTimeConstraintsPipe implements PipeTransform {
   public transform(
     timeItems: readonly PrizmTime[],
-    currentDate: PrizmDay | null,
-    min: PrizmDay | [PrizmDay, PrizmTime],
-    max: PrizmDay | [PrizmDay, PrizmTime]
+    currentDate: PrizmDay | null | undefined,
+    min: PrizmDay | [PrizmDay, PrizmTime] | PrizmDateTimeMinMax,
+    max: PrizmDay | [PrizmDay, PrizmTime] | PrizmDateTimeMinMax
   ): PrizmTime[] {
     let items = [...timeItems];
 
     if (!currentDate || (min instanceof PrizmDay && max instanceof PrizmDay)) {
       return items;
+    }
+
+    if (min instanceof PrizmDateTime) {
+      min = min.time ? [min.day, min.time] : min.day;
+    }
+
+    if (max instanceof PrizmDateTime) {
+      max = max.time ? [max.day, max.time] : max.day;
     }
 
     const minDate = min instanceof PrizmDay ? null : min[0];


### PR DESCRIPTION
feat(components/input-date-time): add time restrictions for min max values #1570
feat(components/input-date-time-range): add time restrictions for min max values #1570

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

PrizmInputLayoutDateTime

### Задача

resolved #1570 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [ ] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes
Добавили ограничения на выбор времени из списка с учетом минимальных и максимальных значений в PrizmInputLayoutDateTime