### PR TITLE
fix(components/panel): fix incorrect css variable name for subheader color #2186 v4

### DIFF
--- a/apps/doc/src/app/components/progress/line-segmented/examples/base/progress-base-example.component.ts
+++ b/apps/doc/src/app/components/progress/line-segmented/examples/base/progress-base-example.component.ts
@@ -29,5 +29,4 @@ export class PrizmProgressBaseExampleComponent {
     takeWhile(i => i != this.max + 1),
     startWith(2)
   );
-  readonly colors = [`var(---prizm-status-warning-primary-default)`, `lightskyblue`, `#3682db`, `red`];
 }

--- a/libs/components/src/lib/components/panel/panel.component.less
+++ b/libs/components/src/lib/components/panel/panel.component.less
@@ -58,7 +58,7 @@
         line-height: 16px;
         font-weight: 400;
 
-        color: var(---prizm-text-icon-tertiary);
+        color: var(--prizm-text-icon-tertiary);
       }
     }
 


### PR DESCRIPTION
fix(components/panel): fix incorrect css variable name for subheader color #2186

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Panel

### Задача

resolved #2186

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Panel, пример для segmented progress

### Release notes

Исправили переменную цвета для подзаголовка панели
