### PR TITLE
fix(components/table): table sort cursor correction #1986

### DIFF
--- a/libs/components/src/lib/components/table/th/th.component.html
+++ b/libs/components/src/lib/components/table/th/th.component.html
@@ -2,9 +2,7 @@
   <ng-container [ngTemplateOutlet]="content"></ng-container>
   {{ table.change$ | async }}
   <span class="sort__block" [class.sort__block_active]="isCurrent">
-    <span class="sorter__number" [style.visibility]="count > 1 && num ? 'visible' : 'hidden'">{{
-      num ?? '0'
-    }}</span>
+    <span class="sorter__number" [class.hidden]="!(count > 1 && num)">{{ num }}</span>
     <button
       class="sorter__icon"
       [icon]="$any(icon$ | async)"

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -83,6 +83,10 @@
       min-width: 16px;
       text-align: end;
       cursor: default;
+
+      &.hidden {
+        display: none;
+      }
     }
   }
 }

--- a/libs/components/src/lib/components/table/th/th.style.less
+++ b/libs/components/src/lib/components/table/th/th.style.less
@@ -71,7 +71,6 @@
       display: flex;
       gap: 2px;
       color: var(--prizm-button-secondary-solid-default);
-      cursor: pointer;
       align-items: center;
       justify-content: center;
 
@@ -83,6 +82,7 @@
     &__number {
       min-width: 16px;
       text-align: end;
+      cursor: default;
     }
   }
 }


### PR DESCRIPTION
fix(components/table): table sort cursor correction #1986
fix(components/table): sorter count div should not reserve space when empty #2021

… empty https://github.com/zyfra/Prizm/issues/2021

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Table

### Задача

resolved #1986 
resolved #2021 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes
Поправили верстку для сортировки таблиц