### PR TITLE
fix(components/input-layout): correct icon for danger status #1916

### DIFF
--- a/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
+++ b/libs/components/src/lib/components/input/common/input-layout/input-layout.component.ts
@@ -29,6 +29,7 @@ import { PrizmI18nService, prizmI18nInitWithKey } from '../../../../services';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import {
   prizmIconsCircleCheckFill,
+  prizmIconsCircleExclamationFill,
   prizmIconsCircleInfoFill,
   prizmIconsDeleteContent,
   prizmIconsTempChevronsDropdownSmall,
@@ -175,7 +176,7 @@ export class PrizmInputLayoutComponent
       prizmIconsDeleteContent,
       prizmIconsTriangleExclamationFill,
       prizmIconsCircleCheckFill,
-      prizmIconsCircleInfoFill,
+      prizmIconsCircleExclamationFill,
       prizmIconsTempChevronsDropdownSmall
     );
   }
@@ -244,7 +245,7 @@ export class PrizmInputLayoutComponent
         break;
 
       case 'danger':
-        statusIcon = 'circle-info-fill';
+        statusIcon = 'circle-exclamation-fill';
         break;
 
       case 'default':


### PR DESCRIPTION
fix(components/input-layout): correct icon for danger status #1916

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

PrizmInputLayout

### Задача

resolved #1916

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [ ] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes

Исправили иконку для статуса danger в PrizmInputLayout
