### PR TITLE
fix(components/multi-select): chevron overlaps input for layout with status #1744 v4

### DIFF
--- a/libs/components/src/lib/components/chips/chips.component.html
+++ b/libs/components/src/lib/components/chips/chips.component.html
@@ -5,7 +5,7 @@
     *ngIf="!!chipsList?.length"
     [active]="singleLine"
     [class.hidden]="singleLine"
-    [reserveSpace]="{ x: 48 }"
+    [reserveSpace]="layoutComponent?.status === 'default' ? { x: 48 } : { x: 76 }"
     [host]="layoutComponent?.el?.nativeElement"
     prizmOverflowHost
   >

--- a/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/multi-select/input-multi-select.component.ts
@@ -183,7 +183,10 @@ export class PrizmInputMultiSelectComponent<T> extends PrizmInputNgControl<T[]> 
 
   override hidden = true;
 
-  readonly button_layout_width = 64;
+  get button_layout_width() {
+    return this.layoutComponent?.status === 'default' ? 64 : 90;
+  }
+
   override readonly testId_ = 'ui-muilti-select';
 
   @HostBinding('style.display')
@@ -193,7 +196,7 @@ export class PrizmInputMultiSelectComponent<T> extends PrizmInputNgControl<T[]> 
 
   @HostBinding('class.inner')
   get inner(): boolean {
-    return !this.layoutComponent?.outer ?? false;
+    return !this.layoutComponent?.outer;
   }
 
   @HostBinding('class.empty')

--- a/libs/components/src/lib/components/dropdowns/tree-multi-select/tree-multi-select.component.ts
+++ b/libs/components/src/lib/components/dropdowns/tree-multi-select/tree-multi-select.component.ts
@@ -168,7 +168,9 @@ export class PrizmInputTreeMultiSelectComponent<T = any>
 {
   searchable = false;
   override hidden = true;
-  readonly button_layout_width = 64;
+  get button_layout_width() {
+    return this.layoutComponent?.status === 'default' ? 64 : 90;
+  }
 
   @ContentChild(PrizmDataListDirective) dataListDirective?: PrizmDataListDirective;
 
@@ -193,7 +195,7 @@ export class PrizmInputTreeMultiSelectComponent<T = any>
 
   @HostBinding('class.inner')
   get inner(): boolean {
-    return !this.layoutComponent?.outer ?? false;
+    return !this.layoutComponent?.outer;
   }
 
   @Input()


### PR DESCRIPTION
fix(components/multi-select): chevron overlaps input for layout with status https://github.com/zyfra/Prizm/issues/1744
fix(components/tree-multi-select): chevron overlaps input for layout with status https://github.com/zyfra/Prizm/issues/1744