### PR TITLE
fix(components/confirm-dialog): correct  paddings #2305

### DIFF
--- a/apps/doc/src/app/components/dialogs/dialog/examples/outher-header/dialog-outher-header-example.component.ts
+++ b/apps/doc/src/app/components/dialogs/dialog/examples/outher-header/dialog-outher-header-example.component.ts
@@ -14,7 +14,7 @@ import { PrizmDialogService, PrizmOverlayInsidePlacement } from '@prizm-ui/compo
 
       .header {
         border-bottom: 1px solid var(--prizm-background-stroke);
-        padding: var(--prizm-dialog-header-padding, 14px 16px);
+        padding: var(--prizm-dialog-header-padding, 16px);
         display: flex;
         justify-content: space-between;
         font-style: var(--prizm-dialog-header-font-style, normal);

--- a/apps/doc/src/app/components/tooltip/examples/with-template/tooltip-with-template-example.component.ts
+++ b/apps/doc/src/app/components/tooltip/examples/with-template/tooltip-with-template-example.component.ts
@@ -7,7 +7,6 @@ import { PrizmOverlayOutsidePlacement } from '@prizm-ui/components';
   styles: [
     `
       .box {
-        padding: 8px;
         .title {
           font-size: 14px;
           font-weight: 500;

--- a/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
+++ b/libs/components/src/lib/components/dialogs/confirm-dialog/confirm-dialog.component.less
@@ -87,7 +87,7 @@
 
 .footer {
   border-top: 1px solid var(--prizm-background-stroke);
-  padding: var(--prizm-confirm-dialog-padding, 14px 16px);
+  padding: var(--prizm-confirm-dialog-padding, 16px);
   max-width: 100%;
 
   .buttons {

--- a/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
+++ b/libs/components/src/lib/components/dialogs/sidebar/sidebar.component.less
@@ -88,7 +88,7 @@
 
 .footer {
   border-top: 1px solid var(--prizm-background-stroke);
-  padding: var(--prizm-sidebar-footer-padding, var(--prizm-sidebar-padding, 14px 16px));
+  padding: var(--prizm-sidebar-footer-padding, var(--prizm-sidebar-padding, 16px));
   max-width: 100%;
   max-height: var(--prizm-sidebar-footer-max-height, 200px);
   overflow: hidden;

--- a/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.less
+++ b/libs/components/src/lib/directives/confirm-popup/confirm-popup-container.component.less
@@ -18,7 +18,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     position: relative;
-    padding: var(--prizm-confirm-popup-container-padding, 16px 14px);
+    padding: var(--prizm-confirm-popup-container-padding, 16px);
     border-radius: var(--prizm-confirm-popup-container-border-radius, 2px);
     background-color: var(--prizm-confirm-popup-container-background, var(--prizm-background-fill-overlay));
   }


### PR DESCRIPTION
fix(components/confirm-dialog): correct  paddings #2305
fix(components/confirm-popup): correct  paddings #2305
fix(components/sidebar): correct  paddings #2305
fix(doc/dialog): correct  paddings for custom header #2305
fix(doc/tooltip): correct  paddings for template example #2305

resolved #2305 