### PR TITLE
feat(components/navigation-menu): padding changed from 4px to 8px between text and other el #1633

### DIFF
--- a/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.less
+++ b/libs/components/src/lib/components/navigation-menu/components/prizm-navigation-menu-item/prizm-navigation-menu-item.component.less
@@ -45,7 +45,7 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     flex: 1;
-    padding: 0 4px;
+    padding: 0 8px;
     font-weight: 400;
     font-size: 14px;
     line-height: 16px;


### PR DESCRIPTION
feat(components/navigation-menu): padding changed from 4px to 8px between text and other el #1633