### PR TITLE
fix(components/tabs): markup correction for tabs contained #000

### DIFF
--- a/libs/components/src/lib/components/tabs/components/tab.component.less
+++ b/libs/components/src/lib/components/tabs/components/tab.component.less
@@ -127,12 +127,11 @@
 
       &:not(.page_active) {
         background: var(--prizm-background-fill-secondary);
-        border-right: 1px solid var(--prizm-background-stroke);
+        border-right: 2px solid var(--prizm-background-stroke);
       }
 
       &:hover:not(:disabled):not(.page_active) {
         background: var(--prizm-button-ghost-hover);
-        border-right: 1px solid var(--prizm-background-stroke);
       }
 
       &_active:not(:disabled)::after {


### PR DESCRIPTION
fix(components/tabs): correct focus styles for contained tabs #1729

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`

### Компонент

Tabs

### Задача

resolved #1729

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Release Notes
Исправили верстку contined табов, находящихся в фокусе.
