### PR TITLE
fix(components/switcher): switcher button markup correction #2032

### DIFF
--- a/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.less
+++ b/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.less
@@ -13,8 +13,11 @@
 :host {
   button {
     border-radius: 0;
+
+    ::ng-deep prizm-wrapper {
+      border-radius: 0;
+    }
     &._focused {
-      border-radius: 2px !important;
       z-index: 1;
     }
   }


### PR DESCRIPTION
fix(components/switcher): switcher button markup correction #2032

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

PrizmSwitcherItem

### Задача

resolved #2032 
### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились


### Release notes

Обновили верстку кнопок в свитчере, убрав лишние скругления.
