### PR TITLE
fix(components/input): padding changed for inner inputs #1763

### DIFF
--- a/libs/components/src/lib/components/input/common/styles/input.component.less
+++ b/libs/components/src/lib/components/input/common/styles/input.component.less
@@ -17,7 +17,7 @@
 
 // In inner context
 :host-context(.prizm-input-form-inner) {
-  padding: 22px 8px 4px 0px;
+  padding: 22px 0px 4px 0px;
 
   &:host-context(.prizm-input-empty-label:not(.prizm-input-form-textarea)) {
     padding-top: 4px;
@@ -42,14 +42,14 @@
 }
 
 :host-context(.prizm-input-form-inner[data-size='l']) {
-  padding: 22px 8px 4px 0px;
+  padding: 22px 0px 4px 0px;
 
   &:host-context(.prizm-input-empty-label:not(.prizm-input-form-textarea)) {
     padding-top: 4px;
   }
 }
 :host-context(.prizm-input-form-inner[data-size='m']) {
-  padding: 16px 8px 2px 0px;
+  padding: 16px 0px 2px 0px;
 
   &:host-context(.prizm-input-empty-label:not(.prizm-input-form-textarea)) {
     padding-top: 2px;


### PR DESCRIPTION
fix(components/input): padding changed for inner inputs #1763

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

_Название компонента или группы компонентов_

### Задача

resolved #1763

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на тестировании

Внутренние отступы в контролах

### Release Notes
Исправлены внутренние отступы у PrizmInput type inner