### PR TITLE
feat(components/navigation): add expanded items support #1838

### DIFF
--- a/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.html
+++ b/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.html
@@ -42,6 +42,7 @@
         [data]="data"
         [activeElement]="activeElement ?? data[parentActiveIdx]"
         (activeItemChange)="saveActiveIdx($any($event))"
+        (expandedItemsChange)="saveNavigationState($any($event))"
       ></prizm-navigation>
     </prizm-scrollbar>
 

--- a/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
+++ b/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
@@ -38,6 +38,8 @@ export class NavigationBasicExampleComponent {
       prizmIconsBatteryThreeQuarters,
       prizmIconsDatabase
     );
+
+    this.activeElement = (this.data[1].children as INavigationTree[])[2];
   }
 
   public toggleNavigation(): void {

--- a/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
+++ b/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
@@ -6,6 +6,7 @@ import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import {
   prizmIconsBars,
   prizmIconsBatteryThreeQuarters,
+  prizmIconsCameraMovie,
   prizmIconsDatabase,
   prizmIconsList,
   prizmIconsMusic,
@@ -36,7 +37,8 @@ export class NavigationBasicExampleComponent {
       prizmIconsMusic,
       prizmIconsList,
       prizmIconsBatteryThreeQuarters,
-      prizmIconsDatabase
+      prizmIconsDatabase,
+      prizmIconsCameraMovie
     );
 
     this.activeElement = (this.data[1].children as INavigationTree[])[2];

--- a/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
+++ b/apps/doc/src/app/components/navigation/examples/navigation-basic-example/navigation-basic-example.component.ts
@@ -11,6 +11,7 @@ import {
   prizmIconsList,
   prizmIconsMusic,
 } from '@prizm-ui/icons/full/source';
+import { LOCAL_STORAGE } from '@ng-web-apis/common';
 
 @Component({
   selector: 'prizm-navigation-basic-example',
@@ -30,6 +31,7 @@ export class NavigationBasicExampleComponent {
   public readonly logo = 'assets/example/logo-dark.png';
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
+  private readonly localStorage = inject(LOCAL_STORAGE) as Storage;
 
   constructor(private readonly themeSwitcher: PrizmThemeService) {
     this.iconsFullRegistry.registerIcons(
@@ -41,7 +43,8 @@ export class NavigationBasicExampleComponent {
       prizmIconsCameraMovie
     );
 
-    this.activeElement = (this.data[1].children as INavigationTree[])[2];
+    this.processNavigationState();
+    this.activeElement = this.getActiveElement() ?? (this.data[1].children as INavigationTree[])[1];
   }
 
   public toggleNavigation(): void {
@@ -67,5 +70,60 @@ export class NavigationBasicExampleComponent {
       this.activeElement = item;
     }
     this.parentActiveIdx = idx;
+    this.localStorage.setItem('ACTIVE_ITEM_TITLE_EXAMPLE', item.title);
+  }
+
+  public saveNavigationState(tree: INavigationTree[]): void {
+    this.localStorage.setItem('EXPANDED_ITEMS_EXAMPLE', JSON.stringify(tree));
+  }
+
+  private processNavigationState() {
+    const navigationState = this.localStorage.getItem('EXPANDED_ITEMS_EXAMPLE');
+
+    if (navigationState) {
+      const parsedState = JSON.parse(navigationState);
+      this.restoreExpanded(this.data, parsedState);
+    } else {
+      this.saveNavigationState(this.data);
+    }
+  }
+
+  private restoreExpanded(menuItems: INavigationTree[], storedMenuItems: INavigationTree[]) {
+    storedMenuItems.forEach(stordeItem => {
+      const menuItem = menuItems.find(el => el.title === stordeItem.title);
+
+      if (menuItem) {
+        menuItem.isExpanded = stordeItem.isExpanded;
+      }
+
+      if (stordeItem.children && menuItem?.children) {
+        this.restoreExpanded(menuItem.children, stordeItem.children);
+      }
+    });
+  }
+
+  private getActiveElement(): INavigationTree | null {
+    const activeElTitile = this.localStorage.getItem('ACTIVE_ITEM_TITLE_EXAMPLE');
+    if (activeElTitile) {
+      return this.findActiveItem(this.data, activeElTitile);
+    }
+    return null;
+  }
+
+  private findActiveItem(menuItems: INavigationTree[], title: string): INavigationTree | null {
+    for (const item of menuItems) {
+      if (item.title === title) {
+        return item;
+      }
+
+      if (item.children) {
+        const currElement = this.findActiveItem(item.children, title);
+        if (currElement) {
+          return currElement;
+        }
+      }
+    }
+
+    return null;
   }
 }

--- a/apps/doc/src/app/components/navigation/navigation-example.component.html
+++ b/apps/doc/src/app/components/navigation/navigation-example.component.html
@@ -16,13 +16,13 @@
       <prizm-navigation-basic-example></prizm-navigation-basic-example>
     </prizm-doc-example>
 
-    <prizm-doc-example
+    <!-- <prizm-doc-example
       id="underContent"
       [content]="exampleNavigationBasic"
       heading="Navigation under content"
     >
       <prizm-navigation-basic-example [isNavigationAbsolute]="true"></prizm-navigation-basic-example>
-    </prizm-doc-example>
+    </prizm-doc-example> -->
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>
@@ -58,6 +58,13 @@
         documentationPropertyMode="output"
       >
         Изменение активного элемента
+      </ng-template>
+      <ng-template
+        documentationPropertyName="expandedItemsChange"
+        documentationPropertyType="EventEmitter<INavigationTree[]>"
+        documentationPropertyMode="output"
+      >
+        Изменение развернутых элементов
       </ng-template>
     </prizm-doc-documentation>
   </ng-template>

--- a/apps/doc/src/app/components/navigation/navigation-example.const.ts
+++ b/apps/doc/src/app/components/navigation/navigation-example.const.ts
@@ -18,6 +18,7 @@ export const NAVIGATION_EXAMPLE: INavigationTree[] = [
             title: 'Страница 1.1.3',
             indicatorStatus: 'success',
             indicatorValue: 2,
+            icon: 'camera-movie',
           },
         ],
       },

--- a/apps/doc/src/app/components/navigation/navigation-example.const.ts
+++ b/apps/doc/src/app/components/navigation/navigation-example.const.ts
@@ -88,14 +88,12 @@ export const NAVIGATION_EXAMPLE: INavigationTree[] = [
   {
     title: 'Очень очень длинный раздел 4',
     icon: 'battery-three-quarters',
-    isExpanded: true,
     children: [
       {
         title: 'Очень очень длинный подраздел 4.1',
       },
       {
         title: 'Очень очень длинный подраздел 4.2',
-        isExpanded: true,
         children: [
           {
             title: 'Очень очень длинный подраздел 4.2.1',

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -9,9 +9,7 @@
     <div class="nav__icon" [style.marginLeft.px]="deep | prizmCalculateNavMargin : true">
       <prizm-icons-full [name]="menuItem?.icon || 'folder'"></prizm-icons-full>
     </div>
-    <span class="nav__title" #title>
-      {{ menuItem?.title }}
-    </span>
+    <span class="nav__title" #title> {{ menuItem?.title }}</span>
 
     <div class="nav__status">
       <div
@@ -38,6 +36,7 @@
         *ngIf="$any(item?.children?.length) > 0"
         [data]="item"
         [deep]="deep + 1"
+        [isExpanded]="item.isExpanded"
       ></prizm-navigation-item-expandable>
     </ng-container>
   </div>

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -22,7 +22,6 @@
     </div>
 
     <button class="nav__chevron" [class.nav__chevron_expanded]="isExpanded" (click)="toggle($event)">
-      <!--      <prizm-icon class="icon" iconClass="arrows-chevron-right"></prizm-icon>-->
       <prizm-icons-full class="icon" name="angle-right"></prizm-icons-full>
     </button>
   </div>

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.html
@@ -6,7 +6,7 @@
     [prizmHintCanShow]="prizmIsTextOverflow(title)"
     (click)="navClick()"
   >
-    <div class="nav__icon" [style.marginLeft.px]="deep > 0 ? 8 + 16 * deep : 0">
+    <div class="nav__icon" [style.marginLeft.px]="deep | prizmCalculateNavMargin : true">
       <prizm-icons-full [name]="menuItem?.icon || 'folder'"></prizm-icons-full>
     </div>
     <span class="nav__title" #title>

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.spec.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.spec.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject } from 'rxjs';
 import { ActiveNavigationItemService } from '../../services/active-navigation-item.service';
 
 import { PrizmNavigationItemExpandableComponent } from './prizm-navigation-item-expandable.component';
+import { ExpandedNavigationItemService } from '../../services/expanded-navigation.service';
 
 // for fix ResizeObserver is not defined
 global.ResizeObserver = class {
@@ -27,6 +28,13 @@ describe('PrizmNavigationItemExpandableComponent', () => {
           useValue: {
             activeItem$: new BehaviorSubject({}),
             activeItem: {},
+          },
+        },
+        {
+          provide: ExpandedNavigationItemService,
+          useValue: {
+            itemsState$: new BehaviorSubject([]),
+            itemsState: [],
           },
         },
       ],

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
@@ -18,6 +18,7 @@ import { PrizmAbstractTestId } from '@prizm-ui/core';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsAngleRight, prizmIconsFolder } from '@prizm-ui/icons/full/source';
 import { prizmIsTextOverflow } from '../../../../util';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 @Component({
   selector: 'prizm-navigation-item-expandable',
@@ -28,12 +29,15 @@ import { prizmIsTextOverflow } from '../../../../util';
 })
 export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId implements OnInit, OnDestroy {
   @ViewChild('container', { static: true }) container!: ElementRef;
+
+  @Input() public deep!: number;
+
+  @Input({ transform: coerceBooleanProperty }) public isExpanded = false;
+
   @Input() public set data(tree: INavigationTree) {
     this.data$.next(tree);
   }
-  @Input() public deep!: number;
 
-  public isExpanded = false;
   override readonly testId_ = 'ui_navigation--item-expandable';
 
   readonly prizmIsTextOverflow = prizmIsTextOverflow;

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-expandable/prizm-navigation-item-expandable.component.ts
@@ -19,6 +19,7 @@ import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsAngleRight, prizmIconsFolder } from '@prizm-ui/icons/full/source';
 import { prizmIsTextOverflow } from '../../../../util';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { ExpandedNavigationItemService } from '../../services/expanded-navigation.service';
 
 @Component({
   selector: 'prizm-navigation-item-expandable',
@@ -58,6 +59,7 @@ export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId 
 
   constructor(
     public activeItemService: ActiveNavigationItemService,
+    public expandedService: ExpandedNavigationItemService,
     private readonly cdRef: ChangeDetectorRef
   ) {
     super();
@@ -79,6 +81,7 @@ export class PrizmNavigationItemExpandableComponent extends PrizmAbstractTestId 
   public toggle($event: Event): void {
     $event.stopPropagation();
     this.isExpanded = !this.isExpanded;
+    this.expandedService.updateExpanded(this.menuItem!, this.isExpanded);
   }
 
   public navClick(): void {

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
@@ -6,10 +6,10 @@
   [prizmHintCanShow]="prizmIsTextOverflow(title)"
   (click)="navClick()"
 >
-  <div class="nav__icon" [style.marginLeft.px]="deep > 0 ? (deep - 1) * 12 : 0">
+  <div class="nav__icon" [style.marginLeft.px]="deep | prizmCalculateNavMargin">
     <prizm-icons-full
       *ngIf="menuItem?.icon"
-      [name]="menuItem?.icon | prizmToType : 'string'"
+      [name]="menuItem!.icon | prizmToType : 'string'"
     ></prizm-icons-full>
   </div>
   <span class="nav__title" #title>

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.html
@@ -6,7 +6,13 @@
   [prizmHintCanShow]="prizmIsTextOverflow(title)"
   (click)="navClick()"
 >
-  <span class="nav__title" #title [style.marginLeft.px]="deep > 0 ? (deep - 1) * 24 : 0">
+  <div class="nav__icon" [style.marginLeft.px]="deep > 0 ? (deep - 1) * 12 : 0">
+    <prizm-icons-full
+      *ngIf="menuItem?.icon"
+      [name]="menuItem?.icon | prizmToType : 'string'"
+    ></prizm-icons-full>
+  </div>
+  <span class="nav__title" #title>
     {{ menuItem?.title }}
   </span>
   <div class="nav__status">

--- a/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.less
+++ b/libs/components/src/lib/components/navigation/components/prizm-navigation-item-simple/prizm-navigation-item-simple.component.less
@@ -25,6 +25,17 @@
       text-overflow: ellipsis;
     }
 
+    &__icon {
+      height: 16px;
+      width: 16px;
+      margin: 0 8px;
+
+      display: inline-flex;
+      align-items: center;
+
+      color: var(--prizm-status-info-primary-default);
+    }
+
     &__status {
       height: 100%;
       width: 32px;

--- a/libs/components/src/lib/components/navigation/pipes/calculate-margin.pipe.ts
+++ b/libs/components/src/lib/components/navigation/pipes/calculate-margin.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: `prizmCalculateNavMargin`, standalone: true })
+export class PrizmCalculateNavMarginPipe implements PipeTransform {
+  public transform(deep: number, expandable?: boolean): number {
+    if (expandable) {
+      return deep > 0 ? 8 + 16 * deep : 0;
+    }
+    return deep > 0 ? (deep - 1) * 12 : 0;
+  }
+}

--- a/libs/components/src/lib/components/navigation/prizm-navigation.component.html
+++ b/libs/components/src/lib/components/navigation/prizm-navigation.component.html
@@ -9,5 +9,6 @@
     *ngIf="$any(item?.children?.length) > 0"
     [data]="$any(item)"
     [deep]="1"
+    [isExpanded]="item.isExpanded"
   ></prizm-navigation-item-expandable>
 </ng-container>

--- a/libs/components/src/lib/components/navigation/prizm-navigation.component.spec.ts
+++ b/libs/components/src/lib/components/navigation/prizm-navigation.component.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 
 import { PrizmNavigationComponent } from './prizm-navigation.component';
 import { ActiveNavigationItemService } from './services/active-navigation-item.service';
+import { ExpandedNavigationItemService } from './services/expanded-navigation.service';
 
 describe('PrizmNavigationComponent', () => {
   let component: PrizmNavigationComponent;
@@ -17,6 +18,13 @@ describe('PrizmNavigationComponent', () => {
           useValue: {
             activeItem$: new BehaviorSubject({}),
             activeItem: {},
+          },
+        },
+        {
+          provide: ExpandedNavigationItemService,
+          useValue: {
+            itemsState$: new BehaviorSubject([]),
+            itemsState: [],
           },
         },
       ],

--- a/libs/components/src/lib/components/navigation/prizm-navigation.component.ts
+++ b/libs/components/src/lib/components/navigation/prizm-navigation.component.ts
@@ -4,29 +4,35 @@ import { IndicatorStatus } from '../indicator';
 import { ActiveNavigationItemService } from './services/active-navigation-item.service';
 import { skip } from 'rxjs/operators';
 import { PrizmAbstractTestId } from '@prizm-ui/core';
+import { ExpandedNavigationItemService } from './services/expanded-navigation.service';
 
 @Component({
   selector: 'prizm-navigation',
   templateUrl: './prizm-navigation.component.html',
   styleUrls: ['./prizm-navigation.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [ActiveNavigationItemService],
+  providers: [ActiveNavigationItemService, ExpandedNavigationItemService],
 })
 export class PrizmNavigationComponent extends PrizmAbstractTestId {
   @Input() public set data(tree: INavigationTree[]) {
     tree.forEach(treeItem => this.calculateStatuses(treeItem));
 
     this.menuItems = tree;
+    this.expandedSerivce.itemsState = this.menuItems;
   }
   @Input() set activeElement(el: INavigationTree) {
     this.activeItemService.activeItem = el;
   }
   @Output() activeItemChange = this.activeItemService.activeItem$.pipe(skip(1));
+  @Output() expandedItemsChange = this.expandedSerivce.itemsState$.pipe(skip(1));
 
   public menuItems: INavigationTree[] = [];
 
   override readonly testId_ = 'ui_navigation';
-  constructor(private readonly activeItemService: ActiveNavigationItemService) {
+  constructor(
+    private readonly activeItemService: ActiveNavigationItemService,
+    private readonly expandedSerivce: ExpandedNavigationItemService
+  ) {
     super();
   }
 

--- a/libs/components/src/lib/components/navigation/prizm-navigation.module.ts
+++ b/libs/components/src/lib/components/navigation/prizm-navigation.module.ts
@@ -8,6 +8,7 @@ import { ActiveNavigationItemService } from './services/active-navigation-item.s
 import { PrizmHintDirective } from '../../directives';
 import { PrizmIconsFullComponent } from '@prizm-ui/icons';
 import { PrizmToTypePipe } from '@prizm-ui/helpers';
+import { PrizmCalculateNavMarginPipe } from './pipes/calculate-margin.pipe';
 
 @NgModule({
   declarations: [
@@ -15,7 +16,13 @@ import { PrizmToTypePipe } from '@prizm-ui/helpers';
     PrizmNavigationItemSimpleComponent,
     PrizmNavigationItemExpandableComponent,
   ],
-  imports: [CommonModule, PrizmHintDirective, PrizmIconsFullComponent, PrizmToTypePipe],
+  imports: [
+    CommonModule,
+    PrizmHintDirective,
+    PrizmIconsFullComponent,
+    PrizmToTypePipe,
+    PrizmCalculateNavMarginPipe,
+  ],
   exports: [PrizmNavigationComponent],
   providers: [ActiveNavigationItemService],
 })

--- a/libs/components/src/lib/components/navigation/prizm-navigation.module.ts
+++ b/libs/components/src/lib/components/navigation/prizm-navigation.module.ts
@@ -7,6 +7,7 @@ import { PrizmNavigationItemExpandableComponent } from './components/prizm-navig
 import { ActiveNavigationItemService } from './services/active-navigation-item.service';
 import { PrizmHintDirective } from '../../directives';
 import { PrizmIconsFullComponent } from '@prizm-ui/icons';
+import { PrizmToTypePipe } from '@prizm-ui/helpers';
 
 @NgModule({
   declarations: [
@@ -14,7 +15,7 @@ import { PrizmIconsFullComponent } from '@prizm-ui/icons';
     PrizmNavigationItemSimpleComponent,
     PrizmNavigationItemExpandableComponent,
   ],
-  imports: [CommonModule, PrizmHintDirective, PrizmIconsFullComponent],
+  imports: [CommonModule, PrizmHintDirective, PrizmIconsFullComponent, PrizmToTypePipe],
   exports: [PrizmNavigationComponent],
   providers: [ActiveNavigationItemService],
 })

--- a/libs/components/src/lib/components/navigation/prizm-navigation.module.ts
+++ b/libs/components/src/lib/components/navigation/prizm-navigation.module.ts
@@ -9,6 +9,7 @@ import { PrizmHintDirective } from '../../directives';
 import { PrizmIconsFullComponent } from '@prizm-ui/icons';
 import { PrizmToTypePipe } from '@prizm-ui/helpers';
 import { PrizmCalculateNavMarginPipe } from './pipes/calculate-margin.pipe';
+import { ExpandedNavigationItemService } from './services/expanded-navigation.service';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,6 @@ import { PrizmCalculateNavMarginPipe } from './pipes/calculate-margin.pipe';
     PrizmCalculateNavMarginPipe,
   ],
   exports: [PrizmNavigationComponent],
-  providers: [ActiveNavigationItemService],
+  providers: [ActiveNavigationItemService, ExpandedNavigationItemService],
 })
 export class PrizmNavigationModule {}

--- a/libs/components/src/lib/components/navigation/services/expanded-navigation.service.ts
+++ b/libs/components/src/lib/components/navigation/services/expanded-navigation.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { INavigationTree } from '../navigation.interfaces';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable()
+export class ExpandedNavigationItemService {
+  public itemsState$: BehaviorSubject<INavigationTree[] | null> = new BehaviorSubject<
+    INavigationTree[] | null
+  >(null);
+
+  public set itemsState(items: INavigationTree[] | null) {
+    this.itemsState$.next(items);
+  }
+
+  public get itemsState(): INavigationTree[] | null {
+    return this.itemsState$.getValue();
+  }
+
+  public updateExpanded(item: INavigationTree, isExpanded: boolean) {
+    item.isExpanded = isExpanded;
+    this.itemsState$.next(this.itemsState);
+  }
+}


### PR DESCRIPTION
feat(components/navigation): add icons support for non-expandable items #1477
feat(components/navigation): add expanded items support #1838
fix(components/navigation): active item should be highlighted after reload #1511


### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Navigation

### Задача

resolved #1838
resolved #1511
resolved #1477 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Поведение при сворачивании/разворачивании элементов навигации

### Release notes

Добавили поддержку разворачивания элементов в навигационном меню по конфигураци и возможность добавлять иконки к неразворачиваемым элементам меню.
