### PR TITLE
fix(components/dialogs): test id postfix setters override for dialogs #2304

### DIFF
--- a/apps/doc/src/app/addons/query-builder/examples/query-builder-basic-example/query-builder-basic-example.component.html
+++ b/apps/doc/src/app/addons/query-builder/examples/query-builder-basic-example/query-builder-basic-example.component.html
@@ -1,4 +1,4 @@
-<prizm-query-builder [expression]="expression">
+<prizm-query-builder [expression]="expression" [testId]="'base'">
   <ng-container *prizmQueryBuilderCondition="let form">
     <div class="condition-wrapper">
       <prizm-input-layout [size]="'m'"><input [formControl]="form.field" prizmInput /></prizm-input-layout>

--- a/apps/doc/src/app/components/dialogs/confirm-dialog/examples/base/base.component.html
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/examples/base/base.component.html
@@ -1,7 +1,7 @@
 <button (click)="show()" type="button" prizmButton>Show Dialog</button>
 
 <div style="margin-top: 16px">
-  <prizm-doc-documentation>
+  <prizm-doc-documentation #doc>
     <ng-template
       [(documentationPropertyValue)]="position"
       [documentationPropertyValues]="positionVariants"

--- a/apps/doc/src/app/components/dialogs/confirm-dialog/examples/base/base.component.ts
+++ b/apps/doc/src/app/components/dialogs/confirm-dialog/examples/base/base.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { PrizmConfirmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
 import { takeUntil } from 'rxjs/operators';
 import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDocDocumentationComponent } from '@prizm-ui/doc';
 
 @Component({
   selector: 'prizm-dialog-service-example',
@@ -17,6 +18,7 @@ import { PrizmDestroyService } from '@prizm-ui/helpers';
   providers: [PrizmDestroyService],
 })
 export class PrizmDialogServiceExampleComponent {
+  @ViewChild('doc') doc!: PrizmDocDocumentationComponent;
   public positionVariants: PrizmOverlayInsidePlacement[] = Object.values(PrizmOverlayInsidePlacement);
   public position: PrizmOverlayInsidePlacement = PrizmOverlayInsidePlacement.CENTER;
   public backdrop = true;
@@ -35,6 +37,7 @@ export class PrizmDialogServiceExampleComponent {
           position: this.position,
           backdrop: this.backdrop,
           size: 'm',
+          testId: this.doc.testIdPostfix,
         }
       )
       .pipe(takeUntil(this.destroy$))

--- a/apps/doc/src/app/components/dialogs/dialog/examples/base/dialog-base-example.component.html
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/base/dialog-base-example.component.html
@@ -1,7 +1,7 @@
 <button (click)="show()" type="button" prizmButton>Show Dialog</button>
 
 <div style="margin-top: 16px">
-  <prizm-doc-documentation [hasTestId]="false">
+  <prizm-doc-documentation #doc [hasTestId]="true">
     <ng-template
       [(documentationPropertyValue)]="position"
       [documentationPropertyValues]="positionVariants"

--- a/apps/doc/src/app/components/dialogs/dialog/examples/base/dialog-base-example.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/base/dialog-base-example.component.ts
@@ -1,5 +1,6 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, ViewChild } from '@angular/core';
 import { PrizmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
+import { PrizmDocDocumentationComponent } from '@prizm-ui/doc';
 
 @Component({
   selector: 'prizm-dialog-service-example',
@@ -14,6 +15,7 @@ import { PrizmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/compo
   ],
 })
 export class PrizmDialogServiceExampleComponent {
+  @ViewChild('doc') doc!: PrizmDocDocumentationComponent;
   public positionVariants: PrizmOverlayInsidePlacement[] = Object.values(PrizmOverlayInsidePlacement);
   public position: PrizmOverlayInsidePlacement = this.positionVariants[1];
   public backdrop = false;
@@ -34,6 +36,8 @@ export class PrizmDialogServiceExampleComponent {
           dismissible: this.dismissible,
           backdrop: this.backdrop,
           size: 'm',
+          id: 'my_id',
+          testId: this.doc.testIdPostfix,
         }
       )
       .subscribe();

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.html
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.html
@@ -10,7 +10,7 @@
   </div>
 </ng-template>
 <div style="margin-top: 16px">
-  <prizm-doc-documentation [hasTestId]="false">
+  <prizm-doc-documentation #doc [hasTestId]="true">
     <ng-template
       [(documentationPropertyValue)]="position"
       [documentationPropertyValues]="positionVariants"

--- a/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.ts
+++ b/apps/doc/src/app/components/dialogs/sidebar/examples/base/base.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
 import { PrizmSidebarService, PrizmOverlayInsidePlacement } from '@prizm-ui/components';
+import { PrizmDocDocumentationComponent } from '@prizm-ui/doc';
 import { tap } from 'rxjs/operators';
 
 @Component({
@@ -16,6 +17,8 @@ import { tap } from 'rxjs/operators';
 })
 export class PrizmSidebarServiceExampleComponent {
   @ViewChild('contentExample') contentExample!: TemplateRef<any>;
+  @ViewChild('doc') doc!: PrizmDocDocumentationComponent;
+
   public positionVariants: PrizmOverlayInsidePlacement[] = [
     PrizmOverlayInsidePlacement.LEFT,
     PrizmOverlayInsidePlacement.RIGHT,
@@ -38,6 +41,7 @@ export class PrizmSidebarServiceExampleComponent {
         backdrop: this.backdrop,
         dismissible: this.dismissible,
         size: 'm',
+        testId: this.doc.testIdPostfix,
       })
       .pipe(
         tap({

--- a/apps/doc/src/app/components/radio/examples/radio-button-basic-example/radio-button-basic-example.component.html
+++ b/apps/doc/src/app/components/radio/examples/radio-button-basic-example/radio-button-basic-example.component.html
@@ -6,5 +6,6 @@
     [value]="item"
     [size]="size"
     [name]="size"
+    [testId]="item"
   ></prizm-radio-button>
 </div>

--- a/apps/doc/src/app/components/radio/examples/radio-button-basic-example/radio-button-basic-example.component.ts
+++ b/apps/doc/src/app/components/radio/examples/radio-button-basic-example/radio-button-basic-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 @Component({

--- a/apps/doc/src/app/components/splitter/splitter-example.component.html
+++ b/apps/doc/src/app/components/splitter/splitter-example.component.html
@@ -132,7 +132,6 @@
     </prizm-doc-documentation>
 
     <prizm-doc-documentation
-      [showValues]="false"
       heading="PrizmSplitterAreaComponent"
       hostComponentKey="PrizmSplitterAreaComponent"
     >

--- a/apps/doc/src/app/components/table/examples/table-basic-example/table-basic-example.component.html
+++ b/apps/doc/src/app/components/table/examples/table-basic-example/table-basic-example.component.html
@@ -1,9 +1,9 @@
 <h3>Size XL</h3>
 <prizm-scrollbar class="scrollable">
-  <table class="table" prizmTable size="xl">
-    <thead>
-      <tr prizmThGroup>
-        <th prizmTh>Код</th>
+  <table class="table" [testId]="'my-base-super-table'" prizmTable size="xl">
+    <thead [testId]="'my-base-table_head'" prizmThead>
+      <tr [testId]="'my-base-th-group'" prizmThGroup>
+        <th [testId]="'my-base-amazing-th'" prizmTh>Код</th>
         <th prizmTh>Наименование</th>
         <th prizmTh>Категория</th>
         <th prizmTh>Количество</th>
@@ -13,7 +13,7 @@
       </tr>
     </thead>
 
-    <tbody [data]="products" prizmTbody>
+    <tbody [data]="products" [testId]="'my-base-table-body'" prizmTbody>
       <ng-container
         *prizmRow="
           let item of products;
@@ -24,9 +24,9 @@
           let last = last
         "
       >
-        <tr prizmTr>
-          <td class="format__number" prizmTd>
-            {{ item.code | spaceNumber: '0.0-0' }}
+        <tr [testId]="'my-base-table-row'" prizmTr>
+          <td class="format__number" [testId]="'my-base-td'" prizmTd>
+            {{ item.code | spaceNumber : '0.0-0' }}
           </td>
           <td prizmTd>
             {{ item.name }}<br />
@@ -35,10 +35,10 @@
             {{ last ? '#last' : '' }}
           </td>
           <td prizmTd>{{ item.category }}</td>
-          <td class="format__number" prizmTd>{{ item.count | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>
           <td prizmTd>{{ item.name }}</td>
           <td prizmTd>{{ item.category }}</td>
-          <td class="format__number" prizmTd>{{ item.count | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>
         </tr>
       </ng-container>
     </tbody>
@@ -73,7 +73,7 @@
       >
         <tr prizmTr>
           <td class="format__number" prizmTd>
-            {{ item.code | spaceNumber: '0.0-0' }}
+            {{ item.code | spaceNumber : '0.0-0' }}
           </td>
           <td prizmTd>
             {{ item.name }}<br />
@@ -82,10 +82,10 @@
             {{ last ? '#last' : '' }}
           </td>
           <td prizmTd>{{ item.category }}</td>
-          <td class="format__number" prizmTd>{{ item.count | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>
           <td prizmTd>{{ item.name }}</td>
           <td prizmTd>{{ item.category }}</td>
-          <td class="format__number" prizmTd>{{ item.count | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.count | spaceNumber : '0.0-0' }}</td>
         </tr>
       </ng-container>
     </tbody>
@@ -107,11 +107,11 @@
     <tbody [data]="products" prizmTbody>
       <ng-container *prizmRow="let item of products; let i = index">
         <tr prizmTr>
-          <td class="format__number" prizmTd>{{ item.code | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.code | spaceNumber : '0.0-0' }}</td>
           <td prizmTd>{{ item.name }}</td>
           <td prizmTd>{{ item.category }}</td>
           <td class="format__number" prizmTd>
-            {{ item.count | spaceNumber: '0.0-0' }}
+            {{ item.count | spaceNumber : '0.0-0' }}
           </td>
         </tr>
       </ng-container>
@@ -134,11 +134,11 @@
     <tbody [data]="products" prizmTbody>
       <ng-container *prizmRow="let item of products; let i = index">
         <tr prizmTr>
-          <td class="format__number" prizmTd>{{ item.code | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.code | spaceNumber : '0.0-0' }}</td>
           <td prizmTd>{{ item.name }}</td>
           <td prizmTd>{{ item.category }}</td>
           <td class="format__number" prizmTd>
-            {{ item.count | spaceNumber: '0.0-0' }}
+            {{ item.count | spaceNumber : '0.0-0' }}
           </td>
         </tr>
       </ng-container>
@@ -161,11 +161,11 @@
     <tbody [data]="products" prizmTbody>
       <ng-container *prizmRow="let item of products; let i = index">
         <tr prizmTr>
-          <td class="format__number" prizmTd>{{ item.code | spaceNumber: '0.0-0' }}</td>
+          <td class="format__number" prizmTd>{{ item.code | spaceNumber : '0.0-0' }}</td>
           <td prizmTd>{{ item.name }}</td>
           <td prizmTd>{{ item.category }}</td>
           <td class="format__number" prizmTd>
-            {{ item.count | spaceNumber: '0.0-0' }}
+            {{ item.count | spaceNumber : '0.0-0' }}
           </td>
         </tr>
       </ng-container>

--- a/libs/addons/query-builder/src/lib/query-builder.component.ts
+++ b/libs/addons/query-builder/src/lib/query-builder.component.ts
@@ -19,6 +19,7 @@ import {
   contentChild,
   DestroyRef,
   effect,
+  Host,
   inject,
   Injector,
   Input,
@@ -162,7 +163,7 @@ export class PrizmQueryBuilderComponent implements OnInit, ControlValueAccessor,
   private destroyRef = inject(DestroyRef);
   private cdr = inject(ChangeDetectorRef);
   private registry = inject(PrizmIconsFullRegistry);
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor() {
     this.registry.registerIcons(prizmIconsTrash, prizmIconsGripDotsVertical, prizmIconsPlusTriangleDown);

--- a/libs/addons/query-builder/src/lib/query-builder.component.ts
+++ b/libs/addons/query-builder/src/lib/query-builder.component.ts
@@ -61,6 +61,7 @@ import {
   PrizmToggleComponent,
 } from '@prizm-ui/components';
 import { PrizmI18nQueryBuilderService } from './i18n/service';
+import { PrizmTestIdDirective } from '@prizm-ui/helpers';
 
 interface ExpressionNode {
   type: 'exp';
@@ -107,6 +108,12 @@ type Node = ExpressionNode | ConditionNode;
     PrizmDataListComponent,
     PrizmListingItemComponent,
     PrizmScrollbarComponent,
+  ],
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
   ],
 })
 export class PrizmQueryBuilderComponent implements OnInit, ControlValueAccessor, Validator {
@@ -155,9 +162,11 @@ export class PrizmQueryBuilderComponent implements OnInit, ControlValueAccessor,
   private destroyRef = inject(DestroyRef);
   private cdr = inject(ChangeDetectorRef);
   private registry = inject(PrizmIconsFullRegistry);
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
 
   constructor() {
     this.registry.registerIcons(prizmIconsTrash, prizmIconsGripDotsVertical, prizmIconsPlusTriangleDown);
+    this.testIdDirective.generateMainTestId = 'ui_query-builder';
     effect(this._assignDragToList);
   }
 

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -67,6 +67,15 @@ export class PrizmDialogConfirmComponent<DATA = unknown> extends PrizmAbstractTe
   @HostBinding('style.width')
   readonly width = '100%';
 
+  @HostBinding('attr.data-testid')
+  override get testId() {
+    const postfix = this.testIdPostfix || this.context.testId;
+    return this.generateMainTestId + (postfix ? `--${postfix}` : '');
+  }
+  override set testId(value: string) {
+    this.testIdPostfix = value;
+  }
+
   override readonly testId_ = 'ui_form_submit';
 
   private readonly animation = {

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.component.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.component.ts
@@ -77,6 +77,15 @@ export class PrizmDialogComponent<O = unknown, DATA = unknown> extends PrizmAbst
   @HostBinding('style.width')
   readonly width = '100%';
 
+  @HostBinding('attr.data-testid')
+  override get testId() {
+    const postfix = this.testIdPostfix || this.context.testId;
+    return this.generateMainTestId + (postfix ? `--${postfix}` : '');
+  }
+  override set testId(value: string) {
+    this.testIdPostfix = value;
+  }
+
   @prizmPure
   public get isFooterArray(): boolean {
     return Boolean(this.footer && Array.isArray(this.footer) && this.footer.length);

--- a/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
+++ b/libs/components/src/lib/components/dialogs/dialog/dialog.models.ts
@@ -37,6 +37,7 @@ export interface PrizmDialogBaseOptions {
   readonly position: PrizmOverlayInsidePlacement;
   readonly styleVars?: Record<string, unknown>;
   readonly parentContainer?: HTMLElement;
+  readonly testId?: string;
 }
 
 export interface PrizmDialogOptions<O = unknown, DATA = unknown> extends PrizmDialogBaseOptions {

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.ts
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.ts
@@ -82,6 +82,15 @@ export class PrizmSidebarComponent<DATA = unknown> extends PrizmAbstractTestId {
     return this.animation;
   }
 
+  @HostBinding('attr.data-testid')
+  override get testId() {
+    const postfix = this.testIdPostfix || this.context.testId;
+    return this.generateMainTestId + (postfix ? `--${postfix}` : '');
+  }
+  override set testId(value: string) {
+    this.testIdPostfix = value;
+  }
+
   override readonly testId_ = 'ui_area--sidebar';
 
   private readonly animation = {

--- a/libs/components/src/lib/components/radio/prizm-radio-button.component.ts
+++ b/libs/components/src/lib/components/radio/prizm-radio-button.component.ts
@@ -19,6 +19,12 @@ import { NgIf } from '@angular/common';
   encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [NgIf, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [
+    {
+      name: 'testId',
+    },
+  ],
 })
 export class PrizmRadioButtonComponent extends PrizmWrappedFormComponent {
   @Input()

--- a/libs/components/src/lib/components/table/directives/table.directive.ts
+++ b/libs/components/src/lib/components/table/directives/table.directive.ts
@@ -4,6 +4,7 @@ import {
   Directive,
   EventEmitter,
   HostBinding,
+  inject,
   Inject,
   Input,
   Output,
@@ -21,7 +22,7 @@ import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmTableRowService } from '../service/row.service';
 import { prizmTableDefaultColumnSort } from '../table.const';
 import { PrizmTableService } from '../table.service';
-import { PrizmDestroyService } from '@prizm-ui/helpers';
+import { PrizmDestroyService, PrizmTestIdDirective } from '@prizm-ui/helpers';
 
 @Directive({
   selector: `table[prizmTable]`,
@@ -36,6 +37,12 @@ import { PrizmDestroyService } from '@prizm-ui/helpers';
   host: {
     style: `border-collapse: separate; border-spacing: 0`,
   },
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
+  ],
   exportAs: 'prizmTable',
 })
 export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
@@ -89,6 +96,8 @@ export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
   @Output()
   readonly sortChange: Observable<PrizmTableCellSorter<T>[]> = this.sorterService.changes$;
 
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
+
   constructor(
     public readonly tree: PrizmTableTreeService,
     public readonly sorterService: PrizmTableSorterService<T>,
@@ -98,6 +107,8 @@ export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
     @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef
   ) {
     super();
+
+    this.testIdDirective.generateMainTestId = 'ui_table';
   }
 
   @Input()

--- a/libs/components/src/lib/components/table/directives/table.directive.ts
+++ b/libs/components/src/lib/components/table/directives/table.directive.ts
@@ -96,7 +96,7 @@ export class PrizmTableDirective<T extends Partial<Record<keyof T, unknown>>>
   @Output()
   readonly sortChange: Observable<PrizmTableCellSorter<T>[]> = this.sorterService.changes$;
 
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor(
     public readonly tree: PrizmTableTreeService,

--- a/libs/components/src/lib/components/table/directives/thead.directive.ts
+++ b/libs/components/src/lib/components/table/directives/thead.directive.ts
@@ -19,7 +19,7 @@ import { PrizmTestIdDirective } from '@prizm-ui/helpers';
   ],
 })
 export class PrizmTheadDirective {
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor() {
     this.testIdDirective.generateMainTestId = 'ui_table_head';

--- a/libs/components/src/lib/components/table/directives/thead.directive.ts
+++ b/libs/components/src/lib/components/table/directives/thead.directive.ts
@@ -1,5 +1,6 @@
-import { Directive } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { INTERSECTION_ROOT_MARGIN, IntersectionObserverService } from '@ng-web-apis/intersection-observer';
+import { PrizmTestIdDirective } from '@prizm-ui/helpers';
 
 @Directive({
   selector: `thead[prizmThead]`,
@@ -10,5 +11,17 @@ import { INTERSECTION_ROOT_MARGIN, IntersectionObserverService } from '@ng-web-a
       useValue: `0px 10000px 10000px 10000px`,
     },
   ],
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
+  ],
 })
-export class PrizmTheadDirective {}
+export class PrizmTheadDirective {
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
+
+  constructor() {
+    this.testIdDirective.generateMainTestId = 'ui_table_head';
+  }
+}

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -18,7 +18,7 @@ import {
 import { CollectionViewer, isDataSource, ListRange } from '@angular/cdk/collections';
 
 import { prizmDefaultProp } from '@prizm-ui/core';
-import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList, PrizmTestIdDirective } from '@prizm-ui/helpers';
 import { BehaviorSubject, isObservable, Observable } from 'rxjs';
 import { switchMap, takeUntil, tap } from 'rxjs/operators';
 import { PolymorphContent } from '../../../directives';
@@ -42,6 +42,12 @@ import { prizmIconsAngleRight } from '@prizm-ui/icons/base/source';
   styleUrls: [`./tbody.component.less`],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: PRIZM_TABLE_PROVIDER,
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
+  ],
 })
 export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   implements CollectionViewer, AfterViewInit, OnDestroy
@@ -151,6 +157,7 @@ export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   });
 
   private readonly iconsRegistry = inject(PrizmIconsRegistry);
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
 
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))
@@ -161,6 +168,7 @@ export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
     private changeDetectorRef: ChangeDetectorRef
   ) {
     this.iconsRegistry.registerIcons(prizmIconsAngleRight);
+    this.testIdDirective.generateMainTestId = 'ui_table_body';
   }
 
   ngAfterViewInit(): void {

--- a/libs/components/src/lib/components/table/tbody/tbody.component.ts
+++ b/libs/components/src/lib/components/table/tbody/tbody.component.ts
@@ -157,7 +157,7 @@ export class PrizmTbodyComponent<T extends Partial<Record<keyof T, unknown>>>
   });
 
   private readonly iconsRegistry = inject(PrizmIconsRegistry);
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))

--- a/libs/components/src/lib/components/table/td/td.component.ts
+++ b/libs/components/src/lib/components/table/td/td.component.ts
@@ -4,6 +4,7 @@ import {
   ContentChild,
   ElementRef,
   HostBinding,
+  inject,
   Input,
   OnDestroy,
   OnInit,
@@ -11,6 +12,7 @@ import {
 import { NgControl } from '@angular/forms';
 import { PrizmTableCellStatus } from '../table.types';
 import { PrizmTdService } from './td.service';
+import { PrizmTestIdDirective } from '@prizm-ui/helpers';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -18,6 +20,12 @@ import { PrizmTdService } from './td.service';
   template: ` <ng-content></ng-content> `,
   styleUrls: [`./td.component.less`],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
+  ],
 })
 export class PrizmTdComponent implements OnInit, OnDestroy {
   @Input() @HostBinding('attr.status') public status: PrizmTableCellStatus = 'default';
@@ -34,10 +42,14 @@ export class PrizmTdComponent implements OnInit, OnDestroy {
     return this.colspan ?? this.elementRef?.nativeElement?.getAttribute('colspan') ?? 1;
   }
 
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
+
   constructor(
     private readonly tdService: PrizmTdService,
     private readonly elementRef: ElementRef<HTMLTableCellElement>
-  ) {}
+  ) {
+    this.testIdDirective.generateMainTestId = 'ui_table_td';
+  }
 
   public ngOnInit(): void {
     this.tdService.increment(parseInt(this.realColspan.toString(), 10));

--- a/libs/components/src/lib/components/table/td/td.component.ts
+++ b/libs/components/src/lib/components/table/td/td.component.ts
@@ -42,7 +42,7 @@ export class PrizmTdComponent implements OnInit, OnDestroy {
     return this.colspan ?? this.elementRef?.nativeElement?.getAttribute('colspan') ?? 1;
   }
 
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor(
     private readonly tdService: PrizmTdService,

--- a/libs/components/src/lib/components/table/th-group/th-group.component.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.component.ts
@@ -69,7 +69,7 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
     colspan: number;
   }>;
 
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))

--- a/libs/components/src/lib/components/table/th-group/th-group.component.ts
+++ b/libs/components/src/lib/components/table/th-group/th-group.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   ContentChildren,
   forwardRef,
+  inject,
   Inject,
   Input,
   OnDestroy,
@@ -19,7 +20,7 @@ import { PrizmHeadDirective } from '../directives/head.directive';
 import { PrizmTableDirective } from '../directives/table.directive';
 import { PRIZM_TABLE_PROVIDER } from '../providers/table.provider';
 import { PrizmThComponent } from '../th/th.component';
-import { moveInEventLoopIteration, prizmEmptyQueryList } from '@prizm-ui/helpers';
+import { moveInEventLoopIteration, prizmEmptyQueryList, PrizmTestIdDirective } from '@prizm-ui/helpers';
 import { PrizmTableService } from '../table.service';
 import { PrizmThGroupService } from './th-group.service';
 
@@ -29,6 +30,12 @@ import { PrizmThGroupService } from './th-group.service';
   templateUrl: `./th-group.template.html`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [PRIZM_TABLE_PROVIDER, PrizmThGroupService],
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
+  ],
 })
 export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
   implements OnInit, AfterContentInit, OnDestroy
@@ -62,6 +69,8 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
     colspan: number;
   }>;
 
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
+
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))
     public readonly table: PrizmTableDirective<T>,
@@ -69,6 +78,8 @@ export class PrizmThGroupComponent<T extends Partial<Record<keyof T, any>>>
     @Self() public readonly thGroupService: PrizmThGroupService
   ) {
     this.tableService.addThGroup(this);
+
+    this.testIdDirective.generateMainTestId = 'ui_th_group';
   }
 
   ngOnInit(): void {

--- a/libs/components/src/lib/components/table/th/th.component.ts
+++ b/libs/components/src/lib/components/table/th/th.component.ts
@@ -24,6 +24,7 @@ import {
   prizmIconsArrowDownWideShort,
   prizmIconsArrowUpWideShort,
 } from '@prizm-ui/icons/base/source';
+import { PrizmTestIdDirective } from '@prizm-ui/helpers';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -35,6 +36,12 @@ import {
     {
       provide: PRIZM_ELEMENT_REF,
       useExisting: ElementRef,
+    },
+  ],
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
     },
   ],
 })
@@ -59,6 +66,7 @@ export class PrizmThComponent<T extends Partial<Record<keyof T, any>>> {
   }
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
 
   constructor(
     @Optional()
@@ -75,6 +83,8 @@ export class PrizmThComponent<T extends Partial<Record<keyof T, any>>> {
       prizmIconsArrowDownWideShort,
       prizmIconsArrowUpWideShort
     );
+
+    this.testIdDirective.generateMainTestId = 'ui_table_th';
   }
 
   get key(): keyof T {
@@ -113,8 +123,8 @@ export class PrizmThComponent<T extends Partial<Record<keyof T, any>>> {
         !this.isCurrent
           ? 'arrow-up-arrow-down-v'
           : this.sorterService.cellOrder(this.key as string) === 'asc'
-            ? `arrow-down-wide-short`
-            : `arrow-up-wide-short`
+          ? `arrow-down-wide-short`
+          : `arrow-up-wide-short`
       )
     );
   }

--- a/libs/components/src/lib/components/table/th/th.component.ts
+++ b/libs/components/src/lib/components/table/th/th.component.ts
@@ -66,7 +66,7 @@ export class PrizmThComponent<T extends Partial<Record<keyof T, any>>> {
   }
 
   private readonly iconsFullRegistry = inject(PrizmIconsFullRegistry);
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor(
     @Optional()

--- a/libs/components/src/lib/components/table/tr/tr.component.ts
+++ b/libs/components/src/lib/components/table/tr/tr.component.ts
@@ -93,7 +93,7 @@ export class PrizmTrComponent<T extends Partial<Record<keyof T, unknown>>> {
   );
 
   @Input() @HostBinding('attr.active') public active = false;
-  private readonly testIdDirective = inject(PrizmTestIdDirective);
+  private readonly testIdDirective = inject(PrizmTestIdDirective, { host: true });
 
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))

--- a/libs/components/src/lib/components/table/tr/tr.component.ts
+++ b/libs/components/src/lib/components/table/tr/tr.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { debounceTime, map, startWith, switchMap } from 'rxjs/operators';
 import { animationFrameScheduler, BehaviorSubject, merge, Observable, of } from 'rxjs';
-import { prizmAutoEmit, prizmDefaultProp } from '@prizm-ui/core';
+import { prizmAutoEmit } from '@prizm-ui/core';
 
 import { PrizmCellDirective } from '../directives/cell.directive';
 import { PrizmTableDirective } from '../directives/table.directive';

--- a/libs/components/src/lib/components/table/tr/tr.component.ts
+++ b/libs/components/src/lib/components/table/tr/tr.component.ts
@@ -4,6 +4,7 @@ import {
   ContentChildren,
   forwardRef,
   HostBinding,
+  inject,
   Inject,
   Input,
   QueryList,
@@ -18,7 +19,7 @@ import { PrizmTableDirective } from '../directives/table.directive';
 import { PRIZM_TABLE_PROVIDER } from '../providers/table.provider';
 import { PrizmTbodyComponent } from '../tbody/tbody.component';
 import { PrizmTableCellStatus } from '../table.types';
-import { PrizmDestroyService, prizmEmptyQueryList } from '@prizm-ui/helpers';
+import { PrizmDestroyService, prizmEmptyQueryList, PrizmTestIdDirective } from '@prizm-ui/helpers';
 import { PrizmTableTreeService } from '../service/tree.service';
 import { PrizmCellService } from '../directives/cell.service';
 import { PrizmTdService } from '../td/td.service';
@@ -32,6 +33,12 @@ import { PrizmTdService } from '../td/td.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   providers: [PRIZM_TABLE_PROVIDER, PrizmCellService, PrizmTdService],
+  hostDirectives: [
+    {
+      directive: PrizmTestIdDirective,
+      inputs: ['testId'],
+    },
+  ],
 })
 export class PrizmTrComponent<T extends Partial<Record<keyof T, unknown>>> {
   @Input() @HostBinding('attr.status') public status: PrizmTableCellStatus = 'default';
@@ -86,6 +93,7 @@ export class PrizmTrComponent<T extends Partial<Record<keyof T, unknown>>> {
   );
 
   @Input() @HostBinding('attr.active') public active = false;
+  private readonly testIdDirective = inject(PrizmTestIdDirective);
 
   constructor(
     @Inject(forwardRef(() => PrizmTableDirective))
@@ -96,7 +104,9 @@ export class PrizmTrComponent<T extends Partial<Record<keyof T, unknown>>> {
     private readonly td: PrizmTdService,
     private readonly tableTreeService: PrizmTableTreeService,
     @Inject(PrizmDestroyService) readonly destroy$: PrizmDestroyService
-  ) {}
+  ) {
+    this.testIdDirective.generateMainTestId = 'ui_table_row';
+  }
 
   public showChildren(idx: number): void {
     this.tableTreeService.showChildren(idx);

--- a/libs/doc/base/src/lib/components/documentation/documentation.component.html
+++ b/libs/doc/base/src/lib/components/documentation/documentation.component.html
@@ -26,7 +26,7 @@
     class="t-row"
     *ngFor="
       let propertyConnector of propertiesConnectors
-        | prizmCallFunc: updateOnChanges : propertiesInnerConnectors
+        | prizmCallFunc : updateOnChanges : propertiesInnerConnectors
         | async;
       let idx = index
     "
@@ -80,7 +80,7 @@
           ></tui-data-list-wrapper>
         </tui-select>
         <ng-template #selectContent let-data>
-          <code>{{ data | prizmCallFunc: inspectAny }}</code>
+          <code>{{ data | prizmCallFunc : inspectAny }}</code>
         </ng-template>
 
         <ng-template #noItems>
@@ -182,7 +182,7 @@
 <ng-container *ngIf="hasTestId">
   <ng-template
     #testIdTemplate="documentationProperty"
-    [documentationPropertyValue]="testIdPostfix"
+    [(documentationPropertyValue)]="testIdPostfix"
     [documentationPropertyName]="testIdName"
     (documentationPropertyValueChange)="changeTestIdPostfix($event, $any(testIdTemplate.host))"
     documentationPropertyType="string"
@@ -193,7 +193,7 @@
 </ng-container>
 <ng-container *ngIf="control">
   <ng-template
-    [documentationPropertyValue]="control | prizmCallFunc: isTouchedFromControl$ | async"
+    [documentationPropertyValue]="control | prizmCallFunc : isTouchedFromControl$ | async"
     (documentationPropertyValueChange)="setTouched(control, $any($event))"
     documentationPropertyName="touched"
     documentationPropertyType="boolean"
@@ -203,7 +203,7 @@
   </ng-template>
 
   <ng-template
-    [documentationPropertyValue]="control | prizmCallFunc: isDirtyFromControl$ | async"
+    [documentationPropertyValue]="control | prizmCallFunc : isDirtyFromControl$ | async"
     (documentationPropertyValueChange)="setDirty(control, $any($event))"
     documentationPropertyName="dirty"
     documentationPropertyType="boolean"
@@ -213,7 +213,7 @@
   </ng-template>
 
   <ng-template
-    [documentationPropertyValue]="control | prizmCallFunc: isPristineFromControl$ | async"
+    [documentationPropertyValue]="control | prizmCallFunc : isPristineFromControl$ | async"
     (documentationPropertyValueChange)="setPristine(control, $any($event))"
     documentationPropertyName="pristine"
     documentationPropertyType="boolean"
@@ -223,7 +223,7 @@
   </ng-template>
 
   <ng-template
-    [documentationPropertyValue]="control | prizmCallFunc: getDisabledFromControl$ | async"
+    [documentationPropertyValue]="control | prizmCallFunc : getDisabledFromControl$ | async"
     (documentationPropertyValueChange)="updateStateOfControl(control, $any($event))"
     documentationPropertyName="disabled"
     documentationPropertyType="boolean"
@@ -233,7 +233,7 @@
   </ng-template>
 
   <ng-template
-    [documentationPropertyValue]="control | prizmCallFunc: getValueFromControl$ | async"
+    [documentationPropertyValue]="control | prizmCallFunc : getValueFromControl$ | async"
     (documentationPropertyValueChange)="updateValueOfControl(control, $any($event))"
     documentationPropertyName="value"
     documentationPropertyType="string"
@@ -243,7 +243,7 @@
   </ng-template>
 
   <ng-template
-    [documentationPropertyValue]="control | prizmCallFunc: getRequiredFromControl$ | async"
+    [documentationPropertyValue]="control | prizmCallFunc : getRequiredFromControl$ | async"
     (documentationPropertyValueChange)="updateRequiredValidatorOfControl(control, $any($event))"
     documentationPropertyName="required"
     documentationPropertyType="boolean"

--- a/libs/helpers/src/lib/directives/index.ts
+++ b/libs/helpers/src/lib/directives/index.ts
@@ -11,3 +11,4 @@ export * from './appearance';
 export * from './appearance-type';
 export * from './parent-sync';
 export * from './has-value';
+export * from './test-id';

--- a/libs/helpers/src/lib/directives/test-id/index.ts
+++ b/libs/helpers/src/lib/directives/test-id/index.ts
@@ -1,0 +1,1 @@
+export * from './test-id';

--- a/libs/helpers/src/lib/directives/test-id/test-id.ts
+++ b/libs/helpers/src/lib/directives/test-id/test-id.ts
@@ -1,0 +1,27 @@
+import { Directive, HostBinding, Input } from '@angular/core';
+
+@Directive({
+  selector: '[prizmTestId]',
+  standalone: true,
+})
+export class PrizmTestIdDirective {
+  protected testIdPostfix?: string;
+
+  @Input()
+  @HostBinding('attr.data-testid')
+  get testId() {
+    return this.generateMainTestId + (this.testIdPostfix ? `--${this.testIdPostfix}` : '');
+  }
+  set testId(value: string) {
+    this.testIdPostfix = value;
+  }
+
+  public get generateMainTestId() {
+    return this.testId_;
+  }
+  public set generateMainTestId(value: string) {
+    this.testId_ = value;
+  }
+
+  private testId_!: string;
+}


### PR DESCRIPTION
feat(helpers/test-id): add test-id directive #2304
feat(components/table): add test-id support for table and its inner components #2304 
feat(doc/splitter): add values for splitter area #2304
feat(addon/query-builder): add testId support #2304
fix(components/dialog): test id postfix setters override #2304
fix(components/confirm-dialog): test id postfix setters override #2304
fix(components/sidebar): test id postfix setters override #2304
fix(components/radio-button): add input for testId in component metadata to fix ability of property binding for testId #2304
