### PR TITLE
fix(components/toast): toast content width changed #305 v4

### DIFF
--- a/libs/components/src/lib/components/toast/toast/toast.component.less
+++ b/libs/components/src/lib/components/toast/toast/toast.component.less
@@ -19,6 +19,7 @@
   .content-box {
     display: flex;
     width: 100%;
+    max-width: 425px;
     word-wrap: break-word;
     flex-flow: column;
     justify-content: space-between;
@@ -29,7 +30,6 @@
     }
     .content {
       color: var(--prizm-text-icon-secondary);
-      width: calc(100% - 72px);
     }
 
     .title {

--- a/libs/components/src/lib/components/toast/toast/toast.component.less
+++ b/libs/components/src/lib/components/toast/toast/toast.component.less
@@ -29,6 +29,7 @@
     }
     .content {
       color: var(--prizm-text-icon-secondary);
+      width: calc(100% - 72px);
     }
 
     .title {


### PR DESCRIPTION
fix(components/toast): toast content width changed #305

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Toast

### Задача

resolved #305 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Регресс возник  в результате фикса по задаче #1433
Нужно проверить ее, а так же все варианты содержимого тоста.

### Release notes

Исправили проблему с версткой в контенте тоста.
