### PR TITLE
Fix/dialog header limits 755 v4

### DIFF
--- a/apps/doc/src/app/components/dialogs/confirm-dialog/confirm.component.html
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/confirm.component.html
@@ -186,10 +186,4 @@
   </ng-template>
 </prizm-doc-page>
 
-<ng-template #contentTemp>
-  Контент из <a class="template-link" href="#">шаблона</a>
-
-  <prizm-input-layout label="Validators">
-    <prizm-input-select [items]="items"></prizm-input-select>
-  </prizm-input-layout>
-</ng-template>
+<ng-template #contentTemp> Контент из <a class="template-link" href="#">шаблона</a> </ng-template>

--- a/apps/doc/src/app/components/dialogs/confirm-dialog/confirm.component.html
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/confirm.component.html
@@ -34,8 +34,6 @@
       <button [size]="size" [icon]="icon" (click)="show()" type="button" prizmButton>Show Dialog</button>
     </prizm-doc-demo>
 
-    <ng-template #headerTemp> Header из <a href="#">шаблона</a> </ng-template>
-
     <prizm-doc-documentation [hasTestId]="false">
       <ng-template
         [(documentationPropertyValue)]="title"
@@ -189,8 +187,7 @@
 </prizm-doc-page>
 
 <ng-template #contentTemp>
-  Content из <a href="#">шаблона</a>
-  [formControl]="control" [items]="items"
+  Контент из <a class="template-link" href="#">шаблона</a>
 
   <prizm-input-layout label="Validators">
     <prizm-input-select [items]="items"></prizm-input-select>

--- a/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/dialog-example.component.html
@@ -57,11 +57,11 @@
       </button>
     </prizm-doc-demo>
 
-    <ng-template #headerTemp> Header из <a href="#">шаблона</a> </ng-template>
+    <ng-template #headerTemp> Header из <a class="template-link" href="#">шаблона</a> </ng-template>
 
     <ng-template #contentTemp>
-      Content из <a href="#">шаблона</a>
-      <button style="margin-top: 10px" prizmButton>Кнопка</button>
+      Content из <a class="template-link" href="#">шаблона</a>
+      <button style="margin-top: 60px" prizmButton>Кнопка</button>
     </ng-template>
 
     <ng-template #footerTemp let-observer> Footer из <i (click)="observer.next(1)">шаблона</i> </ng-template>

--- a/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/sidebar.component.html
@@ -89,12 +89,9 @@
       </button>
     </prizm-doc-demo>
 
-    <ng-template #headerTemp> Header из <a href="#">шаблона</a> </ng-template>
+    <ng-template #headerTemp> Header из <a class="template-link" href="#">шаблона</a> </ng-template>
 
-    <ng-template #contentTemp>
-      Content из <a href="#">шаблона</a>
-      <button style="margin-top: 10px" prizmButton>Кнопка</button>
-    </ng-template>
+    <ng-template #contentTemp> Content из <a class="template-link" href="#">шаблона</a> </ng-template>
 
     <ng-template #footerTemp let-observer> Footer из <i (click)="observer.next(1)">шаблона</i> </ng-template>
 

--- a/apps/doc/src/styles.less
+++ b/apps/doc/src/styles.less
@@ -185,3 +185,15 @@ prizm-doc-page.info-page {
 prizm-doc-navigation tui-accordion-item {
   --tui-base-02: var(--prizm-button-ghost-hover);
 }
+
+.template-link {
+  color: var(--prizm-text-icon-link);
+
+  &:hover {
+    color: var(--prizm-text-icon-link-hover);
+  }
+
+  &:visited:not(:hover) {
+    color: var(--prizm-text-icon-link-visited);
+  }
+}

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -1,5 +1,5 @@
 <div class="host" [prizmTheme]="theme" prizmFocusTrap>
-  <div class="content">
+  <div class="content" [class.has-description]="!!context.description">
     <div
       class="title prizm-font-title-h4"
       #host

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -1,6 +1,11 @@
 <div class="host" [prizmTheme]="theme" prizmFocusTrap>
   <div class="content">
-    <div class="title prizm-font-title-h4">
+    <div
+      class="title prizm-font-title-h4"
+      #host
+      [prizmHintOnOverflow]="context.title"
+      [prizmHintOnOverflowEl]="host"
+    >
       <ng-container *polymorphOutlet="$any(context.title) as data; context: context">
         {{ data }}
       </ng-container>

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -12,6 +12,7 @@
   line-clamp: 3;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+  word-wrap: break-word;
 }
 
 .description {

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -8,6 +8,10 @@
   text-align: var(--prizm-confirm-dialog-title-align, center);
   color: var(--prizm-confirm-dialog-title, var(--prizm-text-icon-primary));
   white-space: pre-line;
+  display: -webkit-box;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 .description {

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -74,8 +74,11 @@
 .content {
   display: flex;
   flex-flow: column;
-  gap: 16px;
   padding: 32px 16px;
+
+  &.has-description {
+    gap: 16px;
+  }
 }
 
 .footer {

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -9,7 +9,7 @@ import { PrizmBaseDialogContext, PrizmDialogSize } from '../dialog';
 import { PrizmConfirmDialogOptions, PrizmConfirmDialogResultDefaultType } from './confirm-dialog.models';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
 import { CommonModule } from '@angular/common';
-import { PolymorphModule, PrizmFocusTrapModule } from '../../../directives';
+import { PolymorphModule, PrizmFocusTrapModule, PrizmHintOnOverflowDirective } from '../../../directives';
 import { PrizmOverlayModule } from '../../../modules';
 import { PrizmTheme, PrizmThemeModule } from '@prizm-ui/theme';
 import { PrizmButtonModule } from '../../button';
@@ -31,6 +31,7 @@ import { PrizmScrollbarModule } from '../../scrollbar';
     PrizmButtonModule,
     PrizmFocusTrapModule,
     PrizmScrollbarModule,
+    PrizmHintOnOverflowDirective,
   ],
   animations: [prizmSlideInTop, prizmFadeIn],
 })

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.html
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.html
@@ -1,7 +1,13 @@
 <div class="host" [prizmTheme]="theme" prizmFocusTrap>
   <ng-container *polymorphOutlet="context.outerHeader as data; context: context">
     <div class="header prizm-font-title-h4" *ngIf="context.header || context.outerHeader">
-      <div class="title" *polymorphOutlet="context.header as data; context: context">
+      <div
+        class="title"
+        #host
+        *polymorphOutlet="context.header as data; context: context"
+        [prizmHintOnOverflow]="data"
+        [prizmHintOnOverflowEl]="host"
+      >
         {{ data }}
       </div>
       <button

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
@@ -35,8 +35,10 @@
   .title {
     .ellipsis();
     max-width: 90%;
-    display: flex;
     align-items: center;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
   }
 }
 

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
@@ -37,6 +37,7 @@
     max-width: 90%;
     align-items: center;
     display: -webkit-box;
+    line-clamp: 3;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
   }

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
@@ -41,6 +41,7 @@
     line-clamp: 1;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
+    word-wrap: break-word;
   }
 }
 

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.less
@@ -36,9 +36,10 @@
     .ellipsis();
     max-width: 90%;
     align-items: center;
+    align-self: center;
     display: -webkit-box;
-    line-clamp: 3;
-    -webkit-line-clamp: 3;
+    line-clamp: 1;
+    -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
   }
 }

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.ts
@@ -12,7 +12,12 @@ import {
   PrizmDialogOptions,
   PrizmDialogSize,
 } from './dialog.models';
-import { PolymorphContent, PolymorphModule, PrizmFocusTrapModule } from '../../../directives';
+import {
+  PolymorphContent,
+  PolymorphModule,
+  PrizmFocusTrapModule,
+  PrizmHintOnOverflowDirective,
+} from '../../../directives';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
 import { CommonModule } from '@angular/common';
 import { PrizmTheme, PrizmThemeModule } from '@prizm-ui/theme';
@@ -40,6 +45,7 @@ import { prizmIconsXmark } from '@prizm-ui/icons/full/source';
     PrizmFocusTrapModule,
     PrizmInputIconButtonModule,
     PrizmScrollbarModule,
+    PrizmHintOnOverflowDirective,
   ],
 })
 export class PrizmDialogComponent<O = unknown, DATA = unknown> extends PrizmAbstractTestId {

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
@@ -10,14 +10,11 @@
       </ng-container>
     </ng-container>
     <ng-container *ngSwitchDefault>
-      <prizm-scrollbar
-        *polymorphOutlet="context.header as data; context: context"
-        [visibility]="context.scrollbarVisibility ?? 'hidden'"
-      >
-        <div class="title">
+      <ng-container *polymorphOutlet="context.header as data; context: context">
+        <div class="title" #host [prizmHintOnOverflow]="context.header" [prizmHintOnOverflowEl]="host">
           {{ data }}
         </div>
-      </prizm-scrollbar>
+      </ng-container>
       <button
         *ngIf="context.closeable"
         [size]="'m'"

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
@@ -15,6 +15,7 @@
   padding: var(--prizm-sidebar-header-padding, var(--prizm-sidebar-padding, 8px 16px));
   display: flex;
   justify-content: space-between;
+  align-items: center;
   max-width: 100%;
   overflow: hidden;
   font-style: var(--prizm-sidebar-header-font-style, normal);
@@ -31,10 +32,12 @@
 
   .title {
     .ellipsis();
-    height: 100%;
     max-width: 90%;
-    display: flex;
-    align-items: center;
+    align-self: center;
+    display: -webkit-box;
+    line-clamp: 1;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
   }
 }
 

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
@@ -38,6 +38,7 @@
     line-clamp: 1;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
+    word-wrap: break-word;
   }
 }
 

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.ts
@@ -10,7 +10,11 @@ import { PrizmSidebarOptions, PrizmSidebarResultDefaultType } from './sidebar.mo
 import { invokeIfCanCloseSidebar } from './util';
 import { PrizmAbstractTestId } from '../../../abstract/interactive';
 import { CommonModule } from '@angular/common';
-import { PolymorphOutletDirective, PrizmFocusTrapModule } from '../../../directives';
+import {
+  PolymorphOutletDirective,
+  PrizmFocusTrapModule,
+  PrizmHintOnOverflowDirective,
+} from '../../../directives';
 import { PrizmTheme, PrizmThemeModule } from '@prizm-ui/theme';
 import { PrizmInputIconButtonModule } from '../../input';
 import { PrizmButtonComponent } from '../../button';
@@ -37,6 +41,7 @@ import { prizmIconsXmark } from '@prizm-ui/icons/full/source';
     PrizmButtonComponent,
     PrizmFocusTrapModule,
     PrizmScrollbarComponent,
+    PrizmHintOnOverflowDirective,
   ],
 })
 export class PrizmSidebarComponent<DATA = unknown> extends PrizmAbstractTestId {

--- a/libs/components/src/lib/components/widget/widget.component.less
+++ b/libs/components/src/lib/components/widget/widget.component.less
@@ -16,6 +16,7 @@ prizm-card {
 
   text-overflow: ellipsis;
   display: -webkit-box;
+  line-clamp: 1;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/libs/components/src/lib/components/widget/widget.component.less
+++ b/libs/components/src/lib/components/widget/widget.component.less
@@ -15,7 +15,6 @@ prizm-card {
   color: var(--prizm-widget-title-text, var(--prizm-text-icon-primary));
 
   text-overflow: ellipsis;
-  overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;

--- a/libs/components/src/lib/util/dom/is-textoverflow.ts
+++ b/libs/components/src/lib/util/dom/is-textoverflow.ts
@@ -3,7 +3,7 @@ import { delay, delayWhen, map } from 'rxjs/operators';
 
 export function prizmIsTextOverflow(element: HTMLElement): boolean {
   if (element) {
-    return element.offsetWidth < element.scrollWidth;
+    return element.offsetWidth < element.scrollWidth || element.offsetHeight < element.scrollHeight;
   } else {
     return false;
   }


### PR DESCRIPTION
feat(helpers/is-text-overflow): added ability to check vertical text overflow
feat(doc/dialog): beautify live demo 'with template' examples
feat(doc/confirm-dialog): beautify live demo 'with template' examples
feat(doc/sidebar): beautify live demo 'with template' examples
fix(components/dialog): limit dialog header with 1 line of text only #755
fix(components/confirm-dialog): limit dialog header with 3 lines of text only #755
fix(components/confirm-dialog): add gap only for dialog with description #000

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [x] `documentation`

### Компонент

Dialog
Hint on overflow

### Задача

resolved #755

### Изменения

- [ ] Имеются BREAKING CHANGES
- [x] Изменения документации
- [x] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Нужно проверить все компоненты, где хинт появляется при переполнении контента
В диалоге обратить внимание на поведение заголовка с шаблоном


### Release notes

В заголовке dialog  и confirm dialog теперь слишком длинный текст обрезается и появляется всплывающая подсказка.
Функция-помощник prizmIsTextOverflow теперь проверяет переполнение и по вертикали.
Так же улучшили внешний вид примеров диалога, сайдбара и confirm диалога.

