### PR TITLE
fix(components/input): correction input hint behavior for input without ng-control #1966  v4

### DIFF
--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
@@ -54,6 +54,7 @@
               [chips]="chips"
               [deletable]="deletable"
               [disabled]="disabled"
+              [hintCanShow]="hintCanShow"
               prizmDocHostElementKey="PrizmChipsComponent"
               prizm-input-bottom
             >

--- a/apps/doc/src/app/components/input/input-text/examples/input-basic-example/input-basic-example.component.html
+++ b/apps/doc/src/app/components/input/input-text/examples/input-basic-example/input-basic-example.component.html
@@ -1,3 +1,3 @@
 <prizm-input-layout label="Заголовок">
-  <input prizmInput />
+  <input [prizmHintCanShow]="true" prizmInput />
 </prizm-input-layout>

--- a/libs/components/src/lib/components/chips/chips.component.html
+++ b/libs/components/src/lib/components/chips/chips.component.html
@@ -33,6 +33,7 @@
         *ngIf="(overflowHost.hiddenElements$ | async)?.length"
         [prizmHint]="overflowHost.hiddenElements$ | prizmGetContextByKeys | async | prizmCallFunc : joinHints"
         [prizmHintDirection]="hintDirection"
+        [prizmHintCanShow]="hintCanShow"
       >
         ...
       </div>

--- a/libs/components/src/lib/components/chips/chips.component.ts
+++ b/libs/components/src/lib/components/chips/chips.component.ts
@@ -28,8 +28,8 @@ import {
   PrizmStringifyDirective,
 } from '@prizm-ui/helpers';
 import { PrizmAbstractTestId } from '../../abstract/interactive';
-import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
-import { PrizmElementReadyDirective, PrizmHintDirective, PrizmLifecycleDirective } from '../../directives';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { PrizmHintDirective } from '../../directives';
 import { PrizmChipsItemComponent } from './chips-item';
 import { PrizmInputLayoutComponent } from '../input';
 
@@ -51,12 +51,9 @@ import { PrizmInputLayoutComponent } from '../input';
   imports: [
     NgIf,
     NgFor,
-    NgTemplateOutlet,
     AsyncPipe,
     PrizmChipsItemComponent,
     PrizmCallFuncPipe,
-    PrizmLifecycleDirective,
-    PrizmElementReadyDirective,
     PrizmLetDirective,
     PrizmHintDirective,
     PrizmOverflowItemDirective,

--- a/libs/components/src/lib/components/input/common/input-hint/input-hint.directive.ts
+++ b/libs/components/src/lib/components/input/common/input-hint/input-hint.directive.ts
@@ -44,7 +44,7 @@ export class PrizmInputHintDirective {
   }
 
   public ngOnChanges(): void {
-    this.hintSyncChanges();
+    this.updateHint();
   }
 
   private hintSyncChanges(): void {

--- a/libs/components/src/lib/components/input/input-number/input-number.component.ts
+++ b/libs/components/src/lib/components/input/input-number/input-number.component.ts
@@ -18,7 +18,6 @@ import { PrizmDestroyService, prizmFormatNumber } from '@prizm-ui/helpers';
 import { fromEvent, merge, Subject } from 'rxjs';
 import { map, takeUntil, tap, throttleTime } from 'rxjs/operators';
 import { PrizmDecimal } from '@prizm-ui/core';
-import { PrizmHintDirective } from '../../../directives';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsMinus, prizmIconsPlus } from '@prizm-ui/icons/full/source';
 
@@ -224,6 +223,7 @@ export class PrizmInputNumberComponent extends PrizmInputControl<number> impleme
     this.ngControl?.statusChanges
       ?.pipe(
         tap(() => {
+          this.inputHint?.updateHint();
           this.stateChanges.next();
         }),
         takeUntil(this.destroy$)

--- a/libs/components/src/lib/components/input/input-text/input-text.component.ts
+++ b/libs/components/src/lib/components/input/input-text/input-text.component.ts
@@ -12,12 +12,10 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   Renderer2,
-  Self,
 } from '@angular/core';
-import { FormControl, NgControl, Validators } from '@angular/forms';
+import { NgControl, Validators } from '@angular/forms';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { takeUntil, tap } from 'rxjs/operators';
 import { PrizmInputControl } from '../common/base/input-control.class';
@@ -194,7 +192,7 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   public ngOnInit(): void {
-    if (this.ngControl) this.initControlListener();
+    this.initControlListener();
     this.inputHint?.updateHint();
     this.safeClearNgxMaskListener();
   }
@@ -234,6 +232,13 @@ export class PrizmInputTextComponent<VALUE extends string | number | null = stri
   }
 
   private initControlListener(): void {
+    if (!this.ngControl?.control) {
+      // Update clear button state and hint in case of setup without `NG_CONTROL` directive applied (i.e. just native input)
+      const unlisten = this.renderer2_.listen(this._inputValue, 'input', () => this.updateValue(this.value));
+      this.destroy.addCallback(unlisten);
+      return;
+    }
+
     this.ngControl?.statusChanges
       ?.pipe(
         tap(() => {


### PR DESCRIPTION
fix(components/input): correction input hint behavior for input without ng-control #1966

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Input
### Задача
resolved #1966 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Поведение хинта, кнопки очистки и обновления данных в input text и связанных компонентах

### Release notes

Исправили проблему с подсказкой для input text.
