### PR TITLE
fix(components/switcher): add type button to switcher button #2254 v4

### DIFF
--- a/apps/doc/src/app/components/switcher/switcher-example.module.ts
+++ b/apps/doc/src/app/components/switcher/switcher-example.module.ts
@@ -25,12 +25,7 @@ import { SwitcherProjectionExampleComponent } from './examples/switcher-projecti
 import { SwitcherProjectionValueExampleComponent } from './examples/switcher-projection-value-example/switcher-projection-value-example.component';
 import { SwitcherBasicValueExampleComponent } from './examples/switcher-basic-value-example/switcher-basic-value-example.component';
 import { SwitcherOverflowExampleComponent } from './examples/switcher-overflow-example/switcher-overflow-example.component';
-import {
-  PrizmCallFuncPipe,
-  PrizmContextGetByKysPipe,
-  PrizmOverflowHostDirective,
-  PrizmOverflowItemDirective,
-} from '@prizm-ui/helpers';
+import { PrizmOverflowHostDirective, PrizmOverflowItemDirective } from '@prizm-ui/helpers';
 
 @NgModule({
   declarations: [

--- a/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.html
+++ b/libs/components/src/lib/components/switcher/components/switcher-item/switcher-item.component.html
@@ -8,6 +8,7 @@
   [appearance]="appearanceDirective.appearance"
   [class.switcher_active_disabled]="isActive && isDisabled"
   [pseudoPressed]="isActive"
+  type="button"
   prizmButton
 >
   <div #prizmHasValue="prizmHasValue" prizmHasValue>
@@ -24,6 +25,7 @@
     [size]="size"
     [appearanceType]="appearanceTypeDirective.appearanceType"
     [appearance]="appearanceDirective.appearance"
+    type="button"
     prizmIconButton
   ></button>
 </ng-container>


### PR DESCRIPTION
fix(components/switcher): add attribute type="button" to switcher button #2254

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Switcher

### Задача

resolved #2254 

### Изменения

- [ ] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [ ] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [x] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились


### Release notes

Добавили type="button" к кнопкам внутри свитчера
