### PR TITLE
fix(components/navigation): register icons for navigation header and resolved #1836 

### DIFF
--- a/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.html
+++ b/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.html
@@ -2,7 +2,6 @@
   <prizm-header class="header" [prizmTheme]="'dark'">
     <div class="project" [class.project_active]="openNavigation" (click)="toggleNavigation()">
       <div class="project__menu">
-        <!--        <prizm-icon iconClass="view-menu"></prizm-icon>-->
         <prizm-icons-full name="bars"></prizm-icons-full>
       </div>
       <img [src]="logo" alt="" />

--- a/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
+++ b/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
@@ -6,6 +6,7 @@ import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import {
   prizmIconsBars,
   prizmIconsBatteryThreeQuarters,
+  prizmIconsDatabase,
   prizmIconsList,
   prizmIconsMusic,
 } from '@prizm-ui/icons/full/source';
@@ -34,7 +35,8 @@ export class NavigationBasicExampleComponent {
       prizmIconsBars,
       prizmIconsMusic,
       prizmIconsList,
-      prizmIconsBatteryThreeQuarters
+      prizmIconsBatteryThreeQuarters,
+      prizmIconsDatabase
     );
   }
 

--- a/libs/components/src/lib/components/header/components/prizm-header-module-btn/prizm-header-module-btn.component.ts
+++ b/libs/components/src/lib/components/header/components/prizm-header-module-btn/prizm-header-module-btn.component.ts
@@ -1,8 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input } from '@angular/core';
 import { IndicatorStatus } from '../../../indicator/indicator.models';
 import { CommonModule } from '@angular/common';
 import { PrizmButtonComponent } from '../../../button';
 import { PrizmHintDirective } from '../../../../directives';
+import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
+import { prizmIconsBell } from '@prizm-ui/icons/full/source';
 
 @Component({
   selector: 'prizm-header-module-btn',
@@ -17,4 +19,10 @@ export class PrizmHeaderModuleBtnComponent {
   @Input() public alertsCount = 0;
   @Input() public title = '';
   @Input() public status: IndicatorStatus = 'info';
+
+  private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
+
+  constructor() {
+    this.iconsFullRegistry.registerIcons(prizmIconsBell);
+  }
 }


### PR DESCRIPTION
fix(components/navigation): register icons for navigation header and example #1836 

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Navigation

### Задача



### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release notes

Зарегистрировали иконку для навигации и хедера
