### PR TITLE
feat(components/input-select): fix position search input for dropdown #1981

### DIFF
--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.html
@@ -27,6 +27,19 @@
   />
 
   <ng-template #dropdown>
+    <div class="list-search-item" *ngIf="searchable">
+      <prizm-input-layout [label]="searchLabelTranslation$ | async" size="m">
+        <input
+          class="input-search"
+          #input
+          [formControl]="searchInputControl"
+          (input)="dropdownHostRef.reCalculatePositions(1000 / 16)"
+          prizmInput
+          prizmAutoFocus
+        />
+        <button [interactive]="true" prizmInputIconButton="magnifying-glass" prizm-input-right></button>
+      </prizm-input-layout>
+    </div>
     <prizm-data-list
       class="block"
       *prizmLet="{ filteredItems: filteredItems$ | async } as $"
@@ -34,19 +47,6 @@
       [style.--prizm-data-list-border]="0"
       (prizmOnDestroy)="onTouch()"
     >
-      <div class="list-search-item" *ngIf="searchable">
-        <prizm-input-layout [label]="searchLabelTranslation$ | async" size="m">
-          <input
-            class="input-search"
-            #input
-            [formControl]="searchInputControl"
-            (input)="dropdownHostRef.reCalculatePositions(1000 / 16)"
-            prizmInput
-            prizmAutoFocus
-          />
-          <button [interactive]="true" prizmInputIconButton="magnifying-glass" prizm-input-right></button>
-        </prizm-input-layout>
-      </div>
       <ng-container *ngIf="$.filteredItems?.length; else emptyTemplate">
         <div
           class="item"

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.less
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.less
@@ -79,7 +79,7 @@
 }
 
 .list-search-item {
-  padding: var(--prizm-select-item-padding, 8px 16px);
+  padding: var(--prizm-select-item-padding, 16px 16px 8px);
 
   prizm-input-layout {
     width: 100%;

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.html
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.html
@@ -97,6 +97,19 @@
     </ng-template>
 
     <ng-template #dropdown>
+      <div class="list-search-item" *ngIf="searchable">
+        <prizm-input-layout [label]="searchLabelTranslation$ | async">
+          <input
+            class="input-search"
+            [ngModel]="printing$.value"
+            [ngModelOptions]="{ standalone: true }"
+            (ngModelChange)="dropdownHostRef.reCalculatePositions(1000 / 16); printing$.next($event)"
+            prizmInput
+            prizmAutoFocus
+          />
+          <button [interactive]="true" prizmInputIconButton="magnifying-glass" prizm-input-right></button>
+        </prizm-input-layout>
+      </div>
       <prizm-data-list
         class="block"
         *prizmLet="(filteredItems$ | async) ?? [] as items"
@@ -104,70 +117,10 @@
         [style.--prizm-data-list-border]="0"
         (prizmOnDestroy)="onTouch()"
       >
-        <div class="list-search-item" *ngIf="searchable">
-          <prizm-input-layout [label]="searchLabelTranslation$ | async">
-            <input
-              class="input-search"
-              [ngModel]="printing$.value"
-              [ngModelOptions]="{ standalone: true }"
-              (ngModelChange)="dropdownHostRef.reCalculatePositions(1000 / 16); printing$.next($event)"
-              prizmInput
-              prizmAutoFocus
-            />
-            <button [interactive]="true" prizmInputIconButton="magnifying-glass" prizm-input-right></button>
-          </prizm-input-layout>
-        </div>
         <ng-container *ngIf="items?.length; else emptyTemplate">
           <ng-container *polymorphOutlet="customItemDataList?.template">
             <prizm-input-select-item *ngFor="let item of items" [item]="item"></prizm-input-select-item>
           </ng-container>
-          <!--          <div-->
-          <!--            class="item"-->
-          <!--            #hostHint-->
-          <!--            *ngFor="let item of items; let idx = index"-->
-          <!--            [class.most-relevant]="isMostRelevant(idx, items)"-->
-          <!--            [class.selected]="-->
-          <!--              item === value ||-->
-          <!--              (item && value && (transformer(item) | prizmCallFunc : identityMatcher : value))-->
-          <!--            "-->
-          <!--            prizmInputSelectOption-->
-          <!--            [value]='item'-->
-          <!--          >-->
-          <!--            <ng-container *ngIf="!isNullish(item); else nullContentTemplate">-->
-          <!--              <span-->
-          <!--                class="text"-->
-          <!--                #elem-->
-          <!--                *prizmLet="-->
-          <!--                  item | prizmCallFunc : stringify : $any(nullContent) | prizmToObservable | async as text-->
-          <!--                "-->
-          <!--                [prizmHint]="text"-->
-          <!--                [prizmHintHost]="hostHint"-->
-          <!--                [prizmHintDirection]="direction"-->
-          <!--                [prizmHintCanShow]="$any(elem | prizmCallFunc : prizmIsTextOverflow$ | async)"-->
-          <!--              >-->
-          <!--                <ng-container-->
-          <!--                  *polymorphOutlet="-->
-          <!--                    listItemTemplate ?? valueTemplate as content;-->
-          <!--                    context: {-->
-          <!--                      $implicit: item,-->
-          <!--                      value: item | prizmCallFunc : transformer,-->
-          <!--                      stringify: text-->
-          <!--                    }-->
-          <!--                  "-->
-          <!--                >-->
-          <!--                  {{ text }}-->
-          <!--                </ng-container>-->
-          <!--              </span>-->
-          <!--            </ng-container>-->
-
-          <!--            <ng-template #nullContentTemplate>-->
-          <!--              <ng-container *ngIf="nullContent">-->
-          <!--                <ng-container *polymorphOutlet="nullContent as content">-->
-          <!--                  {{ content }}-->
-          <!--                </ng-container>-->
-          <!--              </ng-container>-->
-          <!--            </ng-template>-->
-          <!--          </div>-->
         </ng-container>
         <ng-template #emptyTemplate>
           <div class="empty-template">

--- a/libs/components/src/lib/components/dropdowns/select/input-select.component.less
+++ b/libs/components/src/lib/components/dropdowns/select/input-select.component.less
@@ -92,7 +92,7 @@ prizm-icon {
 }
 
 .list-search-item {
-  padding: var(--prizm-select-item-padding, 8px 16px);
+  padding: var(--prizm-select-item-padding, 16px 16px 8px);
 
   prizm-input-layout {
     width: 100%;


### PR DESCRIPTION
feat(components/input-select): fix position of search input for dropdown #1981 Note, there are layout changes: if you overridden the --prizm-select-item-padding variable in the project, there may be a regression. 
feat(components/input-multiselect): fix position of search input for dropdown #1981 Note, there are layout changes: if you overridden the --prizm-select-item-padding variable in the project, there may be a regression. 

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

InputSelect InputMultiSelect

### Задача

resolved #1981 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [ ] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes

Зафиксировали положение для поля поиска в селекте и мультиселекте. Обратите внимание, есть изменения в верстке: если вы в проекте переопределяли  переменную --prizm-select-item-padding, возможен регресс. 
