### PR TITLE
Feat/charts color api 1816 v5

### DIFF
--- a/apps/doc/src/app/charts/area/area.component.html
+++ b/apps/doc/src/app/charts/area/area.component.html
@@ -21,6 +21,7 @@
         [theme]="$any(prizmTheme.changesTheme$ | async)"
         [height]="height"
         [width]="width"
+        [color]="color"
       ></prizm-charts-area>
     </prizm-doc-demo>
     <prizm-doc-documentation>
@@ -90,6 +91,14 @@
         documentationPropertyMode="input"
       >
         Height
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets color to line. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/area/area.component.html
+++ b/apps/doc/src/app/charts/area/area.component.html
@@ -98,7 +98,7 @@
         documentationPropertyType="string"
         documentationPropertyMode="input"
       >
-        Color. Sets color to line. Note, for chart with seriesField use colors array.
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/area/area.component.html
+++ b/apps/doc/src/app/charts/area/area.component.html
@@ -79,7 +79,7 @@
       <ng-template
         documentationPropertyName="options"
         documentationPropertyMode="input"
-        documentationPropertyType="PrizmChartsAriaOptions"
+        documentationPropertyType="PrizmChartsAreaOptions"
       >
         Options
       </ng-template>

--- a/apps/doc/src/app/charts/area/area.component.ts
+++ b/apps/doc/src/app/charts/area/area.component.ts
@@ -11,6 +11,7 @@ export class AreaComponent {
   width: number | null = null;
   xField = 'x';
   yField = 'y';
+  color = '';
   data = [
     {
       x: '2006 Q3',

--- a/apps/doc/src/app/charts/column/column.component.html
+++ b/apps/doc/src/app/charts/column/column.component.html
@@ -32,6 +32,7 @@
         [groupField]="groupField"
         [seriesField]="seriesField"
         [yField]="yField"
+        [color]="color"
       >
       </prizm-charts-column>
     </prizm-doc-demo>
@@ -121,82 +122,14 @@
       >
         Group Field
       </ng-template>
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="ng-content"-->
-      <!--        documentationPropertyType="string"-->
-      <!--        [(documentationPropertyValue)]="content"-->
-      <!--      >-->
-      <!--        NgContent-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="size"-->
-      <!--        documentationPropertyType="PrizmSize"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [documentationPropertyValues]="sizeVariants"-->
-      <!--        [(documentationPropertyValue)]="size"-->
-      <!--      >-->
-      <!--        Size-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="appearance"-->
-      <!--        documentationPropertyType="PrizmAppearance"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [documentationPropertyValues]="appearanceVariants"-->
-      <!--        [(documentationPropertyValue)]="appearance"-->
-      <!--      >-->
-      <!--        Appearance-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="appearanceType"-->
-      <!--        documentationPropertyType="PrizmAppearanceType"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [documentationPropertyValues]="appearanceTypeVariants"-->
-      <!--        [(documentationPropertyValue)]="appearanceType"-->
-      <!--      >-->
-      <!--        AppearanceType-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="icon"-->
-      <!--        documentationPropertyType="PrizmContent"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [documentationPropertyValues]="iconVariants"-->
-      <!--        [(documentationPropertyValue)]="icon"-->
-      <!--      >-->
-      <!--        Icon-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="iconRight"-->
-      <!--        documentationPropertyType="PrizmContent"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [documentationPropertyValues]="iconVariants"-->
-      <!--        [(documentationPropertyValue)]="iconRight"-->
-      <!--      >-->
-      <!--        Right Icon-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="disabled"-->
-      <!--        documentationPropertyType="boolean"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [(documentationPropertyValue)]="disabled"-->
-      <!--      >-->
-      <!--        Disabled-->
-      <!--      </ng-template>-->
-
-      <!--      <ng-template-->
-      <!--        documentationPropertyName="showLoader"-->
-      <!--        documentationPropertyType="boolean"-->
-      <!--        documentationPropertyMode="input"-->
-      <!--        [(documentationPropertyValue)]="showLoader"-->
-      <!--      >-->
-      <!--        Show Loader-->
-      <!--      </ng-template>-->
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
+      </ng-template>
     </prizm-doc-documentation>
   </ng-template>
 

--- a/apps/doc/src/app/charts/column/column.component.ts
+++ b/apps/doc/src/app/charts/column/column.component.ts
@@ -12,6 +12,7 @@ import { PrizmChartsColumnItem } from '@prizm-ui/charts';
 export class ColumnComponent {
   public sizeVariants: ReadonlyArray<PrizmSize> = ['s', 'm', 'xm', 'l', 'xl'];
   public size: PrizmSize = this.sizeVariants[0];
+  color = '';
   public data: PrizmChartsColumnItem[] = [
     {
       product_type: 'Офисные принадлежности',

--- a/apps/doc/src/app/charts/column/examples/stack/prizm-charts-column-stack-example.component.html
+++ b/apps/doc/src/app/charts/column/examples/stack/prizm-charts-column-stack-example.component.html
@@ -6,6 +6,7 @@
   [seriesField]="seriesField"
   [options]="options"
   [theme]="$any(prizmTheme.changesTheme$ | async)"
+  [color]="['#ffe599', '#93c47d']"
   xField="product_type"
   yField="order_amt"
   seriesField="product_sub_type"

--- a/apps/doc/src/app/charts/line/examples/series/prizm-charts-line-series-example.component.html
+++ b/apps/doc/src/app/charts/line/examples/series/prizm-charts-line-series-example.component.html
@@ -6,4 +6,5 @@
   [yField]="'value'"
   [options]="{ smooth: true }"
   [seriesField]="'city'"
+  [color]="['#00bffb', '#f400b1']"
 ></prizm-charts-line>

--- a/apps/doc/src/app/charts/line/line.component.html
+++ b/apps/doc/src/app/charts/line/line.component.html
@@ -29,6 +29,7 @@
         [seriesField]="$any(seriesField)"
         [theme]="$any(prizmTheme.changesTheme$ | async)"
         [height]="height"
+        [color]="color"
       ></prizm-charts-line>
     </prizm-doc-demo>
     <prizm-doc-documentation>
@@ -66,15 +67,6 @@
         documentationPropertyMode="input"
       >
         Series Field Name (use 'key' for example data)
-      </ng-template>
-
-      <ng-template
-        [(documentationPropertyValue)]="width"
-        documentationPropertyName="width"
-        documentationPropertyType="number"
-        documentationPropertyMode="input"
-      >
-        Width
       </ng-template>
 
       <ng-template
@@ -116,6 +108,15 @@
         documentationPropertyMode="input"
       >
         Height
+      </ng-template>
+
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets color to line. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/line/line.component.ts
+++ b/apps/doc/src/app/charts/line/line.component.ts
@@ -11,6 +11,7 @@ export class LineComponent {
   height = 300;
   xField = 'x';
   yField = 'y';
+  color = '';
   width: number | null = null;
   seriesField: string | null = null;
   data: any = [

--- a/apps/doc/src/app/charts/pie/pie.component.html
+++ b/apps/doc/src/app/charts/pie/pie.component.html
@@ -24,6 +24,7 @@
         [interactions]="interactions"
         [label]="label"
         [theme]="$any(prizmTheme.changesTheme$ | async)"
+        [color]="color"
       >
       </prizm-charts-pie>
     </prizm-doc-demo>
@@ -102,6 +103,14 @@
         documentationPropertyMode="input"
       >
         Label
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/pie/pie.component.ts
+++ b/apps/doc/src/app/charts/pie/pie.component.ts
@@ -20,6 +20,7 @@ export class PieComponent {
   ];
   colorField = 'type';
   angleField = 'value';
+  color = '';
   interactions: PrizmChartsPieOptions['interactions'] = [{ type: 'element-active' }];
   label: PrizmChartsPieOptions['label'] = {
     type: 'inner',

--- a/apps/doc/src/app/charts/radar/radar.component.html
+++ b/apps/doc/src/app/charts/radar/radar.component.html
@@ -22,6 +22,7 @@
         [theme]="$any(prizmTheme.changesTheme$ | async)"
         [yField]="yField"
         [options]="options"
+        [color]="color"
       ></prizm-charts-radar>
     </prizm-doc-demo>
     <prizm-doc-documentation>
@@ -91,6 +92,14 @@
         documentationPropertyType="PrizmChartsRadarItem[]"
       >
         Data
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/radar/radar.component.ts
+++ b/apps/doc/src/app/charts/radar/radar.component.ts
@@ -24,6 +24,7 @@ export class RadarComponent {
   public width = 400;
   public height = 300;
   public yField = 'star';
+  public color = '';
   public options: Partial<PrizmChartsRadarOptions> = {
     appendPadding: [0, 10, 0, 10],
     meta: {

--- a/apps/doc/src/app/charts/radial-bar/radial-bar.component.html
+++ b/apps/doc/src/app/charts/radial-bar/radial-bar.component.html
@@ -20,6 +20,7 @@
         [width]="width"
         [yField]="yField"
         [options]="options"
+        [color]="color"
       ></prizm-charts-radial-bar>
     </prizm-doc-demo>
     <prizm-doc-documentation>
@@ -89,6 +90,14 @@
         documentationPropertyMode="input"
       >
         Y Field Name
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/radial-bar/radial-bar.component.ts
+++ b/apps/doc/src/app/charts/radial-bar/radial-bar.component.ts
@@ -30,6 +30,7 @@ export class RadialBarComponent {
   ];
   public xField = 'name';
   public yField = 'star';
+  color = '';
 
   public options: Partial<PrizmChartsRadialBarOptions> = {
     radius: 0.8,

--- a/apps/doc/src/app/charts/scatter/scatter.component.html
+++ b/apps/doc/src/app/charts/scatter/scatter.component.html
@@ -23,6 +23,7 @@
         [colorField]="colorField"
         [theme]="$any($any(prizmTheme.changesTheme$ | async))"
         [options]="{ size: 5, shape: 'circle', appendPadding: 30 }"
+        [color]="color"
       ></prizm-charts-scatter>
     </prizm-doc-demo>
 
@@ -102,6 +103,15 @@
         documentationPropertyMode="input"
       >
         Height
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        [documentationPropertyValues]="$any(colorVariants)"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/scatter/scatter.component.ts
+++ b/apps/doc/src/app/charts/scatter/scatter.component.ts
@@ -260,6 +260,8 @@ export class ScatterComponent {
   public yField = 'Shot conceded';
   public xField = 'xG conceded';
   public colorField = 'Result';
+  public colorVariants = ['', '#664d4d', ['red', 'blue', 'green'], ['#650000', '#7dbbb0', '#a37c18']];
+  public color = this.colorVariants[0];
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   readonly exampleOutline: TuiDocExample = {

--- a/apps/doc/src/app/charts/treemap/treemap.component.html
+++ b/apps/doc/src/app/charts/treemap/treemap.component.html
@@ -19,6 +19,7 @@
         [height]="height"
         [colorField]="colorField"
         [theme]="$any($any(prizmTheme.changesTheme$ | async))"
+        [color]="color"
       ></prizm-charts-treemap>
     </prizm-doc-demo>
     <prizm-doc-documentation>
@@ -72,6 +73,15 @@
         documentationPropertyMode="input"
       >
         Data
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        [documentationPropertyValues]="$any(colorVariants)"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/treemap/treemap.component.ts
+++ b/apps/doc/src/app/charts/treemap/treemap.component.ts
@@ -35,6 +35,12 @@ export class TreemapComponent {
     ],
   };
   public colorField = 'name';
+  public colorVariants = [
+    '',
+    ['red', 'blue', 'green', 'yellow'],
+    ['#b07e9f', '#7dbbb0', '#a37c18', '#e7bee6', '#396878', '#6699cc', '#fc9e7b'],
+  ];
+  public color = this.colorVariants[0];
   readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
   public width: number | null = null;
   public height = 300;

--- a/apps/doc/src/app/charts/waterfall/waterfall.component.html
+++ b/apps/doc/src/app/charts/waterfall/waterfall.component.html
@@ -19,6 +19,7 @@
         [xField]="xField"
         [yField]="yField"
         [theme]="$any(prizmTheme.changesTheme$ | async)"
+        [color]="color"
       ></prizm-charts-waterfall>
     </prizm-doc-demo>
     <prizm-doc-documentation>
@@ -80,6 +81,15 @@
         documentationPropertyMode="input"
       >
         Height
+      </ng-template>
+      <ng-template
+        [(documentationPropertyValue)]="color"
+        [documentationPropertyValues]="$any(colorVariants)"
+        documentationPropertyName="color"
+        documentationPropertyType="string"
+        documentationPropertyMode="input"
+      >
+        Color. Sets charts color. Note, for chart with seriesField use colors array.
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/charts/waterfall/waterfall.component.ts
+++ b/apps/doc/src/app/charts/waterfall/waterfall.component.ts
@@ -20,6 +20,12 @@ export class WaterfallComponent {
   ];
   public xField = 'type';
   public yField = 'money';
+  public colorVariants = [
+    '',
+    ['red', 'blue', 'green', 'yellow'],
+    ['#b07e9f', '#7dbbb0', '#a37c18', '#e7bee6', '#396878', '#6699cc', '#fc9e7b'],
+  ];
+  public color = this.colorVariants[0];
   public options = {
     appendPadding: [15, 0, 0, 0],
     meta: {

--- a/libs/charts/base/src/lib/components/area/model.ts
+++ b/libs/charts/base/src/lib/components/area/model.ts
@@ -1,5 +1,11 @@
 import { Area, AreaOptions } from '@antv/g2plot';
 
-export type PrizmChartsAriaOptions = AreaOptions;
+export type PrizmChartsAreaOptions = AreaOptions;
 export type PrizmChartsAreaOrigin = Area;
 export type PrizmChartsAreaItem = Record<string, unknown>;
+
+/**
+ * @deprecated
+ * use PrizmChartsAreaOptions type, will be removed in 6.0.0
+ * */
+export type PrizmChartsAriaOptions = AreaOptions;

--- a/libs/charts/base/src/lib/components/area/prizm-charts-area.component.ts
+++ b/libs/charts/base/src/lib/components/area/prizm-charts-area.component.ts
@@ -26,6 +26,14 @@ export class PrizmChartsAreaComponent<T extends Record<string, unknown>> extends
     return this.origin?.options?.data;
   }
 
+  @Input()
+  public set color(value: PrizmChartsAriaOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsAriaOptions['color'] {
+    return this.options.color;
+  }
+
   @Input() set autoFit(value: boolean) {
     this.updateOptions({ autoFit: value });
   }

--- a/libs/charts/base/src/lib/components/area/prizm-charts-area.component.ts
+++ b/libs/charts/base/src/lib/components/area/prizm-charts-area.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Injector, Input } from '@angular/core';
 import { prizmDefaultProp } from '@prizm-ui/core';
 import { Area } from '@antv/g2plot';
-import { PrizmChartsAreaItem, PrizmChartsAreaOrigin, PrizmChartsAriaOptions } from './model';
+import { PrizmChartsAreaItem, PrizmChartsAreaOrigin, PrizmChartsAreaOptions } from './model';
 import { PrizmChartsAbstractComponent } from '../../abstract/prizm-charts-abstract';
 import { CommonModule } from '@angular/common';
 
@@ -14,7 +14,7 @@ import { CommonModule } from '@angular/common';
 })
 export class PrizmChartsAreaComponent<T extends Record<string, unknown>> extends PrizmChartsAbstractComponent<
   PrizmChartsAreaOrigin,
-  PrizmChartsAriaOptions
+  PrizmChartsAreaOptions
 > {
   @Input()
   set data(value: PrizmChartsAreaItem[]) {
@@ -27,10 +27,10 @@ export class PrizmChartsAreaComponent<T extends Record<string, unknown>> extends
   }
 
   @Input()
-  public set color(value: PrizmChartsAriaOptions['color']) {
+  public set color(value: PrizmChartsAreaOptions['color']) {
     this.updateOptions({ color: value });
   }
-  public get color(): PrizmChartsAriaOptions['color'] {
+  public get color(): PrizmChartsAreaOptions['color'] {
     return this.options.color;
   }
 

--- a/libs/charts/base/src/lib/components/column/prizm-charts-column.component.ts
+++ b/libs/charts/base/src/lib/components/column/prizm-charts-column.component.ts
@@ -33,6 +33,14 @@ export class PrizmChartsColumnComponent<
   }
 
   @Input()
+  public set color(value: PrizmChartsColumnOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsColumnOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set seriesField(value: string) {
     this.updateOptions({ seriesField: value });
   }

--- a/libs/charts/base/src/lib/components/line/prizm-charts-line.component.ts
+++ b/libs/charts/base/src/lib/components/line/prizm-charts-line.component.ts
@@ -21,6 +21,14 @@ export class PrizmChartsLineComponent<T = unknown> extends PrizmChartsAbstractCo
 
   private origin_!: PrizmChartsLineOrigin;
 
+  @Input()
+  public set color(value: PrizmChartsLineOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsLineOptions['color'] {
+    return this.options.color;
+  }
+
   @Input() set autoFit(value: boolean) {
     this.updateOptions({ autoFit: value });
   }

--- a/libs/charts/base/src/lib/components/pie/prizm-charts-pie.component.ts
+++ b/libs/charts/base/src/lib/components/pie/prizm-charts-pie.component.ts
@@ -40,6 +40,14 @@ export class PrizmChartsPieComponent<T extends Record<string, unknown>> extends 
   }
 
   @Input()
+  public set color(value: PrizmChartsPieOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsPieOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set colorField(value: string) {
     this.updateOptions({ colorField: value });
   }

--- a/libs/charts/base/src/lib/components/radar/prizm-charts-radar.component.ts
+++ b/libs/charts/base/src/lib/components/radar/prizm-charts-radar.component.ts
@@ -32,6 +32,14 @@ export class PrizmChartsRadarComponent<
   }
 
   @Input()
+  public set color(value: PrizmChartsRadarOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsRadarOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set label(value: PrizmChartsRadarOptions['label']) {
     this.updateOptions({ label: value });
   }

--- a/libs/charts/base/src/lib/components/radial-bar/prizm-charts-radial-bar.component.ts
+++ b/libs/charts/base/src/lib/components/radial-bar/prizm-charts-radial-bar.component.ts
@@ -31,6 +31,14 @@ export class PrizmChartsRadialBarComponent<
   }
 
   @Input()
+  public set color(value: PrizmChartsRadialBarOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsRadialBarOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set label(value: PrizmChartsRadialBarOptions['label']) {
     this.updateOptions({ label: value });
   }

--- a/libs/charts/base/src/lib/components/scatter/prizm-charts-scatter.component.ts
+++ b/libs/charts/base/src/lib/components/scatter/prizm-charts-scatter.component.ts
@@ -29,6 +29,14 @@ export class PrizmChartsScatterComponent<
   }
 
   @Input()
+  public set color(value: PrizmChartsScatterOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsScatterOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set yField(value: string) {
     this.updateOptions({ yField: value });
   }

--- a/libs/charts/base/src/lib/components/treemap/prizm-charts-treemap.component.ts
+++ b/libs/charts/base/src/lib/components/treemap/prizm-charts-treemap.component.ts
@@ -26,6 +26,14 @@ export class PrizmChartsTreemapComponent<
   private origin_!: PrizmChartsTreemapOrigin;
 
   @Input()
+  public set color(value: PrizmChartsTreemapOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsTreemapOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set colorField(value: string) {
     this.updateOptions({ colorField: value });
   }

--- a/libs/charts/base/src/lib/components/waterfall/prizm-charts-waterfall.component.ts
+++ b/libs/charts/base/src/lib/components/waterfall/prizm-charts-waterfall.component.ts
@@ -27,6 +27,14 @@ export class PrizmChartsWaterfallComponent<
   }
 
   @Input()
+  public set color(value: PrizmChartsWaterfallOptions['color']) {
+    this.updateOptions({ color: value });
+  }
+  public get color(): PrizmChartsWaterfallOptions['color'] {
+    return this.options.color;
+  }
+
+  @Input()
   public set xField(value: string) {
     this.updateOptions({ xField: value });
   }


### PR DESCRIPTION
 feat(charts/area): replace PrizmChartsAriaOptions(deprecated now) by PrizmChartsAreaOptions
 feat(charts): add color input for area, line, column, pie, radar, radial bar, scatter, treemap, waterfall  #1816
 feat(doc/charts): for line and column charts added ecamples with user's colors #1817  

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [x] `@prizm-ui/charts` 

### Компонент

Line

### Задача

resolved #1816 
resolved #1817 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [x] Добавление фичи
- [x] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились


### Release notes
Добавили отдельное свойство для цвета для графиков типа line, area, column, pie, radar, radial bar, scatter, treemap, waterfall добавили пример по изменению цветов графика в документацию.