### PR TITLE
fix(components/button): text in buttons should be in a single line #1365 v4

### DIFF
--- a/apps/doc/src/app/components/buttons/button/button.component.html
+++ b/apps/doc/src/app/components/buttons/button/button.component.html
@@ -34,7 +34,7 @@
       <prizm-button-with-counter-example></prizm-button-with-counter-example>
     </prizm-doc-example>
 
-    <prizm-doc-example id="counter" [content]="exampleCounter" heading="Button with counter">
+    <prizm-doc-example id="overflow" [content]="exampleOverflow" heading="Button with overflowed text">
       <prizm-button-text-overflow-example></prizm-button-text-overflow-example>
     </prizm-doc-example>
   </ng-template>

--- a/apps/doc/src/app/components/buttons/button/button.component.html
+++ b/apps/doc/src/app/components/buttons/button/button.component.html
@@ -33,6 +33,10 @@
     <prizm-doc-example id="counter" [content]="exampleCounter" heading="Button with counter">
       <prizm-button-with-counter-example></prizm-button-with-counter-example>
     </prizm-doc-example>
+
+    <prizm-doc-example id="counter" [content]="exampleCounter" heading="Button with counter">
+      <prizm-button-text-overflow-example></prizm-button-text-overflow-example>
+    </prizm-doc-example>
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/buttons/button/button.component.ts
+++ b/apps/doc/src/app/components/buttons/button/button.component.ts
@@ -71,4 +71,9 @@ export class ButtonComponent {
     TypeScript: import('./examples/counter/button-with-counter-example.component.ts?raw'),
     HTML: import('./examples/counter/button-with-counter-example.component.html?raw'),
   };
+
+  readonly exampleOverflow: TuiDocExample = {
+    TypeScript: import('./examples/overflow/button-text-overflow-example.component.ts?raw'),
+    HTML: import('./examples/overflow/button-text-overflow-example.component.html?raw'),
+  };
 }

--- a/apps/doc/src/app/components/buttons/button/button.module.ts
+++ b/apps/doc/src/app/components/buttons/button/button.module.ts
@@ -10,6 +10,7 @@ import { PrizmGhostButtonsExampleComponent } from './examples/ghost/ghost-button
 import { prizmIconsButtonsExampleComponent } from './examples/icons/icons-buttons-example.component';
 import { PrizmButtonWithCounterExampleComponent } from './examples/counter/button-with-counter-example.component';
 import { PrizmIfLanguageDirective } from '@prizm-ui/i18n';
+import { PrizmButtonTextOverflowExampleComponent } from './examples/overflow/button-text-overflow-example.component';
 
 @NgModule({
   imports: [
@@ -25,6 +26,7 @@ import { PrizmIfLanguageDirective } from '@prizm-ui/i18n';
     prizmIconsButtonsExampleComponent,
     PrizmGhostButtonsExampleComponent,
     PrizmButtonWithCounterExampleComponent,
+    PrizmButtonTextOverflowExampleComponent,
     PrizmIfLanguageDirective,
   ],
   declarations: [ButtonComponent],

--- a/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.html
+++ b/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.html
@@ -1,10 +1,5 @@
 <div class="container">
-  <button
-    #elem
-    [prizmHintOnOverflow]="'Button With Long long text'"
-    [prizmHintOnOverflowEl]="$any(elem)"
-    prizmButton
-  >
-    Button With Long long text
+  <button [prizmHintOnOverflow]="'Button With Long long text'" [prizmHintOnOverflowEl]="elem" prizmButton>
+    <div class="ellipsis" #elem>Button With Long long text</div>
   </button>
 </div>

--- a/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.html
+++ b/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.html
@@ -1,0 +1,10 @@
+<div class="container">
+  <button
+    #elem
+    [prizmHintOnOverflow]="'Button With Long long text'"
+    [prizmHintOnOverflowEl]="$any(elem)"
+    prizmButton
+  >
+    Button With Long long text
+  </button>
+</div>

--- a/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.ts
+++ b/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { PrizmButtonComponent, PrizmHintOnOverflowDirective } from '@prizm-ui/components';
+
+@Component({
+  selector: 'prizm-button-text-overflow-example',
+  templateUrl: './button-text-overflow-example.component.html',
+  styles: [
+    `
+      .container {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+
+        [prizmButton] {
+          max-width: 120px;
+        }
+      }
+    `,
+  ],
+  standalone: true,
+  imports: [PrizmButtonComponent, PrizmHintOnOverflowDirective],
+})
+export class PrizmButtonTextOverflowExampleComponent {}

--- a/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.ts
+++ b/apps/doc/src/app/components/buttons/button/examples/overflow/button-text-overflow-example.component.ts
@@ -14,6 +14,11 @@ import { PrizmButtonComponent, PrizmHintOnOverflowDirective } from '@prizm-ui/co
         [prizmButton] {
           max-width: 120px;
         }
+
+        .ellipsis {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
       }
     `,
   ],

--- a/apps/doc/src/app/components/navigation-menu/navigation-menu-example.component.ts
+++ b/apps/doc/src/app/components/navigation-menu/navigation-menu-example.component.ts
@@ -56,16 +56,9 @@ export class NavigationMenuExampleComponent {
     'item-groups.service.ts': import(
       './examples/navigation-menu-groups-example/example-data/item-groups.service.ts?raw'
     ),
-    'item-groups.constants.ts': import(
-      './examples/navigation-menu-groups-example/example-data/item-groups.constants.ts?raw'
-    ),
     'expanded-items.service.ts': import(
       './examples/navigation-menu-groups-example/example-data/expanded-items.service.ts?raw'
     ),
-    'interfaces.ts': import('./examples/navigation-menu-groups-example/example-data/interfaces.ts?raw'),
-    'hint-button.ts': import('./examples/hint-button/hint-button.component.html?raw'),
-    'hint-button.html': import('./examples/hint-button/hint-button.component.html?raw'),
-    'hint-button.less': import('./examples/hint-button/hint-button.component.less?raw'),
   };
 
   public readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
@@ -1,0 +1,12 @@
+<prizm-switcher [formControl]="control" [switchers]="switchers"></prizm-switcher>
+
+<div>
+  Value: <b>{{ control.value }}</b>
+</div>
+
+<br />
+
+<div style="display: flex; gap: 1rem">
+  <button (click)="updateValue()" prizmButton>Update value</button>
+  <button (click)="control.setValue(99)" prizmButton>Update extra index</button>
+</div>

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
@@ -1,12 +1,21 @@
-<prizm-switcher [formControl]="control" [switchers]="switchers"></prizm-switcher>
+<prizm-switcher [formControl]="control" fullWidth type="outer">
+  <prizm-switcher-item
+    *ngFor="let item of switchers$ | async"
+    [disabled]="!!item.disabled"
+    [appearance]="item.appearance ?? 'secondary'"
+    [appearanceType]="item.appearanceType ?? 'ghost'"
+  >
+    {{ item.title }}
+  </prizm-switcher-item>
+</prizm-switcher>
 
-<div>
+<!-- <div>
   Value: <b>{{ control.value }}</b>
 </div>
-
 <br />
 
 <div style="display: flex; gap: 1rem">
+  <button (click)="changeItems()" prizmButton>Switch</button>
   <button (click)="updateValue()" prizmButton>Update value</button>
   <button (click)="control.setValue(99)" prizmButton>Update extra index</button>
-</div>
+</div> -->

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
@@ -3,12 +3,11 @@
   #overflowHost="prizmOverflowHost"
   [formControl]="control"
   fullWidth
-  type="outer"
   prizmOverflowHost
 >
   <prizm-switcher-item
     #overflowItem="prizmOverflowItem"
-    *ngFor="let item of switchers$ | async"
+    *ngFor="let item of switchers"
     [disabled]="!!item.disabled"
     [appearance]="item.appearance ?? 'secondary'"
     [appearanceType]="item.appearanceType ?? 'ghost'"
@@ -18,25 +17,17 @@
   </prizm-switcher-item>
   <prizm-dropdown-host [(isOpen)]="openList" [content]="dropdown">
     <button
+      class="show-more-btn"
+      *ngIf="(overflowHost.hiddenElements$ | async)?.length"
       [icon]="'ellipsis-v'"
       (click)="toggle()"
       prizmIconButton
       appearanceType="ghost"
       appearance="secondary"
+      size="xl"
     ></button>
   </prizm-dropdown-host>
 </prizm-switcher>
-
-<!-- <div>
-  Value: <b>{{ control.value }}</b>
-</div>
-<br />
-
-<div style="display: flex; gap: 1rem">
-  <button (click)="changeItems()" prizmButton>Switch</button>
-  <button (click)="updateValue()" prizmButton>Update value</button>
-  <button (click)="control.setValue(99)" prizmButton>Update extra index</button>
-</div> -->
 
 <ng-template #dropdown>
   <prizm-data-list>

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.html
@@ -1,12 +1,30 @@
-<prizm-switcher [formControl]="control" fullWidth type="outer">
+<prizm-switcher
+  class="switcher-max-width"
+  #overflowHost="prizmOverflowHost"
+  [formControl]="control"
+  fullWidth
+  type="outer"
+  prizmOverflowHost
+>
   <prizm-switcher-item
+    #overflowItem="prizmOverflowItem"
     *ngFor="let item of switchers$ | async"
     [disabled]="!!item.disabled"
     [appearance]="item.appearance ?? 'secondary'"
     [appearanceType]="item.appearanceType ?? 'ghost'"
+    prizmOverflowItem
   >
     {{ item.title }}
   </prizm-switcher-item>
+  <prizm-dropdown-host [(isOpen)]="openList" [content]="dropdown">
+    <button
+      [icon]="'ellipsis-v'"
+      (click)="toggle()"
+      prizmIconButton
+      appearanceType="ghost"
+      appearance="secondary"
+    ></button>
+  </prizm-dropdown-host>
 </prizm-switcher>
 
 <!-- <div>
@@ -19,3 +37,11 @@
   <button (click)="updateValue()" prizmButton>Update value</button>
   <button (click)="control.setValue(99)" prizmButton>Update extra index</button>
 </div> -->
+
+<ng-template #dropdown>
+  <prizm-data-list>
+    <ng-container *ngFor="let switcher of overflowHost.hiddenElements$ | async; let i = index">
+      {{ switcher }}
+    </ng-container>
+  </prizm-data-list>
+</ng-template>

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.less
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.less
@@ -1,3 +1,11 @@
 .switcher-max-width {
   max-width: 400px;
 }
+
+.show-more-btn {
+  ::ng-deep prizm-wrapper {
+    border: 1px solid var(--prizm-background-stroke);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.less
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.less
@@ -1,0 +1,3 @@
+.switcher-max-width {
+  max-width: 400px;
+}

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
@@ -1,0 +1,34 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { PrizmSwitcherItem } from '@prizm-ui/components';
+import { FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'prizm-switcher-overflow-example',
+  templateUrl: './switcher-overflow-example.component.html',
+  styleUrls: ['./switcher-overflow-example.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SwitcherOverflowExampleComponent {
+  public readonly switchers: PrizmSwitcherItem[] = [
+    {
+      title: 'Таблицы',
+      disabled: true,
+    },
+    {
+      title: 'Графики',
+    },
+    {
+      title: 'Мнемосхемы',
+      appearanceType: 'outline',
+    },
+    {
+      title: 'Дашборды',
+      appearance: 'primary',
+    },
+  ];
+  public readonly control = new FormControl(10);
+
+  public updateValue() {
+    this.control.setValue(3);
+  }
+}

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { PrizmSwitcherItem } from '@prizm-ui/components';
 import { FormControl } from '@angular/forms';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'prizm-switcher-overflow-example',
@@ -12,23 +13,32 @@ export class SwitcherOverflowExampleComponent {
   public readonly switchers: PrizmSwitcherItem[] = [
     {
       title: 'Таблицы',
-      disabled: true,
     },
     {
       title: 'Графики',
     },
     {
       title: 'Мнемосхемы',
-      appearanceType: 'outline',
     },
     {
       title: 'Дашборды',
-      appearance: 'primary',
     },
   ];
-  public readonly control = new FormControl(10);
+  public readonly switchers2: PrizmSwitcherItem[] = [
+    {
+      title: 'Таблицы',
+    },
+    {
+      title: 'Графики',
+    },
+  ];
+  public readonly switchers$ = new BehaviorSubject<PrizmSwitcherItem[]>(this.switchers);
+  public readonly control = new FormControl(1);
 
   public updateValue() {
     this.control.setValue(3);
+  }
+  public changeItems() {
+    this.switchers$.next(this.switchers$.value === this.switchers ? this.switchers2 : this.switchers);
   }
 }

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
@@ -2,6 +2,8 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { PrizmSwitcherItem } from '@prizm-ui/components';
 import { FormControl } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
+import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
+import { prizmIconsEllipsisV } from '@prizm-ui/icons/full/source';
 
 @Component({
   selector: 'prizm-switcher-overflow-example',
@@ -10,6 +12,7 @@ import { BehaviorSubject } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SwitcherOverflowExampleComponent {
+  public openList = false;
   public readonly switchers: PrizmSwitcherItem[] = [
     {
       title: 'Таблицы',
@@ -35,10 +38,18 @@ export class SwitcherOverflowExampleComponent {
   public readonly switchers$ = new BehaviorSubject<PrizmSwitcherItem[]>(this.switchers);
   public readonly control = new FormControl(1);
 
+  constructor(private readonly iconsFullRegistry: PrizmIconsFullRegistry) {
+    this.iconsFullRegistry.registerIcons(prizmIconsEllipsisV);
+  }
+
   public updateValue() {
     this.control.setValue(3);
   }
   public changeItems() {
     this.switchers$.next(this.switchers$.value === this.switchers ? this.switchers2 : this.switchers);
+  }
+
+  public toggle() {
+    this.openList = !this.openList;
   }
 }

--- a/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
+++ b/apps/doc/src/app/components/switcher/examples/switcher-overflow-example/switcher-overflow-example.component.ts
@@ -1,7 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { PrizmSwitcherItem } from '@prizm-ui/components';
 import { FormControl } from '@angular/forms';
-import { BehaviorSubject } from 'rxjs';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsEllipsisV } from '@prizm-ui/icons/full/source';
 
@@ -26,27 +25,15 @@ export class SwitcherOverflowExampleComponent {
     {
       title: 'Дашборды',
     },
-  ];
-  public readonly switchers2: PrizmSwitcherItem[] = [
     {
-      title: 'Таблицы',
-    },
-    {
-      title: 'Графики',
+      title: 'Карты месторождений',
     },
   ];
-  public readonly switchers$ = new BehaviorSubject<PrizmSwitcherItem[]>(this.switchers);
-  public readonly control = new FormControl(1);
+
+  public readonly control = new FormControl(4);
 
   constructor(private readonly iconsFullRegistry: PrizmIconsFullRegistry) {
     this.iconsFullRegistry.registerIcons(prizmIconsEllipsisV);
-  }
-
-  public updateValue() {
-    this.control.setValue(3);
-  }
-  public changeItems() {
-    this.switchers$.next(this.switchers$.value === this.switchers ? this.switchers2 : this.switchers);
   }
 
   public toggle() {

--- a/apps/doc/src/app/components/switcher/switcher-example.component.html
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.html
@@ -51,16 +51,16 @@
       <prizm-switcher-with-icon-example></prizm-switcher-with-icon-example>
     </prizm-doc-example>
 
-    <prizm-doc-example id="overflow" [content]="exampleOverflow" heading="Switcher overflow">
-      <prizm-switcher-overflow-example></prizm-switcher-overflow-example>
-    </prizm-doc-example>
-
     <prizm-doc-example
       id="onlyIcon"
       [content]="exampleOnlyIconSwitcher"
       heading="Only icon switcher hints (position & theme examples) "
     >
       <prizm-switcher-only-icon-example></prizm-switcher-only-icon-example>
+    </prizm-doc-example>
+
+    <prizm-doc-example id="overflow" [content]="exampleOverflow" heading="Switcher overflow">
+      <prizm-switcher-overflow-example></prizm-switcher-overflow-example>
     </prizm-doc-example>
   </ng-template>
 

--- a/apps/doc/src/app/components/switcher/switcher-example.component.html
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.html
@@ -51,6 +51,10 @@
       <prizm-switcher-with-icon-example></prizm-switcher-with-icon-example>
     </prizm-doc-example>
 
+    <prizm-doc-example id="overflow" [content]="exampleOverflow" heading="Switcher overflow">
+      <prizm-switcher-overflow-example></prizm-switcher-overflow-example>
+    </prizm-doc-example>
+
     <prizm-doc-example
       id="onlyIcon"
       [content]="exampleOnlyIconSwitcher"

--- a/apps/doc/src/app/components/switcher/switcher-example.component.html
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.html
@@ -59,9 +59,10 @@
       <prizm-switcher-only-icon-example></prizm-switcher-only-icon-example>
     </prizm-doc-example>
 
-    <prizm-doc-example id="overflow" [content]="exampleOverflow" heading="Switcher overflow">
+    <!-- TODO: for #2178  -->
+    <!-- <prizm-doc-example id="overflow" [content]="exampleOverflow" heading="Switcher overflow">
       <prizm-switcher-overflow-example></prizm-switcher-overflow-example>
-    </prizm-doc-example>
+    </prizm-doc-example> -->
   </ng-template>
 
   <ng-template prizmDocPageTab prizmDocHost>

--- a/apps/doc/src/app/components/switcher/switcher-example.component.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.ts
@@ -96,6 +96,11 @@ export class SwitcherExampleComponent {
     HTML: import('./examples/switcher-only-icon-example/switcher-only-icon-example.component.html?raw'),
   };
 
+  public readonly exampleOverflow: TuiDocExample = {
+    TypeScript: import('./examples/switcher-overflow-example/switcher-overflow-example.component?raw'),
+    HTML: import('./examples/switcher-overflow/switcher-overflow-example.component.html?raw'),
+  };
+
   public readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);

--- a/apps/doc/src/app/components/switcher/switcher-example.component.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.component.ts
@@ -98,7 +98,7 @@ export class SwitcherExampleComponent {
 
   public readonly exampleOverflow: TuiDocExample = {
     TypeScript: import('./examples/switcher-overflow-example/switcher-overflow-example.component?raw'),
-    HTML: import('./examples/switcher-overflow/switcher-overflow-example.component.html?raw'),
+    HTML: import('./examples/switcher-overflow-example/switcher-overflow-example.component.html?raw'),
   };
 
   public readonly setupModule: RawLoaderContent = import('./examples/setup-module.md?raw');

--- a/apps/doc/src/app/components/switcher/switcher-example.module.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.module.ts
@@ -6,6 +6,9 @@ import { RouterModule } from '@angular/router';
 import { SwitcherBasicExampleComponent } from './examples/switcher-basic-example/switcher-basic-example.component';
 import {
   PrizmButtonComponent,
+  PrizmDataListComponent,
+  PrizmDropdownHostComponent,
+  PrizmListingItemComponent,
   PrizmSwitcherComponent,
   PrizmSwitcherItemComponent,
 } from '@prizm-ui/components';
@@ -22,6 +25,12 @@ import { SwitcherProjectionExampleComponent } from './examples/switcher-projecti
 import { SwitcherProjectionValueExampleComponent } from './examples/switcher-projection-value-example/switcher-projection-value-example.component';
 import { SwitcherBasicValueExampleComponent } from './examples/switcher-basic-value-example/switcher-basic-value-example.component';
 import { SwitcherOverflowExampleComponent } from './examples/switcher-overflow-example/switcher-overflow-example.component';
+import {
+  PrizmCallFuncPipe,
+  PrizmContextGetByKysPipe,
+  PrizmOverflowHostDirective,
+  PrizmOverflowItemDirective,
+} from '@prizm-ui/helpers';
 
 @NgModule({
   declarations: [
@@ -48,6 +57,11 @@ import { SwitcherOverflowExampleComponent } from './examples/switcher-overflow-e
     ReactiveFormsModule,
     PrizmButtonComponent,
     PrizmSwitcherItemComponent,
+    PrizmOverflowHostDirective,
+    PrizmOverflowItemDirective,
+    PrizmDropdownHostComponent,
+    PrizmDataListComponent,
+    PrizmListingItemComponent,
   ],
 })
 export class SwitcherExampleModule {}

--- a/apps/doc/src/app/components/switcher/switcher-example.module.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.module.ts
@@ -21,6 +21,7 @@ import { SwitcherAsyncExampleComponent } from './examples/switcher-async-example
 import { SwitcherProjectionExampleComponent } from './examples/switcher-projection-example/switcher-projection-example.component';
 import { SwitcherProjectionValueExampleComponent } from './examples/switcher-projection-value-example/switcher-projection-value-example.component';
 import { SwitcherBasicValueExampleComponent } from './examples/switcher-basic-value-example/switcher-basic-value-example.component';
+import { SwitcherOverflowExampleComponent } from './examples/switcher-overflow-example/switcher-overflow-example.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { SwitcherBasicValueExampleComponent } from './examples/switcher-basic-va
     SwitcherOnlyIconExampleComponent,
     SwitcherProjectionExampleComponent,
     SwitcherAsyncExampleComponent,
+    SwitcherOverflowExampleComponent,
   ],
   imports: [
     CommonModule,

--- a/libs/components/src/lib/components/button/button.component.html
+++ b/libs/components/src/lib/components/button/button.component.html
@@ -26,7 +26,6 @@
 
 <ng-template #showIconTemp let-icon="icon">
   <ng-container *polymorphOutlet="icon as content; context: { size: size }">
-    <!--    <prizm-icon [iconClass]="content" [size]="16"></prizm-icon>-->
     <prizm-icons-full [name]="content" [size]="16"></prizm-icons-full>
   </ng-container>
 </ng-template>

--- a/libs/components/src/lib/components/button/button.component.less
+++ b/libs/components/src/lib/components/button/button.component.less
@@ -12,6 +12,7 @@
   background: transparent;
   // TODO 5.0.0: set default min-width 120px/64px according to prizm button component description, reseach needed
   min-width: var(--prizm-button-min-width, unset);
+  white-space: nowrap;
 
   &._focus-visible {
     box-shadow: 0 0 0 2px var(--prizm-background-stroke-focus);
@@ -26,11 +27,13 @@
 
   .z-wrapper {
     min-height: inherit;
+    max-height: inherit;
   }
 
   .addSize(@size, @height, @width, @padding, @outline-padding) {
     &[data-size='@{size}'] {
       min-height: @height;
+      max-height: @height;
 
       &[prizmIconButton] {
         width: @width;
@@ -76,6 +79,8 @@
 .text {
   text-align: inherit;
   width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &:empty {
     display: none;

--- a/libs/components/src/lib/components/button/button.component.less
+++ b/libs/components/src/lib/components/button/button.component.less
@@ -27,13 +27,11 @@
 
   .z-wrapper {
     min-height: inherit;
-    max-height: inherit;
   }
 
   .addSize(@size, @height, @width, @padding, @outline-padding) {
     &[data-size='@{size}'] {
       min-height: @height;
-      max-height: @height;
 
       &[prizmIconButton] {
         width: @width;

--- a/libs/helpers/src/lib/directives/overflow/overflow.service.ts
+++ b/libs/helpers/src/lib/directives/overflow/overflow.service.ts
@@ -5,6 +5,7 @@ import { PrizmOverflowItem, PrizmOverflowReserveSpace } from './model';
 import { prizmCreateResizeObservable, PrizmSetSubject } from '../../util';
 import { hideOverflowElements } from './util';
 
+// TODO: rename to PrizmOverflowService
 @Injectable()
 export class OverflowService implements OnDestroy {
   private readonly set = new PrizmSetSubject<PrizmOverflowItem>();


### PR DESCRIPTION
fix(components/button): text in buttons should be in a single line #1365
fix(doc/navigation): extra  code files removed from example  #1365

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Buttons

### Задача

resolved #1365 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Все виды кнопок, поведение кнопок при переполнении, все компоненты, содержащие кнопки (например, свитчер), поведение фокуса, ховера. Так же нужно обратить внимание на кнопки с обводкой.

Все размеры кнопок и свитчеров outer/inner

### Release notes

Исправили верстку кнопок таким образом, чтобы текст мог располагаться только в один ряд, а так же добавили пример для хинта при переполнении кнопок. Обратите внимание, что при использовании кнопок рекомендуется избегать переполнения кнопок и менять текст таким образом, чтобы он полностью умещался в компоненте.
Улучшили читаемость примера для групп в навигационном меню.