### PR TITLE
fix(components/tabs): autoscroll to selected tab in dropdown added #1962

### DIFF
--- a/libs/components/src/lib/components/tabs/tabs.component.html
+++ b/libs/components/src/lib/components/tabs/tabs.component.html
@@ -68,6 +68,7 @@
             <prizm-listing-item
               [disabled]="$any(tab.disabled)"
               [selected]="activeTabIndex === i"
+              [prizmScrollIntoView]="scrollItemIntoView(i)"
               (click)="clickTab(i)"
             >
               <ng-container *ngIf="tab.icon || hasIcons" leftBox>

--- a/libs/components/src/lib/components/tabs/tabs.component.ts
+++ b/libs/components/src/lib/components/tabs/tabs.component.ts
@@ -35,6 +35,7 @@ import {
   PrizmDropdownControllerModule,
   PrizmHintDirective,
   PrizmLifecycleDirective,
+  PrizmScrollIntoViewDirective,
 } from '../../directives';
 import { PrizmButtonComponent } from '../button';
 import { PrizmDataListComponent } from '../data-list';
@@ -74,6 +75,7 @@ import {
     PrizmIconTabsPipe,
     PrizmHintDirective,
     PrizmIconsFullComponent,
+    PrizmScrollIntoViewDirective,
   ],
 })
 export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, OnDestroy {
@@ -201,6 +203,10 @@ export class PrizmTabsComponent extends PrizmAbstractTestId implements OnInit, O
   public clickTab(index: number): void {
     this.openLeft = this.openRight = false;
     this.tabClickHandler(index);
+  }
+
+  public scrollItemIntoView(tabIndex: number): boolean {
+    return tabIndex === this.activeTabIndex;
   }
 
   private initTabClickListener(): void {


### PR DESCRIPTION
fix(components/tabs): autoscrolling to selected tab in dropdown added #1962

### Библиотека

- [ ] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

_Название компонента или группы компонентов_

### Задача

resolved #1962

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились


### Release notes

Добавили автопрокрутку к выбранному скроллу в дропдауне табов. 