### PR TITLE
feat(components/checkbox): add box shadow for disabled radio and checkbox and radio v4 #2024

### DIFF
--- a/libs/components/src/lib/components/checkbox/checkbox.component.less
+++ b/libs/components/src/lib/components/checkbox/checkbox.component.less
@@ -104,6 +104,7 @@
   .checkbox {
     border-color: var(--prizm-form-fill-disable);
     background-color: var(--prizm-form-fill-disable);
+    box-shadow: 0 0 0 1px var(--prizm-background-fill-primary);
     &--checked,
     &--indeterminate {
       background-color: var(--prizm-form-active-disable);

--- a/libs/components/src/lib/components/radio/prizm-radio-button.component.less
+++ b/libs/components/src/lib/components/radio/prizm-radio-button.component.less
@@ -109,6 +109,7 @@ prizm-radio-button {
       & + .radio-button {
         border-color: var(--prizm-form-fill-disable);
         background-color: var(--prizm-form-fill-disable);
+        box-shadow: 0 0 0 1px var(--prizm-background-fill-primary);
       }
 
       &:checked + .radio-button {


### PR DESCRIPTION
feat(components/checkbox): add box shadow for disabled radio and checkbox #2024

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

checkbox
radiobutton

### Задача

resolved #2024

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [ ] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release notes
Добавили тени для компоентов checkbox и radiobutton в состоянии disable для улучшения пользовательского опыта
