### PR TITLE
Fix/chips hover outline 2382 v4

### DIFF
--- a/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
+++ b/apps/doc/src/app/components/input/input-chips/input-chips-example.component.html
@@ -26,7 +26,7 @@
             [hintCanShow]="hintCanShow"
             [prizmDocHostElement]="chipsItem"
             [selected]="selected"
-            [style.--prizm-chips-item-heigh]="prizmChipsItemHeight"
+            [style.--prizm-chips-item-height]="prizmChipsItemHeight"
             [style.--prizm-chips-item-background]="prizmChipsItemBackground"
             [style.--prizm-chips-item-color]="prizmChipsItemColor"
             style="width: 100px"
@@ -66,7 +66,7 @@
     <prizm-doc-documentation heading="PrizmChipsItemComponent" hostComponentKey="PrizmChipsItemComponent">
       <ng-template
         [(documentationPropertyValue)]="prizmChipsItemHeight"
-        documentationPropertyName="prizm-chips-item-heigh"
+        documentationPropertyName="prizm-chips-item-height"
         documentationPropertyType="string"
         documentationPropertyMode="css-var"
       >

--- a/libs/components/src/lib/components/chips/chips-item/chips-item.component.less
+++ b/libs/components/src/lib/components/chips/chips-item/chips-item.component.less
@@ -16,7 +16,6 @@ button {
 
 :host-context(.deletable) {
   .chips-list__item:not(:disabled) {
-    &:hover,
     &:focus-visible {
       outline: var(--prizm-background-stroke-focus) 1px solid;
     }


### PR DESCRIPTION
fix(doc/chips): correct css variable name #2383
fix(components/chips): remove outline from chips on hover https://github.com/zyfra/Prizm/issues/2382


resolved #2383 