### PR TITLE
fix(doc/versions): angular version correction in doc for v5 #2035

### DIFF
--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -28,7 +28,7 @@ export const PRIZM_LANGUAGES_META: readonly PrizmLanguageMeta[] = [
 ];
 export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
   {
-    label: '5.0.0 (ng17)',
+    label: '5.0.0 (ng18)',
     version: '5.0.0',
     stackblitz: 'https://stackblitz.com/edit/prizm-v5-demo',
     link: getDocSite.bind(null, 'https://doc.prizm.zyfra.com', 'http://prizm.site'),

--- a/apps/doc/src/app/version-manager/versions.constants.ts.ng18
+++ b/apps/doc/src/app/version-manager/versions.constants.ts.ng18
@@ -28,7 +28,7 @@ export const PRIZM_LANGUAGES_META: readonly PrizmLanguageMeta[] = [
 ];
 export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
   {
-    label: '<%= version %> (ng17)',
+    label: '<%= version %> (ng18)',
     version: '<%= version %>',
     stackblitz: 'https://stackblitz.com/edit/prizm-v5-demo',
     link: getDocSite.bind(null, 'https://doc.prizm.zyfra.com', 'http://prizm.site'),


### PR DESCRIPTION
fix(doc/versions): angular version correction in doc for v5 #2035

resolved #2035 

### Release notes 
исправлили ошибку с версией Angular для Prizm5 в документации