### PR TITLE
fix(components/day-time-range): fix the "to" time in the toLocalNativeDate function #2326

### DIFF
--- a/libs/components/src/lib/@core/date-time/day-time-range.ts
+++ b/libs/components/src/lib/@core/date-time/day-time-range.ts
@@ -53,9 +53,9 @@ export class PrizmDateTimeRange {
 
     const to = this.dayRange.to.toLocalNativeDate();
     if (this.timeRange?.to) {
-      from.setHours(this.timeRange.to.hours);
-      from.setMinutes(this.timeRange.to.minutes);
-      from.setSeconds(this.timeRange.to.seconds);
+      to.setHours(this.timeRange.to.hours);
+      to.setMinutes(this.timeRange.to.minutes);
+      to.setSeconds(this.timeRange.to.seconds);
     }
 
     return [from ?? null, to ?? null];


### PR DESCRIPTION
fix(components/input-layout-date-time-range): native transformer  assign wrong value for 'to' control https://github.com/zyfra/Prizm/issues/2326

resolved #2326 