### PR TITLE
fix(theme/theme-service): set correct initial theme for micro frontend #2201

### DIFF
--- a/libs/theme/src/lib/services/theme.service.ts
+++ b/libs/theme/src/lib/services/theme.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
+import { distinctUntilChanged, map, tap } from 'rxjs/operators';
 import { PrizmTheme } from '../types/theme';
 import { DOCUMENT } from '@angular/common';
 
@@ -21,7 +21,7 @@ export class PrizmThemeService implements OnDestroy {
     theme: PrizmTheme;
     el?: HTMLElement;
   }>({
-    theme: 'light',
+    theme: this.getInitialTheme(),
   });
   readonly change$ = this.changeSource$.pipe(
     tap(data => data.el && this.themeStorage.set(data.el, data.theme))
@@ -93,5 +93,10 @@ export class PrizmThemeService implements OnDestroy {
     const style = el.style;
     style.setProperty(`--${token}`, value);
     return true;
+  }
+
+  // Need for microfront
+  private getInitialTheme(): PrizmTheme {
+    return this.rootElement.getAttribute(this.attThemeKey) ?? 'light';
   }
 }

--- a/libs/theme/src/lib/services/theme.service.ts
+++ b/libs/theme/src/lib/services/theme.service.ts
@@ -4,6 +4,8 @@ import { distinctUntilChanged, map, tap } from 'rxjs/operators';
 import { PrizmTheme } from '../types/theme';
 import { DOCUMENT } from '@angular/common';
 
+export const ATT_THEME_KEY = 'data-prizm-theme';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -40,7 +42,7 @@ export class PrizmThemeService implements OnDestroy {
   public getLastThemeForElement(el: HTMLElement = this.rootElement): string | null {
     let theme = this.themeStorage.get(el);
     if (el !== this.rootElement_)
-      theme = el.closest(`[${this.attThemeKey}]`)?.getAttribute(this.attThemeKey) as string;
+      theme = el.closest(`[${ATT_THEME_KEY}]`)?.getAttribute(ATT_THEME_KEY) as string;
     return theme ?? null;
   }
 
@@ -62,11 +64,11 @@ export class PrizmThemeService implements OnDestroy {
   }
 
   public getByElement(el?: HTMLElement): PrizmTheme {
-    return (el ?? this.rootElement)?.getAttribute(this.attThemeKey) as PrizmTheme;
+    return (el ?? this.rootElement)?.getAttribute(ATT_THEME_KEY) as PrizmTheme;
   }
 
   private setToHtml(theme: PrizmTheme, el?: HTMLElement): void {
-    (el ?? this.rootElement)?.setAttribute(this.attThemeKey, theme);
+    (el ?? this.rootElement)?.setAttribute(ATT_THEME_KEY, theme);
   }
 
   public update(theme: PrizmTheme, el: HTMLElement = this.rootElement): void {
@@ -97,6 +99,6 @@ export class PrizmThemeService implements OnDestroy {
 
   // Need for microfront
   private getInitialTheme(): PrizmTheme {
-    return this.rootElement.getAttribute(this.attThemeKey) ?? 'light';
+    return this.rootElement.getAttribute(ATT_THEME_KEY) ?? 'light';
   }
 }


### PR DESCRIPTION
fix(theme/theme-service): set correct initial theme for micro frontend #2201

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [x] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Theme Service

### Задача

resolved #2201

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Поведение сервиса тем, тестирование на микрофронтах - в next сборке

### Release notes

Исправили поведение сервиса тем в микро-фронт приложениях
