### PR TITLE
feat(components/paginator): update paginator dictionary #1840

### DIFF
--- a/apps/doc/src/app/components/paginator/examples/paginator-with-labels-example/paginator-with-labels-example.component.html
+++ b/apps/doc/src/app/components/paginator/examples/paginator-with-labels-example/paginator-with-labels-example.component.html
@@ -6,6 +6,6 @@
   [page]="6"
   [paginatorOptions]="{ noRowsSelectorLabel: true }"
   [rowsCountOptions]="[10, 20, 60]"
-  leftButtonLabel="Назад"
-  rightButtonLabel="Вперед"
+  [leftButtonLabel]="({ russian: 'Назад' } | prizmLang : 'Back' | async)!"
+  [rightButtonLabel]="({ russian: 'Вперед' } | prizmLang : 'Forward' | async)!"
 ></prizm-paginator>

--- a/apps/doc/src/app/components/paginator/paginator-example.module.ts
+++ b/apps/doc/src/app/components/paginator/paginator-example.module.ts
@@ -17,6 +17,7 @@ import { PaginatorWithLabelsExampleComponent } from './examples/paginator-with-l
 import { PaginatorInfiniteExampleComponent } from './examples/paginator-infinite-example/paginator-infinite-example.component';
 import { PaginatorOptionsExampleComponent } from './examples/paginator-options-example/paginator-options-example.component';
 import { PaginatorI18nExampleComponent } from './examples/i18n/paginator-i18n-example.component';
+import { PrizmLanguagePipe } from '@prizm-ui/i18n';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { PaginatorI18nExampleComponent } from './examples/i18n/paginator-i18n-ex
     RouterModule.forChild(prizmDocGenerateRoutes(PaginatorExampleComponent)),
     PrizmPaginatorComponent,
     PaginatorI18nExampleComponent,
+    PrizmLanguagePipe,
   ],
 })
 export class PaginatorExampleModule {}

--- a/libs/components/src/lib/components/paginator/paginator.component.html
+++ b/libs/components/src/lib/components/paginator/paginator.component.html
@@ -1,10 +1,12 @@
-<div class="container">
+<div class="container" *prizmLet="paginator$ | async as language">
   <div class="content">
     <span
       class="rows rows__count"
       *ngIf="!paginatorOptions?.noRowsSelector && !paginatorOptions?.noRowsSelectorLabel"
     >
-      <ng-container *polymorphOutlet="textOnPage as title">
+      <ng-container
+        *polymorphOutlet="textOnPage ? textOnPage : (language | prizmPluck : ['linesOnPage']) as title"
+      >
         {{ title }}
       </ng-container>
     </span>
@@ -25,14 +27,14 @@
   <div class="content">
     <span class="rows rows__show" *ngIf="!paginatorOptions?.noInfo" [hidden]="disabled">
       <span data-testid="paginator-i18n-lines-shown">
-        {{ paginator$ | async | prizmPluck : ['linesShown'] }}
+        {{ language | prizmPluck : ['linesShown'] }}
       </span>
       <span data-testid="paginator-lines-shown"> {{ (currentPage - 1) * rows + 1 }} </span>-
       <span data-testid="paginator-total-count">
         {{ currentPage * rows > $any(totalRecords) ? totalRecords : currentPage * rows }}
       </span>
       <span data-testid="paginator-i18n-from-text">
-        {{ paginator$ | async | prizmPluck : ['fromText'] }}
+        {{ language | prizmPluck : ['fromText'] }}
       </span>
       <span data-testid="paginator-real-total-record">
         {{ realTotalRecord }}
@@ -186,7 +188,7 @@
         appearance="primary"
         size="m"
       >
-        {{ moreButtonLabel }}
+        {{ moreButtonLabel ? moreButtonLabel : (language | prizmPluck : ['moreButtonLabel']) }}
       </button>
     </div>
   </div>

--- a/libs/components/src/lib/components/paginator/paginator.component.ts
+++ b/libs/components/src/lib/components/paginator/paginator.component.ts
@@ -56,7 +56,10 @@ import {
 })
 export class PrizmPaginatorComponent extends PrizmAbstractTestId implements OnInit {
   @Input() public paginatorType: PrizmPaginatorType = 'finite';
-  @Input() textOnPage: PolymorphContent = 'Строк на странице';
+  @Input() textOnPage: PolymorphContent;
+  @Input() public leftButtonLabel = '';
+  @Input() public rightButtonLabel = '';
+  @Input() public moreButtonLabel = '';
   /** The length of the total number of items that are being paginated. Defaulted to 0. */
   @Input()
   get totalRecords(): number | null {
@@ -105,10 +108,6 @@ export class PrizmPaginatorComponent extends PrizmAbstractTestId implements OnIn
     noInfo: false,
     noPages: false,
   };
-
-  @Input() public leftButtonLabel = '';
-  @Input() public rightButtonLabel = '';
-  @Input() moreButtonLabel = 'Показать еще';
 
   @Input() public rowsCountOptions: number[] = [];
   @Output() public paginatorChange: EventEmitter<PrizmPaginatorOutput> =

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -136,6 +136,8 @@ export interface PrizmLanguagePaginator {
   paginator: {
     linesShown: string;
     fromText: string;
+    linesOnPage: string;
+    moreButtonLabel: string;
   };
 }
 

--- a/libs/i18n/src/lib/languages/english/paginator.ts
+++ b/libs/i18n/src/lib/languages/english/paginator.ts
@@ -4,5 +4,7 @@ export const PRIZM_ENGLISH_PAGINATOR: PrizmLanguagePaginator = {
   paginator: {
     linesShown: 'Lines shown:',
     fromText: 'out of',
+    linesOnPage: 'Lines per page',
+    moreButtonLabel: 'Show more',
   },
 };

--- a/libs/i18n/src/lib/languages/russian/paginator.ts
+++ b/libs/i18n/src/lib/languages/russian/paginator.ts
@@ -4,5 +4,7 @@ export const PRIZM_RUSSIAN_PAGINATOR: PrizmLanguagePaginator = {
   paginator: {
     linesShown: 'Показано строк:',
     fromText: 'из',
+    linesOnPage: 'Строк на странице',
+    moreButtonLabel: 'Показать ещё',
   },
 };


### PR DESCRIPTION
feat(components/paginator): update paginator dictionary #1840 BREAKING CHANGE in dictionary  - BREAKING CHANGE in dictionaries, why we do this read [here](https://github.com/zyfra/Prizm/discussions/1617)


### Библиотека

- [ ] `@prizm-ui/core`
- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/flag-icons`
- [ ] `@prizm-ui/theme`
- [ ] `@prizm-ui/charts`
- [ ] `@prizm-ui/ast`
- [ ] `@prizm-ui/nx-plugin`

### Компонент
paginator

### Задача
resolved #1840 

### Изменения

- [x] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [ ] Исправление бага

Checklist:

- [x] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [x] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью
 кастомные лейблы в paginator

### Описание

Дополнили локализацию компонента Paginator и доработали примеры.