### PR TITLE
feat(components/prizm-let): prizmLet directive declared deprecated #1880

### DIFF
--- a/libs/helpers/src/lib/directives/let/let-context.service.ts
+++ b/libs/helpers/src/lib/directives/let/let-context.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
+/**
+ * @deprecated
+ * use angular @let instead
+ */
 @Injectable()
 export class PrizmLetContextService<T> implements OnDestroy {
   private readonly context$$ = new BehaviorSubject<T | null>(null);

--- a/libs/helpers/src/lib/directives/let/let.directive.ts
+++ b/libs/helpers/src/lib/directives/let/let.directive.ts
@@ -14,6 +14,11 @@ interface LetContext<T> {
  * @button <ng-container *prizmLet="{items: items$ | async, center: center} as $"> {{$.items?.count}} {{$.center}}</ng-container>
  * @button <ng-container *prizmLet="queryParams.isMap$ | async as isMap">{{isMap}}</ng-container>
  */
+
+/**
+ * @deprecated
+ * use angular @let instead
+ */
 @Directive({
   selector: '[prizmLet]',
   exportAs: 'prizmLet',


### PR DESCRIPTION
feat(components/prizm-let): prizmLet directive declared deprecated #1880

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

PrizmLetDirective

### Задача

resolved #1880

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [ ] Исправление бага


### Release notes
Перевели директиву prizmLet в раздел deprecated, рекомендуем использовать  нативный let Ангуляра. 
