### PR TITLE
Fix/dialog styles 2209 v4

### DIFF
--- a/apps/doc/src/app/components/dialogs/confirm-dialog/examples/footer-template/footer-template.component.html
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/examples/footer-template/footer-template.component.html
@@ -5,16 +5,22 @@
     <button
       (click)="completeWith('secondary')"
       prizmButton
-      appearance="secondary"
+      appearance="primary"
       appearanceType="fill"
       size="l"
     >
       Cancel
     </button>
-    <button (click)="completeWith('danger')" prizmButton appearance="danger" appearanceType="fill" size="l">
+    <button
+      (click)="completeWith('danger')"
+      prizmButton
+      appearance="secondary"
+      appearanceType="outline"
+      size="l"
+    >
       Danger Action
     </button>
-    <button (click)="completeWith('primary')" prizmButton appearance="primary" appearanceType="fill" size="l">
+    <button (click)="completeWith('primary')" prizmButton appearance="danger" appearanceType="ghost" size="l">
       Confirm
     </button>
   </div>

--- a/apps/doc/src/app/components/dialogs/confirm-dialog/examples/footer-template/footer-template.component.ts
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/examples/footer-template/footer-template.component.ts
@@ -15,7 +15,14 @@ import { PrizmDestroyService } from '@prizm-ui/helpers';
       .custom-footer {
         display: flex;
         flex-direction: column;
-        gap: 1rem;
+
+        [prizmButton] {
+          margin-bottom: 8px;
+        }
+
+        [prizmButton]:last-child {
+          margin-top: 8px;
+        }
       }
     `,
   ],

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -64,7 +64,7 @@
             >
             </ng-container>
           </div>
-          <div class="bottom">
+          <div class="bottom" [class.extra-margin]="context.confirmButton && context.supportButton">
             <ng-container
               *ngIf="context.cancelButton"
               [ngTemplateOutlet]="buttonTemplate"

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -67,7 +67,11 @@
   }
 
   .bottom {
-    margin-top: 16px;
+    margin-top: 8px;
+
+    &.extra-margin {
+      margin-top: 16px;
+    }
   }
 }
 

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.less
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.less
@@ -83,7 +83,7 @@ prizm-scrollbar {
   }
 
   .bottom {
-    margin-top: 24px;
+    margin-top: 16px;
   }
 }
 


### PR DESCRIPTION

- fix(components/confirm-dialog): correct footer buttons margins #2209
- fix(doc/confirm-dialog): correct footer template example according to style guides #2209
- fix(components/confirm-popup): correct margin for cancel button #2296