### PR TITLE
feat(components/confirm-dialog): add translations for default button texts #2209

### DIFF
--- a/apps/doc/src/app/components/dialogs/confirm-dialog/examples/footer-template/footer-template.component.html
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/examples/footer-template/footer-template.component.html
@@ -5,16 +5,22 @@
     <button
       (click)="completeWith('secondary')"
       prizmButton
-      appearance="secondary"
+      appearance="primary"
       appearanceType="fill"
       size="l"
     >
       Cancel
     </button>
-    <button (click)="completeWith('danger')" prizmButton appearance="danger" appearanceType="fill" size="l">
+    <button
+      (click)="completeWith('danger')"
+      prizmButton
+      appearance="secondary"
+      appearanceType="outline"
+      size="l"
+    >
       Danger Action
     </button>
-    <button (click)="completeWith('primary')" prizmButton appearance="primary" appearanceType="fill" size="l">
+    <button (click)="completeWith('primary')" prizmButton appearance="danger" appearanceType="ghost" size="l">
       Confirm
     </button>
   </div>

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -21,7 +21,7 @@
 
   <div class="footer prizm-font-btn-links-14">
     <ng-template #columnWrapper let-column="column"> </ng-template>
-
+    @let dictionary = dictionary$ | async;
     <ng-container *polymorphOutlet="$any(context.footer); context: context">
       <ng-container [ngSwitch]="!context.showByVertical">
         <div class="horizontal" *ngSwitchCase="true">
@@ -29,7 +29,7 @@
             <ng-container
               *ngIf="context.supportButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.supportButton }"
+              [ngTemplateOutletContext]="{ button: context.supportButton, defaultText: dictionary?.continue }"
             >
             </ng-container>
           </div>
@@ -37,14 +37,14 @@
             <ng-container
               *ngIf="context.cancelButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.cancelButton }"
+              [ngTemplateOutletContext]="{ button: context.cancelButton, defaultText: dictionary?.cancel }"
             >
             </ng-container>
 
             <ng-container
               *ngIf="context.confirmButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.confirmButton }"
+              [ngTemplateOutletContext]="{ button: context.confirmButton, defaultText: dictionary?.confirm }"
             >
             </ng-container>
           </div>
@@ -54,13 +54,13 @@
             <ng-container
               *ngIf="context.confirmButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.confirmButton }"
+              [ngTemplateOutletContext]="{ button: context.confirmButton, defaultText: dictionary?.confirm }"
             >
             </ng-container>
             <ng-container
               *ngIf="context.supportButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.supportButton }"
+              [ngTemplateOutletContext]="{ button: context.supportButton, defaultText: dictionary?.continue }"
             >
             </ng-container>
           </div>
@@ -68,7 +68,7 @@
             <ng-container
               *ngIf="context.cancelButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.cancelButton }"
+              [ngTemplateOutletContext]="{ button: context.cancelButton, defaultText: dictionary?.cancel }"
             >
             </ng-container>
           </div>
@@ -76,7 +76,7 @@
       </ng-container>
     </ng-container>
 
-    <ng-template #buttonTemplate let-button="button">
+    <ng-template #buttonTemplate let-button="button" let-defaultText="defaultText">
       <button
         [style]="button.style"
         [appearance]="button.appearance"
@@ -89,7 +89,7 @@
         (click)="button.action(context)"
         prizmButton
       >
-        {{ button.text }}
+        {{ button.text ?? defaultText }}
       </button>
     </ng-template>
   </div>

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -67,7 +67,7 @@
   }
 
   .bottom {
-    margin-top: 16px;
+    margin-top: 8px;
   }
 }
 

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Inject, Input } from '@angular/core';
 import { Observable } from 'rxjs';
-import { PRIZM_ANIMATIONS_DURATION } from '../../../tokens';
+import { PRIZM_ANIMATIONS_DURATION, PRIZM_DIALOG_KIT } from '../../../tokens';
 import { PRIZM_DIALOG_CLOSE_STREAM, PRIZM_DIALOG_PROVIDERS } from '../dialog/dialog-options';
 import { PrizmAnimationOptions, prizmFadeIn, prizmSlideInTop } from '../../../animations';
 import { takeUntil } from 'rxjs/operators';
@@ -13,13 +13,14 @@ import { PolymorphModule, PrizmFocusTrapDirective, PrizmHintOnOverflowDirective 
 import { PrizmTheme, PrizmThemeModule } from '@prizm-ui/theme';
 import { PrizmButtonComponent } from '../../button';
 import { PrizmScrollbarModule } from '../../scrollbar';
+import { prizmI18nInitWithKey, PrizmLanguageDialogs } from '@prizm-ui/i18n';
 
 @Component({
   selector: 'prizm-confirm-dialog',
   templateUrl: './confirm-dialog.component.html',
   styleUrls: ['./confirm-dialog.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: PRIZM_DIALOG_PROVIDERS,
+  providers: [PRIZM_DIALOG_PROVIDERS, ...prizmI18nInitWithKey(PRIZM_DIALOG_KIT, 'dialog')],
   standalone: true,
   imports: [
     CommonModule,
@@ -79,6 +80,8 @@ export class PrizmDialogConfirmComponent<DATA = unknown> extends PrizmAbstractTe
   constructor(
     @Inject(PRIZM_ANIMATIONS_DURATION) private readonly duration: number,
     @Inject(PRIZM_DIALOG_CLOSE_STREAM) readonly close$: Observable<unknown>,
+    @Inject(PRIZM_DIALOG_KIT)
+    public readonly dictionary$: Observable<PrizmLanguageDialogs['dialog']>,
     private readonly destroy$: PrizmDestroyService,
     private readonly elRef: ElementRef
   ) {

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.service.ts
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.service.ts
@@ -56,7 +56,6 @@ export class PrizmConfirmDialogService<
       this.generateButton(
         options,
         options.supportButton,
-        'Продолжить',
         PrizmConfirmDialogResultDefaultType.confirm,
         'danger',
         'ghost'
@@ -65,7 +64,6 @@ export class PrizmConfirmDialogService<
     const confirmButton = this.generateButton(
       options,
       options.confirmButton as any,
-      'Подтвердить',
       PrizmConfirmDialogResultDefaultType.confirm,
       'primary'
     );
@@ -73,7 +71,6 @@ export class PrizmConfirmDialogService<
     const cancelButton = this.generateButton(
       options,
       options.cancelButton as any,
-      'Отмена',
       PrizmConfirmDialogResultDefaultType.cancel,
       'secondary',
       'ghost'
@@ -87,12 +84,11 @@ export class PrizmConfirmDialogService<
   private generateButton(
     options: Partial<T>,
     button: PrizmConfirmDialogButton | string,
-    defaultText: string,
     defaultComplete: PrizmConfirmDialogResultDefaultType,
     defaultAppearance?: PrizmAppearance,
     defaultAppearanceType?: PrizmAppearanceType
   ): PrizmConfirmDialogButton {
-    const buttonText = (typeof button === 'string' ? button : button?.text) ?? defaultText;
+    const buttonText = (typeof button === 'string' ? button : button?.text) ?? null;
     const btn = ((typeof button === 'string' ? {} : button) ?? {}) as Partial<PrizmConfirmDialogButton>;
 
     return {

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.html
@@ -43,6 +43,7 @@
   </div>
 
   <div class="footer prizm-font-btn-links-14" *ngIf="!context.hideFooter">
+    @let dictionary = dictionary$ | async;
     <ng-container *ngIf="context.footer; else notFooter">
       <div *polymorphOutlet="context.footer as footer; context: context">
         {{ footer }}
@@ -55,7 +56,7 @@
             <ng-container
               *ngIf="context.supportButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.supportButton }"
+              [ngTemplateOutletContext]="{ button: context.supportButton, defaultText: dictionary?.continue }"
             >
             </ng-container>
           </div>
@@ -63,21 +64,21 @@
             <ng-container
               *ngIf="context.cancelButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.cancelButton }"
+              [ngTemplateOutletContext]="{ button: context.cancelButton, defaultText: dictionary?.cancel }"
             >
             </ng-container>
 
             <ng-container
               *ngIf="context.confirmButton"
               [ngTemplateOutlet]="buttonTemplate"
-              [ngTemplateOutletContext]="{ button: context.confirmButton }"
+              [ngTemplateOutletContext]="{ button: context.confirmButton, defaultText: dictionary?.confirm }"
             >
             </ng-container>
           </div>
         </div>
       </ng-container>
 
-      <ng-template #buttonTemplate let-button="button">
+      <ng-template #buttonTemplate let-button="button" let-defaultText="defaultText">
         <button
           [style]="button.style"
           [appearance]="button.appearance"
@@ -89,7 +90,7 @@
           (click)="button.action(context)"
           prizmButton
         >
-          {{ button.text }}
+          {{ button.text ?? defaultText }}
         </button>
       </ng-template>
     </ng-template>

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Inject, Input, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { PRIZM_ANIMATIONS_DURATION } from '../../../tokens';
+import { PRIZM_ANIMATIONS_DURATION, PRIZM_DIALOG_KIT } from '../../../tokens';
 import { PRIZM_DIALOG_CLOSE_STREAM, PRIZM_DIALOG_PROVIDERS } from '../dialog/dialog-options';
 import { PrizmAnimationOptions, prizmFadeIn, prizmSlideInTop } from '../../../animations';
 import { takeUntil, tap } from 'rxjs/operators';
@@ -22,13 +22,14 @@ import { PrizmScrollbarComponent } from '../../scrollbar';
 import { PrizmOverlayComponent } from '../../../modules/overlay/overlay.component';
 import { PrizmIconsFullRegistry } from '@prizm-ui/icons/core';
 import { prizmIconsXmark } from '@prizm-ui/icons/full/source';
+import { prizmI18nInitWithKey, PrizmLanguageDialogs } from '@prizm-ui/i18n';
 
 @Component({
   selector: 'prizm-sidebar',
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: PRIZM_DIALOG_PROVIDERS,
+  providers: [PRIZM_DIALOG_PROVIDERS, ...prizmI18nInitWithKey(PRIZM_DIALOG_KIT, 'dialog')],
   animations: [prizmSlideInTop, prizmFadeIn],
   standalone: true,
   imports: [
@@ -96,6 +97,8 @@ export class PrizmSidebarComponent<DATA = unknown> extends PrizmAbstractTestId {
   constructor(
     @Inject(PRIZM_ANIMATIONS_DURATION) private readonly duration: number,
     @Inject(PRIZM_DIALOG_CLOSE_STREAM) readonly close$: Observable<unknown>,
+    @Inject(PRIZM_DIALOG_KIT)
+    public readonly dictionary$: Observable<PrizmLanguageDialogs['dialog']>,
     private readonly destroy$: PrizmDestroyService
   ) {
     super();

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.service.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.service.ts
@@ -74,7 +74,6 @@ export class PrizmSidebarService<
       this.generateButton(
         options,
         options.supportButton as any,
-        'Продолжить',
         PrizmSidebarResultDefaultType.confirm,
         'danger',
         'ghost'
@@ -83,7 +82,6 @@ export class PrizmSidebarService<
     const confirmButton = this.generateButton(
       options,
       options.confirmButton as any,
-      'Подтвердить',
       PrizmSidebarResultDefaultType.confirm,
       'primary'
     );
@@ -93,7 +91,6 @@ export class PrizmSidebarService<
       this.generateButton(
         options,
         options.cancelButton as any,
-        'Отмена',
         PrizmSidebarResultDefaultType.cancel,
         'secondary',
         'ghost'
@@ -107,12 +104,11 @@ export class PrizmSidebarService<
   private generateButton(
     options: Partial<T>,
     button: PrizmSidebarButton | string,
-    defaultText: string,
     defaultComplete: PrizmSidebarResultDefaultType,
     defaultAppearance?: PrizmAppearance,
     defaultAppearanceType?: PrizmAppearanceType
   ): PrizmSidebarButton {
-    const buttonText = (typeof button === 'string' ? button : button?.text) ?? defaultText;
+    const buttonText = (typeof button === 'string' ? button : button?.text) ?? null;
     const btn = ((typeof button === 'string' ? {} : button) ?? {}) as Partial<PrizmSidebarButton>;
 
     return {

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.html
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.html
@@ -11,19 +11,25 @@
       </ng-container>
 
       <div class="footer prizm-font-btn-links-14">
+        @let dictionary = dictionary$ | async;
         <ng-container>
           <div class="vertical">
             <div class="top">
               <ng-container
                 *ngIf="context.confirmButton"
                 [ngTemplateOutlet]="buttonTemplate"
-                [ngTemplateOutletContext]="{ button: context.confirmButton }"
+                [ngTemplateOutletContext]="{
+                  button: context.confirmButton,
+                  defaultText: dictionary?.confirm
+                }"
               >
               </ng-container>
               <ng-container
                 *ngIf="context.supportButton"
                 [ngTemplateOutlet]="buttonTemplate"
-                [ngTemplateOutletContext]="$any({ button: context.supportButton })"
+                [ngTemplateOutletContext]="
+                  $any({ button: context.supportButton, defaultText: dictionary?.quit })
+                "
               >
               </ng-container>
             </div>
@@ -31,14 +37,14 @@
               <ng-container
                 *ngIf="context.cancelButton"
                 [ngTemplateOutlet]="buttonTemplate"
-                [ngTemplateOutletContext]="{ button: context.cancelButton }"
+                [ngTemplateOutletContext]="{ button: context.cancelButton, defaultText: dictionary?.cancel }"
               >
               </ng-container>
             </div>
           </div>
         </ng-container>
 
-        <ng-template #buttonTemplate let-button="button">
+        <ng-template #buttonTemplate let-button="button" let-defaultText="defaultText">
           <button
             [style]="button.style"
             [appearance]="button.appearance"
@@ -49,7 +55,7 @@
             (click)="button.action(context)"
             prizmButton
           >
-            {{ button.text }}
+            {{ button.text ?? defaultText }}
           </button>
         </ng-template>
       </div>

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.ts
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.ts
@@ -1,11 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
 import { PrizmHintContainerComponent } from '../hint/hint-container.component';
+import { prizmI18nInitWithKey, PrizmLanguageDialogs } from '@prizm-ui/i18n';
+import { PRIZM_DIALOG_KIT } from '../../tokens';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'prizm-confirm-popup-container',
   templateUrl: './confirm-popup-container.component.html',
   styleUrls: ['./confirm-popup-container.component.less'],
-  providers: [PrizmDestroyService],
+  providers: [PrizmDestroyService, ...prizmI18nInitWithKey(PRIZM_DIALOG_KIT, 'dialog')],
 })
-export class PrizmConfirmPopupContainerComponent extends PrizmHintContainerComponent<any> {}
+export class PrizmConfirmPopupContainerComponent extends PrizmHintContainerComponent<any> {
+  public readonly dictionary$: Observable<PrizmLanguageDialogs['dialog']> = inject(PRIZM_DIALOG_KIT);
+}

--- a/libs/components/src/lib/directives/confirm-popup/util.ts
+++ b/libs/components/src/lib/directives/confirm-popup/util.ts
@@ -36,12 +36,11 @@ export const prizmGetConfirmPopupContext: PrizmHintGetContextFn = function getCo
 function generateButton(
   options: PrizmConfirmPopupContext,
   button: PrizmConfirmDialogButton | string,
-  defaultText: string,
   defaultComplete: PrizmConfirmDialogResultDefaultType,
   defaultAppearance?: PrizmAppearance,
   defaultAppearanceType?: PrizmAppearanceType
 ): PrizmConfirmDialogButton {
-  const buttonText = (typeof button === 'string' ? button : button?.text) ?? defaultText;
+  const buttonText = (typeof button === 'string' ? button : button?.text) ?? null;
   const btn = ((typeof button === 'string' ? {} : button) ?? {}) as Partial<PrizmConfirmDialogButton>;
 
   const result = {
@@ -64,7 +63,6 @@ function safeUpdateButtonsWithDefaultStyles(options: PrizmConfirmPopupContext): 
   const supportButton = generateButton(
     options,
     options.supportButton as string,
-    'Выйти без сохранения',
     PrizmConfirmDialogResultDefaultType.support,
     'danger',
     'outline'
@@ -73,7 +71,6 @@ function safeUpdateButtonsWithDefaultStyles(options: PrizmConfirmPopupContext): 
   const confirmButton = generateButton(
     options,
     options.confirmButton as string,
-    'Подтвердить',
     PrizmConfirmDialogResultDefaultType.confirm,
     'primary'
   );
@@ -81,7 +78,6 @@ function safeUpdateButtonsWithDefaultStyles(options: PrizmConfirmPopupContext): 
   const cancelButton = generateButton(
     options,
     options.cancelButton as string,
-    'Отмена',
     PrizmConfirmDialogResultDefaultType.cancel,
     'secondary',
     'ghost'

--- a/libs/components/src/lib/tokens/i18n.ts
+++ b/libs/components/src/lib/tokens/i18n.ts
@@ -4,6 +4,7 @@ import {
   PrizmLanguageColumnSettings,
   PrizmLanguageCore,
   PrizmLanguageCron,
+  PrizmLanguageDialogs,
   PrizmLanguageFileUpload,
   PrizmLanguageInputLayout,
   PrizmLanguageInputLayoutDateRelative,
@@ -87,4 +88,8 @@ export const PRIZM_TIME_PAGINATION = new InjectionToken<
 
 export const PRIZM_TIME_PICKER = new InjectionToken<Observable<PrizmLanguageTimePicker['timePicker']>>(
   `time picker i18n text`
+);
+
+export const PRIZM_DIALOG_KIT = new InjectionToken<Observable<PrizmLanguageDialogs['dialog']>>(
+  `base language dialog texts`
 );

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -167,6 +167,14 @@ export interface PrizmLanguageTimePicker {
   };
 }
 
+export interface PrizmLanguageDialogs {
+  dialog: {
+    confirm: string;
+    cancel: string;
+    continue: string;
+  };
+}
+
 export interface PrizmLanguageCore {
   months: MONTHS_ARRAY;
   close: string;
@@ -337,6 +345,7 @@ export interface PrizmLanguage
     PrizmLanguageColumnSettings,
     PrizmLanguagePaginator,
     PrizmLanguageTimePagination,
-    PrizmLanguageTimePicker {}
+    PrizmLanguageTimePicker,
+    PrizmLanguageDialogs {}
 
 export type PrizmI18nFn<K> = (lan: PrizmLanguageName) => K | Observable<K>;

--- a/libs/i18n/src/lib/interfaces/language.ts
+++ b/libs/i18n/src/lib/interfaces/language.ts
@@ -172,6 +172,7 @@ export interface PrizmLanguageDialogs {
     confirm: string;
     cancel: string;
     continue: string;
+    quit: string;
   };
 }
 

--- a/libs/i18n/src/lib/languages/english/dialogs.ts
+++ b/libs/i18n/src/lib/languages/english/dialogs.ts
@@ -5,5 +5,6 @@ export const PRIZM_ENGLISH_DIALOG: PrizmLanguageDialogs = {
     confirm: 'Confirm',
     cancel: 'Cancel',
     continue: 'Continue',
+    quit: 'Quit without saving',
   },
 };

--- a/libs/i18n/src/lib/languages/english/dialogs.ts
+++ b/libs/i18n/src/lib/languages/english/dialogs.ts
@@ -1,0 +1,9 @@
+import { PrizmLanguageDialogs } from '../../interfaces';
+
+export const PRIZM_ENGLISH_DIALOG: PrizmLanguageDialogs = {
+  dialog: {
+    confirm: 'Confirm',
+    cancel: 'Cancel',
+    continue: 'Continue',
+  },
+};

--- a/libs/i18n/src/lib/languages/english/english.ts
+++ b/libs/i18n/src/lib/languages/english/english.ts
@@ -11,6 +11,7 @@ import { PRIZM_ENGLISH_TIME_PAGINATION } from './time-pagination';
 import { PRIZM_ENGLISH_TIME_PICKER } from './time-picker';
 import { PRIZM_ENGLISH_LANGUAGE_KIT } from './kit';
 import { PRIZM_ENGLISH_PAGINATOR } from './paginator';
+import { PRIZM_ENGLISH_DIALOG } from './dialogs';
 
 export const PRIZM_ENGLISH_LANGUAGE = {
   name: `english`,
@@ -27,4 +28,5 @@ export const PRIZM_ENGLISH_LANGUAGE = {
   ...PRIZM_ENGLISH_PAGINATOR,
   ...PRIZM_ENGLISH_TIME_PAGINATION,
   ...PRIZM_ENGLISH_TIME_PICKER,
+  ...PRIZM_ENGLISH_DIALOG,
 } as PrizmLanguage;

--- a/libs/i18n/src/lib/languages/english/index.ts
+++ b/libs/i18n/src/lib/languages/english/index.ts
@@ -11,3 +11,7 @@ export * from './column-settings';
 export * from './paginator';
 export * from './input-layout-date-time';
 export * from './input';
+export * from './dialogs';
+export * from './input-layout-date-time-range';
+export * from './time-pagination';
+export * from './time-picker';

--- a/libs/i18n/src/lib/languages/russian/dialogs.ts
+++ b/libs/i18n/src/lib/languages/russian/dialogs.ts
@@ -5,5 +5,6 @@ export const PRIZM_RUSSIAN_DIALOG: PrizmLanguageDialogs = {
     confirm: 'Подтвердить',
     cancel: 'Отменить',
     continue: 'Продолжить',
+    quit: 'Выйти без сохранения',
   },
 };

--- a/libs/i18n/src/lib/languages/russian/dialogs.ts
+++ b/libs/i18n/src/lib/languages/russian/dialogs.ts
@@ -1,0 +1,9 @@
+import { PrizmLanguageDialogs } from '../../interfaces';
+
+export const PRIZM_RUSSIAN_DIALOG: PrizmLanguageDialogs = {
+  dialog: {
+    confirm: 'Подтвердить',
+    cancel: 'Отменить',
+    continue: 'Продолжить',
+  },
+};

--- a/libs/i18n/src/lib/languages/russian/index.ts
+++ b/libs/i18n/src/lib/languages/russian/index.ts
@@ -11,3 +11,7 @@ export * from './column-settings';
 export * from './paginator';
 export * from './input';
 export * from './input-layout-date-time';
+export * from './dialogs';
+export * from './input-layout-date-time-range';
+export * from './time-pagination';
+export * from './time-picker';

--- a/libs/i18n/src/lib/languages/russian/russian.ts
+++ b/libs/i18n/src/lib/languages/russian/russian.ts
@@ -11,6 +11,7 @@ import { PRIZM_RUSSIAN_TIME_PAGINATION } from './time-pagination';
 import { PRIZM_RUSSIAN_TIME_PICKER } from './time-picker';
 import { PRIZM_RUSSIAN_LANGUAGE_KIT } from './kit';
 import { PRIZM_RUSSIAN_PAGINATOR } from './paginator';
+import { PRIZM_RUSSIAN_DIALOG } from './dialogs';
 
 export const PRIZM_RUSSIAN_LANGUAGE = {
   name: `russian`,
@@ -27,4 +28,5 @@ export const PRIZM_RUSSIAN_LANGUAGE = {
   ...PRIZM_RUSSIAN_PAGINATOR,
   ...PRIZM_RUSSIAN_TIME_PAGINATION,
   ...PRIZM_RUSSIAN_TIME_PICKER,
+  ...PRIZM_RUSSIAN_DIALOG,
 } as PrizmLanguage;


### PR DESCRIPTION
feat(components/confirm-dialog): add translations for default button texts #2209
feat(components/sidebar): add translations for default button texts #2209
feat(components/confirm-popup: add translations for default button texts #2209
fix(components/confirm-dialog): correct footer buttons margins #2209
fix(doc/confirm-dialog): correct footer template example according to style guides #2209

BREAKING CHANGE in dictionary - why we do this read [here](https://github.com/zyfra/Prizm/discussions/1617)

### Библиотека

- [x] `@prizm-ui/components`
- [ ] `@prizm-ui/install`
- [ ] `@prizm-ui/icons`
- [ ] `@prizm-ui/theme`
- [ ] `documentation`

### Компонент

Sidebar
Confirm Dialog
Confirm Popup

### Задача

resolved #2209

### Изменения

- [x] Имеются BREAKING CHANGES
- [ ] Изменения документации
- [x] Добавление фичи
- [x] Исправление бага

Checklist:

- [ ] После фичи обновил документацию
- [ ] Сделал код чище чем был до этого
- [ ] Тесты и линтер на рабочей машине успешно выполнились

### Следует обратить внимание на ревью

Тексты кнопок в футерах компонентов, в том числе с использованием шаблонов

### Release notes

Добавили переводы для кнопок в Confirm Dialog, Confirm Popup, Sidebar. Исправили верстку для кнопок в футере Confirm Dialog. Поправили пример для Confirm Dialog с шаблоном в футере, чтобы он соответствовал гайдам стилей. 
