### PR TITLE
5.8.1

### DIFF
--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.8.1](https://github.com/zyfra/Prizm)
+
+### Bugfixes
+
+- feat(components/input-tree-multi-select): InputTreeMultiSelect: Fixed an issue where cloned values could not be unselected. Now, users can properly remove selected items. (#2353, #2352)
+  (Added a test example in the documentation to verify the fix.)
+
 ## [5.8.0](https://github.com/zyfra/Prizm)
 
 ### Features

--- a/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
+++ b/apps/doc/src/app/about-prizm/changelog/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfixes
 
-- feat(components/input-tree-multi-select): InputTreeMultiSelect: Fixed an issue where cloned values could not be unselected. Now, users can properly remove selected items. (#2353, #2352)
+- fix(components/input-tree-multi-select): InputTreeMultiSelect: Fixed an issue where cloned values could not be unselected. Now, users can properly remove selected items. (#2353, #2352)
   (Added a test example in the documentation to verify the fix.)
 
 ## [5.8.0](https://github.com/zyfra/Prizm)

--- a/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.html
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.html
@@ -1,0 +1,32 @@
+<prizm-input-layout label="Validators">
+  <prizm-input-tree-multi-select
+    #input
+    [mode]="'only-current'"
+    [stringify]="stringify"
+    [getChildren]="getChildren"
+    [formControl]="control"
+    [searchable]="true"
+    [identityMatcher]="identityMatcher"
+    [searchMatcher]="searchMatcher"
+  >
+    <prizm-data-list-wrapper *prizmDataList>
+      <ng-container *ngFor="let arrItem of items$ | async">
+        <prizm-input-tree-multi-select-item *prizmInputTreeMultiSelectItem="arrItem; let item = item">
+          {{ item.data.value }}
+        </prizm-input-tree-multi-select-item>
+      </ng-container>
+    </prizm-data-list-wrapper>
+  </prizm-input-tree-multi-select>
+</prizm-input-layout>
+
+<br />
+<br />
+<div style="display: flex; gap: 8px">
+  <button (click)="setDefaultValue()" prizmButton>
+    Set default value: <b>{{ items[1].data.value }}</b>
+  </button>
+  <button (click)="change()" prizmButton>Update Items</button>
+</div>
+
+<br />
+<br />

--- a/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.ts
@@ -87,7 +87,6 @@ export class PrizmTreeSelectBaseExampleComponent {
     a: TreeSelectItem,
     b: TreeSelectItem
   ): boolean => {
-    console.log('#Mz identityMatcher', { a, b });
     return a?.data.id === b?.data.id;
   };
 

--- a/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.ts
@@ -1,0 +1,101 @@
+import { Component } from '@angular/core';
+import { PrizmMultiSelectIdentityMatcher, PrizmMultiSelectSearchMatcher } from '@prizm-ui/components';
+import { BehaviorSubject, delay } from 'rxjs';
+import { UntypedFormControl } from '@angular/forms';
+
+type TreeSelectItem = {
+  data: { value: string; id: string };
+  children?: TreeSelectItem[];
+};
+
+@Component({
+  selector: 'prizm-tree-select-base-example',
+  templateUrl: './tree-select-base-example.component.html',
+  styles: [
+    `
+      .box {
+        display: flex;
+        gap: 1rem;
+      }
+
+      .value {
+        overflow: hidden;
+        max-width: 100%;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    `,
+  ],
+})
+export class PrizmTreeSelectBaseExampleComponent {
+  protected items: TreeSelectItem[] = [
+    {
+      data: {
+        value: 'One',
+        id: 'One',
+      },
+    },
+    {
+      data: {
+        value: 'Two',
+        id: 'Two',
+      },
+      children: [
+        {
+          data: {
+            value: 'first in two',
+            id: 'first in two',
+          },
+          children: [
+            {
+              data: {
+                value: 'first in first in two',
+                id: 'first in first in two',
+              },
+            },
+          ],
+        },
+        {
+          data: {
+            value: 'second in two',
+            id: 'second in two',
+          },
+        },
+      ],
+    },
+  ];
+  private selectedItems$$ = new BehaviorSubject<TreeSelectItem[]>(this.items);
+  protected items$ = this.selectedItems$$.pipe(delay(100));
+  public value = this.items[0];
+  readonly control = new UntypedFormControl([{ ...this.items[0] }]);
+
+  public stringify(item: TreeSelectItem | null): string {
+    return item?.data ? item.data.value : '';
+  }
+  public getChildren(item: TreeSelectItem): TreeSelectItem[] {
+    return item.children ?? [];
+  }
+
+  public searchMatcher: PrizmMultiSelectSearchMatcher<TreeSelectItem> = (
+    search: string,
+    item: TreeSelectItem
+  ) => {
+    return item.data.value?.toLowerCase().includes(search.toLowerCase());
+  };
+
+  public readonly identityMatcher: PrizmMultiSelectIdentityMatcher<TreeSelectItem> = (
+    a: TreeSelectItem,
+    b: TreeSelectItem
+  ): boolean => {
+    console.log('#Mz identityMatcher', { a, b });
+    return a?.data.id === b?.data.id;
+  };
+
+  public setDefaultValue(): void {
+    this.control.setValue([{ ...this.items[1] }], { emitEvent: false });
+  }
+  public change(): void {
+    this.control.setValue(null);
+    // this.selectedItems$$.next(this.selectedItems$$.value === this.items ? this.items2 : this.items);
+  }
+}

--- a/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.ts
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/examples/base/tree-select-base-example.component.ts
@@ -96,6 +96,5 @@ export class PrizmTreeSelectBaseExampleComponent {
   }
   public change(): void {
     this.control.setValue(null);
-    // this.selectedItems$$.next(this.selectedItems$$.value === this.items ? this.items2 : this.items);
   }
 }

--- a/apps/doc/src/app/components/input/input-tree-multi-select/input-tree-multi-select.component.html
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/input-tree-multi-select.component.html
@@ -3,6 +3,9 @@
     Our tree-multi-select component is a wrapper around the input tree multi-select element.
   </div>
   <ng-template prizmDocPageTab>
+    <prizm-doc-example id="base" [content]="exampleBase" heading="Base">
+      <prizm-tree-select-base-example></prizm-tree-select-base-example>
+    </prizm-doc-example>
     <prizm-doc-example id="projection" [content]="exampleProjection" heading="Projection">
       <prizm-tree-select-projection-example></prizm-tree-select-projection-example>
     </prizm-doc-example>

--- a/apps/doc/src/app/components/input/input-tree-multi-select/input-tree-multi-select.component.ts
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/input-tree-multi-select.component.ts
@@ -118,6 +118,10 @@ export class InputTreeMultiSelectComponent {
     TypeScript: import('./examples/projection/tree-select-projection-example.component.ts?raw'),
     HTML: import('./examples/projection/tree-select-projection-example.component.html?raw'),
   };
+  readonly exampleBase: TuiDocExample = {
+    TypeScript: import('./examples/base/tree-select-base-example.component.ts?raw'),
+    HTML: import('./examples/base/tree-select-base-example.component.html?raw'),
+  };
   readonly exampleTransform: TuiDocExample = {
     TypeScript: import('./examples/transform/tree-select-transform-example.component.ts?raw'),
     HTML: import('./examples/transform/tree-select-transform-example.component.html?raw'),

--- a/apps/doc/src/app/components/input/input-tree-multi-select/input-tree-multi-select.module.ts
+++ b/apps/doc/src/app/components/input/input-tree-multi-select/input-tree-multi-select.module.ts
@@ -10,14 +10,14 @@ import {
   PrizmDataListWrapperComponent,
   PrizmHintOnOverflowDirective,
   PrizmInputCommonModule,
+  PrizmInputTreeMultiSelectCheckboxDirective,
   PrizmInputTreeMultiSelectComponent,
   PrizmInputTreeSelectComponent,
   PrizmScrollbarModule,
-  PrizmInputTreeMultiSelectCheckboxDirective,
   PrizmTreeMultiSelectItemComponent,
   PrizmTreeMultiSelectItemDirective,
-  PrizmTreeSelectItemComponent,
   PrizmTreeMultiSelectModeDirective,
+  PrizmTreeSelectItemComponent,
 } from '@prizm-ui/components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PrizmHtmlRefDirective, PrizmLetDirective } from '@prizm-ui/helpers';
@@ -28,6 +28,7 @@ import { PrizmTreeSelectTransformExampleComponent } from './examples/transform/t
 import { PrizmTreeSelectSearchExampleComponent } from './examples/search/tree-select-search-example.component';
 import { PrizmTreeSelectI18nExampleComponent } from './examples/i18n/tree-select-i18n-example.component';
 import { PrizmTreeSelectOnlyCurrentExampleComponent } from './examples/only-current/tree-select-only-current-example.component';
+import { PrizmTreeSelectBaseExampleComponent } from './examples/base/tree-select-base-example.component';
 
 @NgModule({
   imports: [
@@ -62,6 +63,7 @@ import { PrizmTreeSelectOnlyCurrentExampleComponent } from './examples/only-curr
     PrizmTreeSelectTransformExampleComponent,
     PrizmTreeSelectSearchExampleComponent,
     PrizmTreeSelectProjectionExampleComponent,
+    PrizmTreeSelectBaseExampleComponent,
     InputTreeMultiSelectComponent,
   ],
   exports: [InputTreeMultiSelectComponent],

--- a/apps/doc/src/app/version-manager/current.const.ts
+++ b/apps/doc/src/app/version-manager/current.const.ts
@@ -1,1 +1,1 @@
-export const PRIZM_CURRENT_VERSION = '5.8.0';
+export const PRIZM_CURRENT_VERSION = '5.8.1';

--- a/apps/doc/src/app/version-manager/versions.constants.ts
+++ b/apps/doc/src/app/version-manager/versions.constants.ts
@@ -28,8 +28,8 @@ export const PRIZM_LANGUAGES_META: readonly PrizmLanguageMeta[] = [
 ];
 export const PRIZM_VERSIONS_META: readonly PrizmVersionMeta[] = [
   {
-    label: '5.8.0 (ng18)',
-    version: '5.8.0',
+    label: '5.8.1 (ng18)',
+    version: '5.8.1',
     stackblitz: 'https://stackblitz.com/edit/prizm-v5-demo',
     link: getDocSite.bind(null, 'https://doc.prizm.zyfra.com', 'http://prizm.site'),
 

--- a/libs/addons/query-builder/package.json
+++ b/libs/addons/query-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/addon-query-builder",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",

--- a/libs/ast/package.json
+++ b/libs/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/ast",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/libs/charts/base/package.json
+++ b/libs/charts/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/charts",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -10,8 +10,8 @@
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",
-    "@prizm-ui/theme": "^5.8.0",
-    "@prizm-ui/helpers": "^5.8.0"
+    "@prizm-ui/theme": "^5.8.1",
+    "@prizm-ui/helpers": "^5.8.1"
   },
   "dependencies": {
     "tslib": "^2.3.0",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/components",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Prizm UI system design components library http://prizm.zyfra.com",
   "license": "MIT",
   "private": false,
@@ -12,11 +12,11 @@
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",
     "@angular/cdk": "^18.1.3",
-    "@prizm-ui/helpers": "^5.8.0",
-    "@prizm-ui/core": "^5.8.0",
-    "@prizm-ui/i18n": "^5.8.0",
-    "@prizm-ui/theme": "^5.8.0",
-    "@prizm-ui/icons": "^5.8.0"
+    "@prizm-ui/helpers": "^5.8.1",
+    "@prizm-ui/core": "^5.8.1",
+    "@prizm-ui/i18n": "^5.8.1",
+    "@prizm-ui/theme": "^5.8.1",
+    "@prizm-ui/icons": "^5.8.1"
   },
   "dependencies": {
     "tslib": "^2.3.0",

--- a/libs/components/src/lib/components/dropdowns/tree-multi-select/tree-select-multi-selected.directive.ts
+++ b/libs/components/src/lib/components/dropdowns/tree-multi-select/tree-select-multi-selected.directive.ts
@@ -73,7 +73,7 @@ export class PrizmTreeMultiSelectSelectedDirective<T> {
 
   public unselect(item: T) {
     if (!this.value) return;
-    this.value = this.value.filter(i => i !== item);
+    this.value = this.value.filter(i => !this.treeSelectIdentityMatcherDirective.identityMatcher(i, item));
   }
 
   public hasSelectedChildren(item: T): boolean {

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/core",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "license": "MIT",
   "description": "The main library for creating Angular components and elements using Prizm.",
   "private": false,

--- a/libs/helpers/package.json
+++ b/libs/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/helpers",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "license": "MIT",
   "description": "Library to make it easy to create Angular applications. Contains Injectables Service, RxJS utilities, directives, and standard pipes.",
   "private": false,

--- a/libs/i18n/package.json
+++ b/libs/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/i18n",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3"

--- a/libs/icons/base/package.json
+++ b/libs/icons/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Prizm UI base icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",
-    "@prizm-ui/core": "^5.8.0"
+    "@prizm-ui/core": "^5.8.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/flags/package.json
+++ b/libs/icons/flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/flag-icons",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Prizm UI flags icon pack library http://prizm.zyfra.com",
   "private": false,
   "publishConfig": {
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",
-    "@prizm-ui/core": "^5.8.0"
+    "@prizm-ui/core": "^5.8.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/icons/loader/package.json
+++ b/libs/icons/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/icons-loader",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "private": false,
   "publishConfig": {
     "access": "public",
@@ -9,7 +9,7 @@
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",
-    "@prizm-ui/icons": "^5.8.0"
+    "@prizm-ui/icons": "^5.8.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/nxmv/package.json
+++ b/libs/nxmv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-mv",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {

--- a/libs/plugin/package.json
+++ b/libs/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/nx-plugin",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "main": "src/index.js",
   "private": false,
   "publishConfig": {
@@ -10,6 +10,6 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@prizm-ui/ast": "^5.8.0"
+    "@prizm-ui/ast": "^5.8.1"
   }
 }

--- a/libs/schematics/package.json
+++ b/libs/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/install",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Package installer @prizm-ui/* , Angular schematic ng-add",
   "schematics": "./src/collection.json",
   "private": false,

--- a/libs/schematics/src/ng-add/consts.ts
+++ b/libs/schematics/src/ng-add/consts.ts
@@ -11,21 +11,21 @@ interface ImportingModule {
 export const MAIN_PACKAGES: ReadonlyArray<Package> = [
   {
     name: '@prizm-ui/core',
-    version: '5.8.0',
+    version: '5.8.1',
   },
   {
     name: '@prizm-ui/components',
-    version: '5.8.0',
+    version: '5.8.1',
   },
   {
     name: '@prizm-ui/helpers',
-    version: '5.8.0',
+    version: '5.8.1',
   },
 ];
 
 export const INSTALL_PACKAGE: Readonly<Package> = {
   name: '@prizm-ui/install',
-  version: '5.8.0',
+  version: '5.8.1',
 };
 
 export const MAIN_MODULES: ReadonlyArray<ImportingModule> = [

--- a/libs/theme/package.json
+++ b/libs/theme/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@prizm-ui/theme",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "peerDependencies": {
     "@angular/common": "^18.1.3",
     "@angular/core": "^18.1.3",
-    "@prizm-ui/core": "^5.8.0",
-    "@prizm-ui/helpers": "^5.8.0"
+    "@prizm-ui/core": "^5.8.1",
+    "@prizm-ui/helpers": "^5.8.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/local/package.json
+++ b/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/local",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "dependencies": {
     "@nx/devkit": "19.5.6",
     "tslib": "^2.3.0"

--- a/nxmv.json
+++ b/nxmv.json
@@ -38,7 +38,7 @@
         "nxVersion": "19.5.6"
       },
       "vars": {
-        "version": "5.8.0",
+        "version": "5.8.1",
         "v4version": "4.8.1"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizm-ui/sdk",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "license": "MIT",
   "husky": {
     "hooks": {
@@ -17,7 +17,6 @@
     "cypress:open": "cypress open",
     "start": "nx run doc:serve",
     "build": "nx affected:build --all",
-    "build:all": "nx run-many -t build --all",
     "build:next": "nx run doc:build",
     "build:doc": "nx run doc:build:development --deployUrl=/ --baseHref=/",
     "build:stats": "nx build next --stats-json",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cypress:open": "cypress open",
     "start": "nx run doc:serve",
     "build": "nx affected:build --all",
+    "build:all": "nx run-many -t build --all",
     "build:next": "nx run doc:build",
     "build:doc": "nx run doc:build:development --deployUrl=/ --baseHref=/",
     "build:stats": "nx build next --stats-json",

--- a/package.json.ng18
+++ b/package.json.ng18
@@ -17,6 +17,7 @@
     "cypress:open": "cypress open",
     "start": "nx run doc:serve",
     "build": "nx affected:build --all",
+    "build:all": "nx run-many -t build --all",
     "build:next": "nx run doc:build",
     "build:doc": "nx run doc:build:development --deployUrl=/ --baseHref=/",
     "build:stats": "nx build next --stats-json",


### PR DESCRIPTION
## [5.8.1](https://github.com/zyfra/Prizm)

### Bugfixes

- fix(components/input-tree-multi-select): InputTreeMultiSelect: Fixed an issue where cloned values could not be unselected. Now, users can properly remove selected items. (#2353, #2352)
  (Added a test example in the documentation to verify the fix.)



Исправлена ошибка, из-за которой невозможно было снять выделение с клонированного значения в InputTreeMultiSelect. Теперь можно корректно удалять выбранные элементы.

Также в документацию добавлен пример для тестирования данной баги.